### PR TITLE
Creator entity with User relation

### DIFF
--- a/myfans-backend/src/app.module.ts
+++ b/myfans-backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import configuration from './config/configuration';
 import { validate } from './config/env.validation';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { validate } from './config/env.validation';
               synchronize: configService.get<string>('NODE_ENV') !== 'production',
             },
     }),
+    UsersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/myfans-backend/src/creators/README.md
+++ b/myfans-backend/src/creators/README.md
@@ -1,0 +1,21 @@
+# Creator Entity
+
+Creator is a one-to-one extension of `User` when `user.is_creator` is true. It stores creator-specific fields without duplicating user data.
+
+## Relation to User
+
+- **Constraint**: `user.is_creator` should match the existence of a Creator row. When `is_creator` is true, a Creator record must exist. When false, no Creator record should exist.
+- **Cascade delete**: When a User is deleted, the associated Creator row is automatically deleted (database-level `ON DELETE CASCADE`).
+
+## Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | uuid | Primary key |
+| user_id | uuid | FK to users (unique) |
+| bio | text | Creator biography |
+| subscription_price | decimal(18,6) | Subscription price |
+| currency | string | e.g. XLM, USDC |
+| is_verified | boolean | Verification status |
+| created_at | timestamp | |
+| updated_at | timestamp | |

--- a/myfans-backend/src/creators/entities/creator.entity.spec.ts
+++ b/myfans-backend/src/creators/entities/creator.entity.spec.ts
@@ -1,0 +1,54 @@
+import { DataSource } from 'typeorm';
+import { Creator } from './creator.entity';
+import { User } from '../../users/entities/user.entity';
+
+describe('Creator Entity', () => {
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      type: 'better-sqlite3',
+      database: ':memory:',
+      entities: [User, Creator],
+      synchronize: true,
+    });
+    await dataSource.initialize();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  it('can create and query Creator with User relation', async () => {
+    const userRepo = dataSource.getRepository(User);
+    const creatorRepo = dataSource.getRepository(Creator);
+
+    const user = userRepo.create({
+      email: 'creator@test.com',
+      is_creator: true,
+    });
+    await userRepo.save(user);
+
+    const creator = creatorRepo.create({
+      user_id: user.id,
+      bio: 'Test bio',
+      subscription_price: '9.99',
+      currency: 'USDC',
+      is_verified: false,
+    });
+    await creatorRepo.save(creator);
+
+    const loaded = await creatorRepo.findOne({
+      where: { id: creator.id },
+      relations: ['user'],
+    });
+
+    expect(loaded).toBeDefined();
+    expect(loaded?.user).toBeDefined();
+    expect(loaded?.user.id).toBe(user.id);
+    expect(loaded?.user.email).toBe('creator@test.com');
+    expect(loaded?.bio).toBe('Test bio');
+    expect(Number(loaded?.subscription_price)).toBe(9.99);
+    expect(loaded?.currency).toBe('USDC');
+  });
+});

--- a/myfans-backend/src/creators/entities/creator.entity.ts
+++ b/myfans-backend/src/creators/entities/creator.entity.ts
@@ -1,0 +1,51 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+/**
+ * Creator entity - one-to-one extension of User when user.is_creator is true.
+ * Cascades delete when User is deleted. user.is_creator should match existence of Creator row.
+ */
+@Entity('creators')
+export class Creator {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'user_id', unique: true })
+  user_id!: string;
+
+  @OneToOne(() => User, (user) => user.creator, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user!: User;
+
+  @Column({ type: 'text', nullable: true })
+  bio!: string | null;
+
+  @Column({
+    name: 'subscription_price',
+    type: 'decimal',
+    precision: 18,
+    scale: 6,
+    default: 0,
+  })
+  subscription_price!: string;
+
+  @Column({ length: 10, default: 'XLM' })
+  currency!: string;
+
+  @Column({ name: 'is_verified', default: false })
+  is_verified!: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  created_at!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updated_at!: Date;
+}

--- a/myfans-backend/src/users/entities/user.entity.ts
+++ b/myfans-backend/src/users/entities/user.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Creator } from '../../creators/entities/creator.entity';
+
+/**
+ * User entity. When is_creator is true, a corresponding Creator row must exist.
+ * The Creator entity extends User with creator-specific fields (bio, subscription pricing, etc.).
+ */
+@Entity('users')
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ default: false })
+  is_creator!: boolean;
+
+  @Column({ unique: true })
+  email!: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  created_at!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updated_at!: Date;
+
+  @OneToOne(() => Creator, (creator) => creator.user, { cascade: true })
+  creator?: Creator | null;
+}

--- a/myfans-backend/src/users/users.module.ts
+++ b/myfans-backend/src/users/users.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Creator } from '../creators/entities/creator.entity';
+import { User } from './entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User, Creator])],
+  exports: [TypeOrmModule],
+})
+export class UsersModule {}


### PR DESCRIPTION
## Add Creator entity with User relation

### Summary
Introduces a Creator entity as a one-to-one extension of User when `user.is_creator` is true, for creator-specific fields without duplicating user data.

### Changes
- **User entity**: Added `id`, `email`, `is_creator`, `created_at`, `updated_at` plus `OneToOne` relation to Creator
- **Creator entity**: `id`, `user_id` (unique FK to User), `bio`, `subscription_price`, `currency`, `is_verified`, `created_at`, `updated_at`
- **Relation**: OneToOne between User and Creator with `onDelete: 'CASCADE'` when User is deleted
- **UsersModule**: Registers User and Creator with TypeORM
- **Docs**: Entity comments and `src/creators/README.md` describing the relation and cascade behavior
- **Test**: Unit test to create Creator and load it with User

### Acceptance criteria
- [x] Creator entity exists and can be created/queried
- [x] Relation to User works; creator loads with user
- [x] Migration/sync runs without errors
- [x] Cascade delete when User is deleted
- [x] Index on `user_id` (unique constraint)
- [x] `is_creator` on User documented as matching presence of Creator row
closes #30 