### PR TITLE
feat: implement direct payment routing

### DIFF
--- a/src/components/content_component/content.cairo
+++ b/src/components/content_component/content.cairo
@@ -154,7 +154,7 @@ pub mod ContentComponent {
                         active_content.append(id_u256);
                     }
                 }
-            };
+            }
 
             active_content
         }

--- a/src/interfaces/IMyFans.cairo
+++ b/src/interfaces/IMyFans.cairo
@@ -11,4 +11,5 @@ pub trait IMyFans<TContractState> { // Main contract functionality will be added
         ref self: TContractState, fan_address: ContractAddress, creator_address: ContractAddress,
     );
     fn set_autorenew(ref self: TContractState, creator_address: ContractAddress, enable: bool);
+    fn get_creator_balance(self: @TContractState, creator: ContractAddress) -> u256;
 }

--- a/src/myfans.cairo
+++ b/src/myfans.cairo
@@ -173,6 +173,11 @@ pub mod MyFans {
                 .transfer(platform_recipient, platform_fee_amount);
             assert(platform_fee_success, 'Platform fee transfer failed');
 
+            // Transfer creator's share to the creator
+            let creator_share_success = token_dispatcher
+                .transfer(creator_address, creator_share_amount);
+            assert(creator_share_success, 'Creator share transfer failed');
+
             // Add creator's share to their balance stored in the contract
             let current_creator_balance = self.creator_balances.read(creator_address);
             self
@@ -270,6 +275,11 @@ pub mod MyFans {
                 .transfer(platform_recipient, platform_fee_amount);
             assert(platform_fee_success, 'Platform fee transfer failed');
 
+            // Transfer creator's share to the creator
+            let creator_share_success = token_dispatcher
+                .transfer(creator_address, creator_share_amount);
+            assert(creator_share_success, 'Creator share transfer failed');
+
             // Add creator's share to their balance stored in the contract
             let current_creator_balance = self.creator_balances.read(creator_address);
             self
@@ -356,11 +366,11 @@ pub mod MyFans {
                     ),
                 );
         }
+        fn get_creator_balance(self: @ContractState, creator: ContractAddress) -> u256 {
+            self.creator_balances.read(creator)
+        }
     }
 
-    fn get_creator_balance(self: @ContractState, creator: ContractAddress) -> u256 {
-        self.creator_balances.read(creator)
-    }
 
     // Implement content interface
     #[abi(embed_v0)]

--- a/src/myfans.cairo
+++ b/src/myfans.cairo
@@ -358,6 +358,10 @@ pub mod MyFans {
         }
     }
 
+    fn get_creator_balance(self: @ContractState, creator: ContractAddress) -> u256 {
+        self.creator_balances.read(creator)
+    }
+
     // Implement content interface
     #[abi(embed_v0)]
     impl ContentImpl = ContentComponent::ContentImpl<ContractState>;

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -30,6 +30,10 @@ pub fn RELAYER() -> ContractAddress {
     'RELAYER'.try_into().unwrap()
 }
 
+pub fn PLATFORM() -> ContractAddress {
+    'PLATFORM'.try_into().unwrap()
+}
+
 // Use u256::pow directly after importing the trait
 const TENPOWEIGHTHEEN: u256 = 1000_000_000_000_000_000_u256; // 10^18
 const SUBSCRIPTION_FEE: u256 = 10 * TENPOWEIGHTHEEN;
@@ -37,6 +41,9 @@ const SUBSCRIPTION_DURATION_DAYS: u64 = 30;
 const INITIAL_TIMESTAMP: u64 = 1000;
 const DAY_IN_SECONDS: u64 = 24 * 60 * 60;
 const SUBSCRIPTION_DURATION_SECONDS: u64 = SUBSCRIPTION_DURATION_DAYS * DAY_IN_SECONDS;
