### PR TITLE
Feat: Implement subscribe() function for direct fan-to-creator subscriptions with expiry and fee

### DIFF
--- a/src/components/content_component/content.cairo
+++ b/src/components/content_component/content.cairo
@@ -154,7 +154,7 @@ pub mod ContentComponent {
                         active_content.append(id_u256);
                     }
                 }
-            }; //scarb fmt removes a semicolon here that messes with the workflow
+            } //scarb fmt removes a semicolon here that messes with the workflow
 
             active_content
         }

--- a/src/interfaces/IERC20.cairo
+++ b/src/interfaces/IERC20.cairo
@@ -1,7 +1,7 @@
 use starknet::ContractAddress;
 
 #[starknet::interface]
-trait IERC20<TContractState> {
+pub trait IERC20<TContractState> {
     fn name(self: @TContractState) -> felt252;
     fn symbol(self: @TContractState) -> felt252;
     fn decimals(self: @TContractState) -> u8;
@@ -13,4 +13,5 @@ trait IERC20<TContractState> {
         ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256,
     ) -> bool;
     fn approve(ref self: TContractState, spender: ContractAddress, amount: u256) -> bool;
+    fn mint(ref self: TContractState, recipient: ContractAddress, amount: u256) -> bool;
 }

--- a/src/interfaces/IMyFans.cairo
+++ b/src/interfaces/IMyFans.cairo
@@ -1,5 +1,10 @@
+use myfans::myfans::MyFans::Subscription;
 use starknet::ContractAddress;
 
 #[starknet::interface]
-trait IMyFans<TContractState> { // Main contract functionality will be added here
+pub trait IMyFans<TContractState> { // Main contract functionality will be added here
+    fn subscribe(ref self: TContractState, creator_address: ContractAddress);
+    fn get_subscription_details(
+        self: @TContractState, fan_address: ContractAddress, creator_address: ContractAddress,
+    ) -> Subscription;
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -15,3 +15,13 @@ pub mod components {
         pub mod types;
     }
 }
+
+pub mod interfaces {
+    pub mod IERC20;
+    pub mod IMyFans;
+}
+pub mod myfans;
+
+pub mod mocks {
+    pub mod mock_erc20;
+}

--- a/src/mocks/mock_erc20.cairo
+++ b/src/mocks/mock_erc20.cairo
@@ -1,0 +1,183 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IERC20<TContractState> {
+    fn name(self: @TContractState) -> ByteArray;
+    fn symbol(self: @TContractState) -> ByteArray;
+    fn decimals(self: @TContractState) -> u8;
+
+    fn total_supply(self: @TContractState) -> u256;
+    fn balance_of(self: @TContractState, account: ContractAddress) -> u256;
+    fn allowance(self: @TContractState, owner: ContractAddress, spender: ContractAddress) -> u256;
+    fn approve(ref self: TContractState, spender: ContractAddress, amount: u256) -> bool;
+    fn transfer(ref self: TContractState, recipient: ContractAddress, amount: u256) -> bool;
+    fn transfer_from(
+        ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256,
+    ) -> bool;
+
+    fn mint(ref self: TContractState, recipient: ContractAddress, amount: u256) -> bool;
+}
+
+#[starknet::contract]
+pub mod MockToken {
+    use core::num::traits::{Pow, Zero};
+    use starknet::event::EventEmitter;
+    use starknet::storage::{
+        Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
+    use starknet::{ContractAddress, get_caller_address};
+    use super::IERC20;
+
+    const INITIAL_SUPPLY: u256 = 1_000_000_000 * 10_u256.pow(18); // 1B tokens with 18 decimals
+
+    #[storage]
+    pub struct Storage {
+        balances: Map<ContractAddress, u256>,
+        allowances: Map<
+            (ContractAddress, ContractAddress), u256,
+        >, // Mapping<(owner, spender), amount>
+        token_name: ByteArray,
+        symbol: ByteArray,
+        decimal: u8,
+        total_supply: u256,
+        owner: ContractAddress,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        Transfer: Transfer,
+        Approval: Approval,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct Transfer {
+        #[key]
+        from: ContractAddress,
+        #[key]
+        to: ContractAddress,
+        amount: u256,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct Approval {
+        #[key]
+        owner: ContractAddress,
+        #[key]
+        spender: ContractAddress,
+        value: u256,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress, name: ByteArray) {
+        self.token_name.write(name);
+        self.symbol.write("MKT");
+        self.decimal.write(18);
+        self.owner.write(owner);
+
+        self.mint(owner, INITIAL_SUPPLY);
+    }
+
+    #[abi(embed_v0)]
+    impl MockTokenImpl of IERC20<ContractState> {
+        fn total_supply(self: @ContractState) -> u256 {
+            self.total_supply.read()
+        }
+
+        fn balance_of(self: @ContractState, account: ContractAddress) -> u256 {
+            let balance = self.balances.entry(account).read();
+
+            balance
+        }
+
+        fn allowance(
+            self: @ContractState, owner: ContractAddress, spender: ContractAddress,
+        ) -> u256 {
+            let allowance = self.allowances.entry((owner, spender)).read();
+
+            allowance
+        }
+
+        fn transfer(ref self: ContractState, recipient: ContractAddress, amount: u256) -> bool {
+            let sender = get_caller_address();
+
+            let sender_prev_balance = self.balances.entry(sender).read();
+            let recipient_prev_balance = self.balances.entry(recipient).read();
+
+            assert(sender_prev_balance >= amount, 'Insufficient amount');
+
+            self.balances.entry(sender).write(sender_prev_balance - amount);
+            self.balances.entry(recipient).write(recipient_prev_balance + amount);
+
+            assert(
+                self.balances.entry(recipient).read() >= recipient_prev_balance,
+                'Transaction failed',
+            );
+
+            self.emit(Transfer { from: sender, to: recipient, amount });
+
+            true
+        }
+
+        fn transfer_from(
+            ref self: ContractState,
+            sender: ContractAddress,
+            recipient: ContractAddress,
+            amount: u256,
+        ) -> bool {
+            let spender = get_caller_address();
+
+            let spender_allowance = self.allowances.entry((sender, spender)).read();
+            let sender_balance = self.balances.entry(sender).read();
+            let recipient_balance = self.balances.entry(recipient).read();
+
+            if (amount > spender_allowance || amount > sender_balance) {
+                return false;
+            }
+
+            self.allowances.entry((sender, spender)).write(spender_allowance - amount);
+            self.balances.entry(sender).write(sender_balance - amount);
+            self.balances.entry(recipient).write(recipient_balance + amount);
+
+            self.emit(Transfer { from: sender, to: recipient, amount });
+
+            return true;
+        }
+
+        fn approve(ref self: ContractState, spender: ContractAddress, amount: u256) -> bool {
+            let caller = get_caller_address();
+
+            self.allowances.entry((caller, spender)).write(amount);
+
+            self.emit(Approval { owner: caller, spender, value: amount });
+
+            true
+        }
+
+        fn name(self: @ContractState) -> ByteArray {
+            self.token_name.read()
+        }
+
+        fn symbol(self: @ContractState) -> ByteArray {
+            self.symbol.read()
+        }
+
+        fn decimals(self: @ContractState) -> u8 {
+            self.decimal.read()
+        }
+
+        fn mint(ref self: ContractState, recipient: ContractAddress, amount: u256) -> bool {
+            let previous_total_supply = self.total_supply.read();
+            let previous_balance = self.balances.entry(recipient).read();
+
+            self.total_supply.write(previous_total_supply + amount);
+            self.balances.entry(recipient).write(previous_balance + amount);
+
+            let zero_address = Zero::zero();
+
+            self.emit(Transfer { from: zero_address, to: recipient, amount });
+
+            true
+        }
+    }
+}

--- a/src/myfans.cairo
+++ b/src/myfans.cairo
@@ -1,41 +1,145 @@
 /// Main contract implementation
 #[starknet::contract]
-mod MyFans {
+pub mod MyFans {
     use core::num::traits::Zero;
     use core::traits::Into;
 
     // Import components
     use myfans::components::content_component::content::ContentComponent;
-    use myfans::components::content_component::interface::IContent;
+    use myfans::components::user_component::interface::IUser;
+    use myfans::components::user_component::user::UserComponent;
     use myfans::interfaces::IMyFans::IMyFans;
-    use starknet::storage::Map;
-    use starknet::{
-        ClassHash, ContractAddress, get_block_timestamp, get_caller_address, get_contract_address,
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
     };
+    use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
     use crate::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
+
 
     // Define components
     component!(path: ContentComponent, storage: content_storage, event: ContentEvent);
+    component!(path: UserComponent, storage: user_storage, event: UserEvent);
+
+    #[derive(Copy, Drop, Serde, Debug, starknet::Store)]
+    pub struct Subscription {
+        pub fan: ContractAddress,
+        pub creator: ContractAddress,
+        pub start_time: u64,
+        pub expiry_time: u64,
+        pub is_active: bool,
+    }
 
     #[storage]
     struct Storage {
         #[substorage(v0)]
         content_storage: ContentComponent::Storage,
+        #[substorage(v0)]
+        user_storage: UserComponent::Storage,
+        subscriptions: Map<(ContractAddress, ContractAddress), Subscription>,
+        subscription_fee: u256,
+        subscription_duration_seconds: u64,
+        fee_token_address: ContractAddress,
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
         ContentEvent: ContentComponent::Event,
+        UserEvent: UserComponent::Event,
+        Subscribed: Subscribed,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct Subscribed {
+        #[key]
+        fan: ContractAddress,
+        #[key]
+        creator: ContractAddress,
+        expiry_time: u64,
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState) {}
+    fn constructor(
+        ref self: ContractState,
+        initial_fee_token_address: ContractAddress,
+        initial_subscription_fee: u256,
+        initial_subscription_duration_days: u64,
+    ) {
+        self.fee_token_address.write(initial_fee_token_address);
+        self.subscription_fee.write(initial_subscription_fee);
+        self.subscription_duration_seconds.write(initial_subscription_duration_days * 24 * 60 * 60);
+    }
 
     #[abi(embed_v0)]
-    impl MyFansImpl of IMyFans<ContractState> {}
+    impl MyFansImpl of IMyFans<ContractState> {
+        fn subscribe(ref self: ContractState, creator_address: ContractAddress) {
+            let fan_address = get_caller_address();
+            assert(fan_address != creator_address, 'Cannot subscribe to self');
+
+            // 1. Verify creator is registered and verified (is_creator)
+            let creator_profile = self.user_storage.get_user_profile(creator_address);
+            assert(creator_profile.user_address != Zero::zero(), 'Creator not found');
+            assert(creator_profile.is_creator, 'Not a verified creator');
+
+            // 2. Check for duplicate active subscriptions
+            let current_timestamp = get_block_timestamp();
+            let existing_subscription = self.subscriptions.read((fan_address, creator_address));
+            if existing_subscription.is_active {
+                assert(
+                    current_timestamp >= existing_subscription.expiry_time,
+                    'Subscription already active',
+                );
+            }
+
+            // 3. Handle subscription fee transfer
+            let fee = self.subscription_fee.read();
+            let token_address = self.fee_token_address.read();
+            assert(token_address != Zero::zero(), 'Fee token not set');
+            assert(fee > 0, 'Subscription fee must be > 0');
+
+            let token_dispatcher = IERC20Dispatcher { contract_address: token_address };
+            // Transfer fee from fan to the contract.
+            // For splitting fees, this contract would then transfer parts to creator/platform.
+            // Fan must have approved this contract to spend `fee` amount of `token_address`.
+            let success = token_dispatcher.transfer_from(fan_address, get_contract_address(), fee);
+            assert(success, 'Fee transfer failed');
+
+            // 4. Record the subscription
+            let start_time = current_timestamp;
+            let duration = self.subscription_duration_seconds.read();
+            let expiry_time = start_time + duration;
+
+            let new_subscription = Subscription {
+                fan: fan_address,
+                creator: creator_address,
+                start_time: start_time,
+                expiry_time: expiry_time,
+                is_active: true,
+            };
+            self.subscriptions.write((fan_address, creator_address), new_subscription);
+
+            // 5. Emit event
+            self
+                .emit(
+                    Event::Subscribed(
+                        Subscribed { fan: fan_address, creator: creator_address, expiry_time },
+                    ),
+                );
+        }
+
+        fn get_subscription_details(
+            self: @ContractState, fan_address: ContractAddress, creator_address: ContractAddress,
+        ) -> Subscription {
+            let sub = self.subscriptions.read((fan_address, creator_address));
+            sub
+        }
+    }
 
     // Implement content interface
     #[abi(embed_v0)]
     impl ContentImpl = ContentComponent::ContentImpl<ContractState>;
+    // Implement user interface
+    #[abi(embed_v0)]
+    impl UserImpl = UserComponent::UserImpl<ContractState>;
 }

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -1,1 +1,263 @@
+use core::num::traits::Pow;
+use core::result::ResultTrait;
+use core::traits::TryInto;
+use myfans::components::user_component::interface::{IUserDispatcher, IUserDispatcherTrait};
+use myfans::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
+use myfans::interfaces::IMyFans::{IMyFansDispatcher, IMyFansDispatcherTrait};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare, start_cheat_block_timestamp,
+    start_cheat_caller_address, stop_cheat_block_timestamp, stop_cheat_caller_address,
+};
+use starknet::{ContractAddress, get_block_timestamp};
 
+pub fn OWNER() -> ContractAddress {
+    'OWNER'.try_into().unwrap()
+}
+
+pub fn FAN1() -> ContractAddress {
+    'FAN1'.try_into().unwrap()
+}
+
+pub fn CREATOR1() -> ContractAddress {
+    'CREATOR1'.try_into().unwrap()
+}
+
+pub fn NON_CREATOR() -> ContractAddress {
+    'NON_CREATOR'.try_into().unwrap()
+}
+
+// Use u256::pow directly after importing the trait
+const SUBSCRIPTION_FEE: u256 = 10 * 10_u256.pow(18); // 10 tokens
+const SUBSCRIPTION_DURATION_DAYS: u64 = 30;
+
+struct SetupResult {
+    myfans_contract_address: ContractAddress,
+    erc20_contract_address: ContractAddress,
+    owner_address: ContractAddress,
+    fan1_address: ContractAddress,
+    creator1_address: ContractAddress,
+}
+
+fn setup_erc20(owner: ContractAddress) -> ContractAddress {
+    let contract = declare("MockToken").unwrap();
+
+    let name: ByteArray = "MockToken";
+
+    let mut constructor_calldata = array![];
+    owner.serialize(ref constructor_calldata);
+    name.serialize(ref constructor_calldata);
+
+    let (erc20_address, _) = contract.contract_class().deploy(@constructor_calldata).unwrap();
+    erc20_address
+}
+
+fn setup_myfans(
+    fee_token_address: ContractAddress, subscription_fee: u256, subscription_duration_days: u64,
+) -> ContractAddress {
+    let contract = declare("MyFans").unwrap();
+    let mut constructor_calldata = array![
+        fee_token_address.into(),
+        subscription_fee.low.into(),
+        subscription_fee.high.into(),
+        subscription_duration_days.into(),
+    ];
+    let (myfans_address, _) = contract.contract_class().deploy(@constructor_calldata).unwrap();
+    myfans_address
+}
+
+fn setup_full_env() -> SetupResult {
+    let owner_address: ContractAddress = OWNER();
+    let fan1_address: ContractAddress = FAN1();
+    let creator1_address: ContractAddress = CREATOR1();
+
+    let erc20_address = setup_erc20(owner_address);
+
+    let myfans_address = setup_myfans(erc20_address, SUBSCRIPTION_FEE, SUBSCRIPTION_DURATION_DAYS);
+
+    // Distribute some tokens to fan1 for testing
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: erc20_address };
+
+    start_cheat_caller_address(erc20_address, owner_address);
+    erc20_dispatcher
+        .transfer(fan1_address, SUBSCRIPTION_FEE * 2); // Give fan enough for 2 subscriptions
+
+    stop_cheat_caller_address(erc20_address);
+
+    // Setup creator account
+    let myfans_user_dispatcher = IUserDispatcher { contract_address: myfans_address };
+
+    start_cheat_caller_address(myfans_address, creator1_address);
+    myfans_user_dispatcher.create_account('creator1');
+
+    stop_cheat_caller_address(myfans_address);
+
+    SetupResult {
+        myfans_contract_address: myfans_address,
+        erc20_contract_address: erc20_address,
+        owner_address,
+        fan1_address,
+        creator1_address,
+    }
+}
+
+#[test]
+fn test_subscribe_successfully() {
+    let setup_res = setup_full_env();
+    let myfans_dispatcher = IMyFansDispatcher {
+        contract_address: setup_res.myfans_contract_address,
+    };
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: setup_res.erc20_contract_address };
+
+    // Fan1 approves MyFans contract to spend tokens
+    start_cheat_caller_address(setup_res.erc20_contract_address, setup_res.fan1_address);
+    erc20_dispatcher.approve(setup_res.myfans_contract_address, SUBSCRIPTION_FEE);
+    stop_cheat_caller_address(setup_res.erc20_contract_address);
+
+    // Fan1 subscribes to Creator1
+
+    start_cheat_caller_address(setup_res.myfans_contract_address, setup_res.fan1_address);
+    myfans_dispatcher.subscribe(setup_res.creator1_address);
+
+    stop_cheat_caller_address(setup_res.myfans_contract_address);
+
+    let sub_details = myfans_dispatcher
+        .get_subscription_details(setup_res.fan1_address, setup_res.creator1_address);
+
+    assert(sub_details.is_active, 'Subscription should be active');
+    assert(sub_details.fan == setup_res.fan1_address, 'Fan address mismatch');
+    assert(sub_details.creator == setup_res.creator1_address, 'Creator address mismatch');
+    let expected_expiry = sub_details.start_time + SUBSCRIPTION_DURATION_DAYS * 24 * 60 * 60;
+    assert(sub_details.expiry_time == expected_expiry, 'Expiry time mismatch');
+
+    // Verify fee transfer
+    let contract_balance = erc20_dispatcher.balance_of(setup_res.myfans_contract_address);
+    assert(contract_balance == SUBSCRIPTION_FEE, 'Contract fee incorrect');
+    let fan_balance_after = erc20_dispatcher.balance_of(setup_res.fan1_address);
+    // Initial fan balance was SUBSCRIPTION_FEE * 2
+    assert(fan_balance_after == SUBSCRIPTION_FEE, 'Fan balance incorrect after sub');
+}
+
+#[test]
+#[should_panic(expected: ('Subscription already active',))]
+fn test_subscribe_duplicate_active_subscription() {
+    let setup_res = setup_full_env();
+    let myfans_dispatcher = IMyFansDispatcher {
+        contract_address: setup_res.myfans_contract_address,
+    };
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: setup_res.erc20_contract_address };
+
+    // Fan1 approves MyFans contract
+
+    start_cheat_caller_address(setup_res.erc20_contract_address, setup_res.fan1_address);
+    erc20_dispatcher.approve(setup_res.myfans_contract_address, SUBSCRIPTION_FEE * 2);
+
+    stop_cheat_caller_address(setup_res.erc20_contract_address);
+
+    // First subscription
+
+    start_cheat_caller_address(setup_res.myfans_contract_address, setup_res.fan1_address);
+    myfans_dispatcher.subscribe(setup_res.creator1_address);
+
+    stop_cheat_caller_address(setup_res.myfans_contract_address);
+
+    // Attempt second subscription immediately
+
+    start_cheat_caller_address(setup_res.myfans_contract_address, setup_res.fan1_address);
+    myfans_dispatcher.subscribe(setup_res.creator1_address); // This should panic
+
+    stop_cheat_caller_address(setup_res.myfans_contract_address);
+}
+
+#[test]
+#[should_panic(expected: ('Creator not found',))]
+fn test_subscribe_to_non_creator() {
+    let setup_res = setup_full_env();
+    let myfans_dispatcher = IMyFansDispatcher {
+        contract_address: setup_res.myfans_contract_address,
+    };
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: setup_res.erc20_contract_address };
+    let non_creator_address: ContractAddress = NON_CREATOR();
+
+    // Fan1 approves MyFans contract
+
+    start_cheat_caller_address(setup_res.erc20_contract_address, setup_res.fan1_address);
+    erc20_dispatcher.approve(setup_res.myfans_contract_address, SUBSCRIPTION_FEE);
+
+    stop_cheat_caller_address(setup_res.erc20_contract_address);
+
+    // Attempt to subscribe to a non-creator
+
+    start_cheat_caller_address(setup_res.myfans_contract_address, setup_res.fan1_address);
+    myfans_dispatcher.subscribe(non_creator_address); // This should panic
+
+    stop_cheat_caller_address(setup_res.myfans_contract_address);
+}
+
+#[test]
+#[should_panic(expected: ('Fee transfer failed',))]
+fn test_subscribe_insufficient_allowance() {
+    let setup_res = setup_full_env();
+    let myfans_dispatcher = IMyFansDispatcher {
+        contract_address: setup_res.myfans_contract_address,
+    };
+    // Fan1 does NOT approve MyFans contract
+
+    // Attempt to subscribe
+
+    start_cheat_caller_address(setup_res.myfans_contract_address, setup_res.fan1_address);
+    myfans_dispatcher.subscribe(setup_res.creator1_address); // This should panic
+
+    stop_cheat_caller_address(setup_res.myfans_contract_address);
+}
+
+#[test]
+fn test_subscribe_after_expiry() {
+    let setup_res = setup_full_env();
+    let myfans_dispatcher = IMyFansDispatcher {
+        contract_address: setup_res.myfans_contract_address,
+    };
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: setup_res.erc20_contract_address };
+
+    // Fan1 approves MyFans contract for two subscriptions
+
+    start_cheat_caller_address(setup_res.erc20_contract_address, setup_res.fan1_address);
+    erc20_dispatcher.approve(setup_res.myfans_contract_address, SUBSCRIPTION_FEE * 2);
+
+    stop_cheat_caller_address(setup_res.erc20_contract_address);
+
+    // First subscription
+
+    start_cheat_caller_address(setup_res.myfans_contract_address, setup_res.fan1_address);
+    myfans_dispatcher.subscribe(setup_res.creator1_address);
+
+    stop_cheat_caller_address(setup_res.myfans_contract_address);
+
+    let first_sub_details = myfans_dispatcher
+        .get_subscription_details(setup_res.fan1_address, setup_res.creator1_address);
+
+    // Advance time past expiry
+    let current_block_timestamp = get_block_timestamp();
+    let time_to_advance = first_sub_details.expiry_time
+        - current_block_timestamp
+        + 1; // 1 second after expiry
+    start_cheat_block_timestamp(
+        setup_res.myfans_contract_address, current_block_timestamp + time_to_advance,
+    );
+
+    // Second subscription (should succeed as first one expired)
+
+    start_cheat_caller_address(setup_res.myfans_contract_address, setup_res.fan1_address);
+    myfans_dispatcher.subscribe(setup_res.creator1_address);
+
+    stop_cheat_caller_address(setup_res.myfans_contract_address);
+
+    stop_cheat_block_timestamp(setup_res.myfans_contract_address);
+
+    let second_sub_details = myfans_dispatcher
+        .get_subscription_details(setup_res.fan1_address, setup_res.creator1_address);
+    assert(second_sub_details.is_active, 'Second sub should be active');
+    assert(
+        second_sub_details.start_time > first_sub_details.start_time,
+        'Second sub start time invalid',
+    );
+}


### PR DESCRIPTION
## PR Description

### 📚 Overview

This PR introduces a `subscribe(creator_address)` function to the MyFans contract, enabling fans to directly subscribe to verified creators using a fixed subscription fee. Subscription records include the fan, creator, and expiry details, and duplicate active subscriptions are prevented.

### ✨ Features & Implementation

- **subscribe(creator_address):**
  - Allows fans to subscribe to a creator by paying a fixed fee in an ERC20 token.
  - Validates that the creator is a registered and verified creator.
  - Prevents duplicate active subscriptions for the same fan-creator pair.
  - Records start time, expiry (30 days), the fan, and creator in a subscription struct.
  - Emits a `Subscribed` event on successful subscription.

- **get_subscription_details():**
  - Returns the subscription record for a given fan and creator.

- **Contract Structure:**
  - Adds the Subscription struct and mapping.
  - Integrates with mock ERC20 for testability.
  - Follows platform coding standards and leverages component-based architecture.

- **Testing:**
  - Extensive integration tests for:
    - Successful subscriptions
    - Subscription expiry and renewal
    - Rejection of duplicate active subscriptions
    - Rejection for non-verified creators
    - Fee handling and allowance requirements

### 🛡️ Acceptance Criteria

- Contract deploys and runs successfully on testnet.
- Subscription records are accurate and enforce 30-day expiry.
- Duplicate active subscriptions are rejected.
- Only verified creators can be subscribed to.
- Adequate tests cover all edge cases, including error scenarios.
- Event logging is in place for transparency and future indexing.

Closes #3 