### PR TITLE
feat: implement Auto-Renewal and Manual Renewal Support

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.11.3
+scarb 2.11.4
 starknet-foundry 0.39.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 scarb 2.11.4
-starknet-foundry 0.39.0
+starknet-foundry 0.41.0

--- a/src/components/content_component/content.cairo
+++ b/src/components/content_component/content.cairo
@@ -154,7 +154,7 @@ pub mod ContentComponent {
                         active_content.append(id_u256);
                     }
                 }
-            };
+            }
 
             active_content
         }

--- a/src/interfaces/IMyFans.cairo
+++ b/src/interfaces/IMyFans.cairo
@@ -10,7 +10,5 @@ pub trait IMyFans<TContractState> { // Main contract functionality will be added
     fn renew_subscription(
         ref self: TContractState, fan_address: ContractAddress, creator_address: ContractAddress,
     );
-    fn set_autorenew(
-        ref self: TContractState, creator_address: ContractAddress, enable: bool,
-    );
+    fn set_autorenew(ref self: TContractState, creator_address: ContractAddress, enable: bool);
 }

--- a/src/interfaces/IMyFans.cairo
+++ b/src/interfaces/IMyFans.cairo
@@ -7,4 +7,10 @@ pub trait IMyFans<TContractState> { // Main contract functionality will be added
     fn get_subscription_details(
         self: @TContractState, fan_address: ContractAddress, creator_address: ContractAddress,
     ) -> Subscription;
+    fn renew_subscription(
+        ref self: TContractState, fan_address: ContractAddress, creator_address: ContractAddress,
+    );
+    fn set_autorenew_preference(
+        ref self: TContractState, creator_address: ContractAddress, enable: bool,
+    );
 }

--- a/src/interfaces/IMyFans.cairo
+++ b/src/interfaces/IMyFans.cairo
@@ -10,7 +10,7 @@ pub trait IMyFans<TContractState> { // Main contract functionality will be added
     fn renew_subscription(
         ref self: TContractState, fan_address: ContractAddress, creator_address: ContractAddress,
     );
-    fn set_autorenew_preference(
+    fn set_autorenew(
         ref self: TContractState, creator_address: ContractAddress, enable: bool,
     );
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -21,6 +21,8 @@ pub mod interfaces {
     pub mod IMyFans;
 }
 pub mod myfans;
+    pub use myfans::MyFans;
+    pub use myfans::MyFans::Event;
 
 pub mod mocks {
     pub mod mock_erc20;

--- a/src/myfans.cairo
+++ b/src/myfans.cairo
@@ -45,7 +45,7 @@ pub mod MyFans {
 
     #[event]
     #[derive(Drop, starknet::Event)]
-    enum Event {
+    pub enum Event {
         ContentEvent: ContentComponent::Event,
         UserEvent: UserComponent::Event,
         Subscribed: Subscribed,
@@ -54,31 +54,31 @@ pub mod MyFans {
     }
 
     #[derive(Drop, starknet::Event)]
-    struct Subscribed {
+    pub struct Subscribed {
         #[key]
-        fan: ContractAddress,
+        pub fan: ContractAddress,
         #[key]
-        creator: ContractAddress,
-        expiry_time: u64,
+        pub creator: ContractAddress,
+        pub expiry_time: u64,
     }
 
     #[derive(Drop, starknet::Event)]
-    struct Renewed {
+    pub struct Renewed {
         #[key]
-        fan: ContractAddress,
+        pub fan: ContractAddress,
         #[key]
-        creator: ContractAddress,
-        new_expiry_time: u64,
-        renewed_by: ContractAddress,
+        pub creator: ContractAddress,
+        pub new_expiry_time: u64,
+        pub renewed_by: ContractAddress,
     }
 
     #[derive(Drop, starknet::Event)]
-    struct AutorenewPreferenceSet {
+    pub struct AutorenewPreferenceSet {
         #[key]
-        fan: ContractAddress,
+        pub fan: ContractAddress,
         #[key]
-        creator: ContractAddress,
-        enabled: bool,
+        pub creator: ContractAddress,
+        pub enabled: bool,
     }
 
     #[constructor]

--- a/src/myfans.cairo
+++ b/src/myfans.cairo
@@ -237,7 +237,7 @@ pub mod MyFans {
                 .emit(
                     Event::AutorenewPreferenceSet(
                         AutorenewPreferenceSet {
-                            fan: fan_address, creator: creator_address, enabled: true,
+                            fan: fan_address, creator: creator_address, enabled: enable,
                         },
                     ),
                 );

--- a/src/myfans.cairo
+++ b/src/myfans.cairo
@@ -213,7 +213,7 @@ pub mod MyFans {
                 );
         }
 
-        fn set_autorenew_preference(
+        fn set_autorenew(
             ref self: ContractState, creator_address: ContractAddress, enable: bool,
         ) {
             let fan_address = get_caller_address();

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -513,3 +513,20 @@ fn test_renew_subscription_fail_relayer_autorenew_disabled() {
     stop_cheat_caller_address(setup_res.myfans_contract_address);
     stop_cheat_block_timestamp(setup_res.myfans_contract_address);
 }
+
+#[test]
+#[should_panic(expected: 'Subscription not found')]
+fn test_renew_subscription_fail_not_found() {
+    let setup_res = setup_full_env();
+    let myfans_dispatcher = IMyFansDispatcher {
+        contract_address: setup_res.myfans_contract_address,
+    };
+    let fan_address: ContractAddress = FAN1();
+    let creator_address: ContractAddress = CREATOR1();
+    let relayer_address: ContractAddress = RELAYER();
+
+    // Attempt to renew a non-existent subscription by RELAYER
+    start_cheat_caller_address(setup_res.myfans_contract_address, relayer_address);
+    myfans_dispatcher.renew_subscription(fan_address, creator_address); 
+    stop_cheat_caller_address(setup_res.myfans_contract_address);
+}


### PR DESCRIPTION
## What does this PR do?
### Implement Auto-Renewal and Manual Renewal Support. closes #11 

### Implementations
- Add an auto-renew flag to the subscription model.
- Add a renew_subscription() function callable by relayers.
- Store and update subscription duration correctly.
- Thoroughly test each function for proper function
- Test for proper event emission

### Completed tasks

- [x] Subscriptions auto-renew if flag is set.
- [x] Relayers can call renew logic and extend subscription period.
- [x] Manual renewals also supported.