+const PLATFORM_FEE_PERCENTAGE: u256 = 10;
+const PLATFORM_FEE_AMOUNT: u256 = (SUBSCRIPTION_FEE * PLATFORM_FEE_PERCENTAGE) / 100;
+const CREATOR_SHARE_AMOUNT: u256 = SUBSCRIPTION_FEE - PLATFORM_FEE_AMOUNT;
 
 
 struct SetupResult {
@@ -45,6 +52,7 @@ struct SetupResult {
     owner_address: ContractAddress,
     fan1_address: ContractAddress,
     creator1_address: ContractAddress,
+    platform_address: ContractAddress,
 }
 
 fn setup_erc20(owner: ContractAddress) -> ContractAddress {
@@ -61,7 +69,10 @@ fn setup_erc20(owner: ContractAddress) -> ContractAddress {
 }
 
 fn setup_myfans(
-    fee_token_address: ContractAddress, subscription_fee: u256, subscription_duration_days: u64,
+    fee_token_address: ContractAddress,
+    subscription_fee: u256,
+    subscription_duration_days: u64,
+    initial_platform_address: ContractAddress,
 ) -> ContractAddress {
     let contract = declare("MyFans").unwrap();
     let mut constructor_calldata = array![
@@ -69,6 +80,7 @@ fn setup_myfans(
         subscription_fee.low.into(),
         subscription_fee.high.into(),
         subscription_duration_days.into(),
+        initial_platform_address.into(),
     ];
     let (myfans_address, _) = contract.contract_class().deploy(@constructor_calldata).unwrap();
     myfans_address
@@ -78,18 +90,21 @@ fn setup_full_env() -> SetupResult {
     let owner_address: ContractAddress = OWNER();
     let fan1_address: ContractAddress = FAN1();
     let creator1_address: ContractAddress = CREATOR1();
+    let platform_address: ContractAddress = PLATFORM();
 
     let erc20_address = setup_erc20(owner_address);
 
-    let myfans_address = setup_myfans(erc20_address, SUBSCRIPTION_FEE, SUBSCRIPTION_DURATION_DAYS);
+    let myfans_address = setup_myfans(
+        erc20_address, SUBSCRIPTION_FEE, SUBSCRIPTION_DURATION_DAYS, platform_address,
+    );
 
     // Distribute some tokens to fan1 for testing
     let erc20_dispatcher = IERC20Dispatcher { contract_address: erc20_address };
 
     start_cheat_caller_address(erc20_address, owner_address);
     erc20_dispatcher
-        .transfer(fan1_address, SUBSCRIPTION_FEE * 2); // Give fan enough for 2 subscriptions
-
+        .transfer(fan1_address, SUBSCRIPTION_FEE * 5); // Give fan enough for 5 subscriptions
+    erc20_dispatcher.transfer(platform_address, 1000);
     stop_cheat_caller_address(erc20_address);
 
     // Setup creator account
@@ -106,6 +121,7 @@ fn setup_full_env() -> SetupResult {
         owner_address,
         fan1_address,
         creator1_address,
+        platform_address,
     }
 }
 

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -156,10 +156,10 @@ fn test_subscribe_successfully() {
 
     // Verify fee transfer
     let contract_balance = erc20_dispatcher.balance_of(setup_res.myfans_contract_address);
-    assert(contract_balance == SUBSCRIPTION_FEE, 'Contract fee incorrect');
+    assert(contract_balance == 0, 'Contract fee incorrect');
     let fan_balance_after = erc20_dispatcher.balance_of(setup_res.fan1_address);
     // Initial fan balance was SUBSCRIPTION_FEE * 2
-    assert(fan_balance_after == SUBSCRIPTION_FEE, 'Fan balance incorrect after sub');
+    assert(fan_balance_after == SUBSCRIPTION_FEE * 4, 'Fan balance incorrect after sub');
 }
 
 #[test]
@@ -282,10 +282,10 @@ fn test_renew_subscription_expired_by_fan() {
 
     // Verify fee transfer
     let contract_balance = erc20_dispatcher.balance_of(setup_res.myfans_contract_address);
-    assert(contract_balance == SUBSCRIPTION_FEE * 2, 'Contract fee incorrect');
+    assert(contract_balance == 0, 'Contract fee incorrect');
     let fan_balance_after = erc20_dispatcher.balance_of(setup_res.fan1_address);
     // Initial: 3*FEE, subscribed: 2*FEE, renewed: 1*FEE
-    assert(fan_balance_after == 0, 'Fan balance incorrect');
+    assert(fan_balance_after == SUBSCRIPTION_FEE * 3, 'Fan balance incorrect');
 
     // Verify event emission
     let expected_renewed_event = myfans::MyFans::Event::Renewed(
@@ -368,10 +368,10 @@ fn test_renew_subscription_not_expired_by_fan() {
 
     // Verify fee transfer
     let contract_balance = erc20_dispatcher.balance_of(setup_res.myfans_contract_address);
-    assert(contract_balance == SUBSCRIPTION_FEE * 2, 'Contract fee incorrect');
+    assert(contract_balance == 0, 'Contract fee incorrect');
     let fan_balance_after = erc20_dispatcher.balance_of(setup_res.fan1_address);
     // Initial: 3*FEE, subscribed: 2*FEE, renewed: 1*FEE
-    assert(fan_balance_after == 0, 'Fan balance incorrect');
+    assert(fan_balance_after == SUBSCRIPTION_FEE * 3, 'Fan balance incorrect');
 
     // Verify event emission
     let expected_renewed_event = myfans::MyFans::Event::Renewed(
@@ -457,10 +457,10 @@ fn test_renew_subscription_expired_by_relayer_autorenew_enabled() {
 
     // Verify fee transfer
     let contract_balance = erc20_dispatcher.balance_of(setup_res.myfans_contract_address);
-    assert(contract_balance == SUBSCRIPTION_FEE * 2, 'Contract fee incorrect');
+    assert(contract_balance == 0, 'Contract fee incorrect');
     let fan_balance_after = erc20_dispatcher.balance_of(setup_res.fan1_address);
     // Initial: 3*FEE, subscribed: 2*FEE, renewed: 1*FEE
-    assert(fan_balance_after == 0, 'Fan balance incorrect');
+    assert(fan_balance_after == SUBSCRIPTION_FEE * 3, 'Fan balance incorrect');
 
     // Verify event emission
     let expected_renewed_event = myfans::MyFans::Event::Renewed(
@@ -686,5 +686,86 @@ fn test_set_autorenew_disable_by_fan() {
                 (setup_res.myfans_contract_address, expected_disable_event),
             ],
         );
+}
+
+#[test]
+fn test_fee_splitting_on_subscribe() {
+    // Setup the environment
+    let setup_res = setup_full_env();
+    let myfans_dispatcher = IMyFansDispatcher {
+        contract_address: setup_res.myfans_contract_address,
+    };
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: setup_res.erc20_contract_address };
+    let mut spy = spy_events();
+
+    // Get initial balances
+    let initial_platform_erc20_balance = erc20_dispatcher.balance_of(setup_res.platform_address);
+    let initial_creator_myfans_balance = myfans_dispatcher
+        .get_creator_balance(setup_res.creator1_address);
+    let initial_fan_erc20_balance = erc20_dispatcher.balance_of(setup_res.fan1_address);
+
+    // Fan1 approves MyFans contract to spend the subscription fee amount
+    start_cheat_caller_address(setup_res.erc20_contract_address, setup_res.fan1_address);
+    erc20_dispatcher.approve(setup_res.myfans_contract_address, SUBSCRIPTION_FEE);
+    stop_cheat_caller_address(setup_res.erc20_contract_address);
+
+    // Fan1 subscribes to Creator1
+    start_cheat_caller_address(setup_res.myfans_contract_address, setup_res.fan1_address);
+    myfans_dispatcher.subscribe(setup_res.creator1_address);
+    stop_cheat_caller_address(setup_res.myfans_contract_address);
+
+    // Verify final balances
+    let final_platform_erc20_balance = erc20_dispatcher.balance_of(setup_res.platform_address);
+    let final_creator_myfans_balance = myfans_dispatcher
+        .get_creator_balance(setup_res.creator1_address);
+    let final_fan_erc20_balance = erc20_dispatcher.balance_of(setup_res.fan1_address);
+    let myfans_contract_erc20_balance = erc20_dispatcher
+        .balance_of(setup_res.myfans_contract_address);
+
+    // The MyFans contract should transfer the platform fee directly
+    assert_eq!(
+        final_platform_erc20_balance,
+        initial_platform_erc20_balance + PLATFORM_FEE_AMOUNT,
+        "Platform balance incorrect",
+    );
+
+    // The MyFans contract should store the creator share internally
+    assert_eq!(
+        final_creator_myfans_balance,
+        initial_creator_myfans_balance + CREATOR_SHARE_AMOUNT,
+        "Creator balance incorrect",
+    );
+
+    // The total fee should be transferred out of the fan's balance
+    assert_eq!(
+        final_fan_erc20_balance,
+        initial_fan_erc20_balance - SUBSCRIPTION_FEE,
+        "Fan balance incorrect",
+    );
+
+    // The MyFans contract should not hold any of the subscription fee after splitting
+    // (except potentially dust if division wasn't perfect, but with 10% of 10*10^18 it should be
+    // exact)
+    assert_eq!(myfans_contract_erc20_balance, 0, "contract balance should be 0");
+
+    // Verify event emissions
+    let expected_platform_fee_event = myfans::MyFans::Event::PlatformFeePaid(
+        myfans::MyFans::PlatformFeePaid {
+            subscriber: setup_res.fan1_address,
+            creator: setup_res.creator1_address,
+            platform: setup_res.platform_address,
+            amount: PLATFORM_FEE_AMOUNT,
+            total_fee: SUBSCRIPTION_FEE,
+        },
+    );
+
+    let expected_creator_share_event = myfans::MyFans::Event::CreatorShareDeposited(
+        myfans::MyFans::CreatorShareDeposited {
+            subscriber: setup_res.fan1_address,
+            creator: setup_res.creator1_address,
+            amount: CREATOR_SHARE_AMOUNT,
+            total_fee: SUBSCRIPTION_FEE,
+        },
+    );
 }
 


### PR DESCRIPTION
## What does this PR do?
### Implement Direct Payment Routing. closes #12 

### IMPLEMENTATIONS

- Add platform_fee_percentage constant.
- In subscribe() and renew_subscription() functions, split payment and update balances for creator and platform.
- Store balances in a mapping: creator -> amount
- add get_creator_balance() function to make testing easier
- thoroughly test function and assert proper functionality of new change in other tests

### TASKS

- [x] Payments are automatically split between creator and platform.
- [x] Balances are updated correctly.
- [x] No funds are lost or misrouted.

