### PR TITLE
dashboard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "ajv": "^6.12.6",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "tailwindcss": "^4",
@@ -1763,32 +1764,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -2413,11 +2388,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
@@ -2432,14 +2410,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2609,13 +2589,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4900,16 +4873,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {

--- a/frontend/src/app/creators/page.tsx
+++ b/frontend/src/app/creators/page.tsx
@@ -1,14 +1,21 @@
 'use client';
-import { useState } from 'react';
+
+import { useState, useRef } from 'react';
 import WalletConnect from '@/components/WalletConnect';
+import { DashboardHome } from '@/components/dashboard';
 
 export default function CreatorsPage() {
   const [asset, setAsset] = useState('');
   const [amount, setAmount] = useState('');
   const [days, setDays] = useState('30');
+  const createPlanSectionRef = useRef<HTMLDivElement>(null);
 
   const handleCreatePlan = async () => {
     alert(`Plan created: ${amount} ${asset} every ${days} days`);
+  };
+
+  const scrollToCreatePlan = () => {
+    createPlanSectionRef.current?.scrollIntoView({ behavior: 'smooth' });
   };
 
   return (
@@ -18,37 +25,44 @@ export default function CreatorsPage() {
         <WalletConnect />
       </header>
 
-      <div className="max-w-2xl mx-auto">
+      <section className="mb-10" aria-label="Dashboard home">
+        <DashboardHome
+          onCreatePlan={scrollToCreatePlan}
+          onUploadContent={() => alert('Upload content — coming soon')}
+        />
+      </section>
+
+      <div ref={createPlanSectionRef} className="max-w-2xl">
         <h2 className="text-xl mb-4">Create Subscription Plan</h2>
-        
+
         <div className="space-y-4">
           <input
             type="text"
             placeholder="Asset (e.g., USDC address)"
             value={asset}
             onChange={(e) => setAsset(e.target.value)}
-            className="w-full p-2 border rounded"
+            className="w-full p-2 border rounded dark:bg-gray-800 dark:border-gray-700 dark:text-white"
           />
-          
+
           <input
             type="number"
             placeholder="Amount"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
-            className="w-full p-2 border rounded"
+            className="w-full p-2 border rounded dark:bg-gray-800 dark:border-gray-700 dark:text-white"
           />
-          
+
           <input
             type="number"
             placeholder="Interval (days)"
             value={days}
             onChange={(e) => setDays(e.target.value)}
-            className="w-full p-2 border rounded"
+            className="w-full p-2 border rounded dark:bg-gray-800 dark:border-gray-700 dark:text-white"
           />
-          
+
           <button
             onClick={handleCreatePlan}
-            className="w-full px-4 py-2 bg-blue-600 text-white rounded"
+            className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors"
           >
             Create Plan
           </button>

--- a/frontend/src/components/dashboard/ActivityFeed.tsx
+++ b/frontend/src/components/dashboard/ActivityFeed.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import React from 'react';
+import { BaseCard } from '@/components/cards';
+import type { ActivityItem } from '@/lib/dashboard';
+
+function formatTimeAgo(iso: string): string {
+  const d = new Date(iso);
+  const now = Date.now();
+  const diff = now - d.getTime();
+  const mins = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(diff / 86400000);
+  if (mins < 60) return `${mins}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7) return `${days}d ago`;
+  return d.toLocaleDateString();
+}
+
+function typeIcon(type: ActivityItem['type']) {
+  const base = 'flex-shrink-0 w-9 h-9 rounded-full flex items-center justify-center';
+  const green = 'bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400';
+  const blue = 'bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400';
+  const amber = 'bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400';
+  const red = 'bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400';
+  switch (type) {
+    case 'subscription':
+      return (
+        <span className={`${base} ${green}`} aria-hidden>
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6z" /></svg>
+        </span>
+      );
+    case 'renewal':
+      return (
+        <span className={`${base} ${blue}`} aria-hidden>
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885 6.002 6.002 0 00-9.716-2.2V3a1 1 0 011-1zm8 12a1 1 0 01-1 1H9a1 1 0 01-1-1v-1a1 1 0 012 0v.5h1a1 1 0 011 1z" clipRule="evenodd" /></svg>
+        </span>
+      );
+    case 'content':
+      return (
+        <span className={`${base} ${amber}`} aria-hidden>
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" /></svg>
+        </span>
+      );
+    case 'cancellation':
+      return (
+        <span className={`${base} ${red}`} aria-hidden>
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" /></svg>
+        </span>
+      );
+    case 'payout':
+      return (
+        <span className={`${base} ${green}`} aria-hidden>
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path d="M8.433 7.418c.155-.103.346-.196.567-.267v1.698a2.305 2.305 0 01-.567-.267C8.07 8.34 8 8.114 8 8c0-.114.07-.34.433-.582zM11 12.849v-1.698c.22.071.412.164.567.267.364.243.433.468.433.582 0 .114-.07.34-.433.582a2.305 2.305 0 01-.567.267z" /><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676 1.096C6.97 7.087 6.905 7.5 7 8c.095.5.03.913-.324 1.204C6.3 9.47 6 10.036 6 11v.5a1 1 0 002 0v-.5c0-.364.14-.704.382-.958.243-.254.418-.582.418-.958V8.5a1 1 0 002 0v-.5c0-.364.14-.704.382-.958.243-.254.418-.582.418-.958V7a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676 1.096C6.97 7.087 6.905 7.5 7 8c.095.5.03.913-.324 1.204C6.3 9.47 6 10.036 6 11v.5a1 1 0 002 0v-.5c0-.364.14-.704.382-.958.243-.254.418-.582.418-.958V8.5a1 1 0 002 0v-.5c0-.364.14-.704.382-.958.243-.254.418-.582.418-.958V7z" clipRule="evenodd" /></svg>
+        </span>
+      );
+    default:
+      return <span className={`${base} bg-gray-100 dark:bg-gray-700`} aria-hidden />;
+  }
+}
+
+export interface ActivityFeedProps {
+  items: ActivityItem[];
+}
+
+export function ActivityFeed({ items }: ActivityFeedProps) {
+  return (
+    <BaseCard className="flex flex-col" padding="lg" as="section" aria-labelledby="activity-heading">
+      <h2 id="activity-heading" className="text-sm font-semibold text-gray-900 dark:text-white mb-4">
+        Recent activity
+      </h2>
+      <ul className="space-y-4">
+        {items.slice(0, 5).map((item) => (
+          <li key={item.id} className="flex gap-3">
+            {typeIcon(item.type)}
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-900 dark:text-white">{item.title}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{item.description}</p>
+            </div>
+            <div className="flex flex-shrink-0 items-start gap-1">
+              {item.metadata && (
+                <span className="text-xs font-medium text-gray-600 dark:text-gray-300">{item.metadata}</span>
+              )}
+              <span className="text-xs text-gray-400 dark:text-gray-500">{formatTimeAgo(item.timestamp)}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </BaseCard>
+  );
+}
+
+export default ActivityFeed;

--- a/frontend/src/components/dashboard/ActivityFeedSkeleton.tsx
+++ b/frontend/src/components/dashboard/ActivityFeedSkeleton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React from 'react';
+import { BaseCard } from '@/components/cards';
+
+const ITEM_COUNT = 5;
+
+/**
+ * Skeleton for activity feed. Matches list layout to prevent CLS.
+ */
+export function ActivityFeedSkeleton() {
+  return (
+    <BaseCard className="flex flex-col" padding="lg">
+      <div className="h-5 w-32 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-4" />
+      <ul className="space-y-4" aria-hidden>
+        {Array.from({ length: ITEM_COUNT }).map((_, i) => (
+          <li key={i} className="flex gap-3">
+            <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse" />
+            <div className="flex-1 min-w-0">
+              <div className="h-4 w-3/4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-2" />
+              <div className="h-3 w-full bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+            </div>
+            <div className="flex-shrink-0 h-3 w-12 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+          </li>
+        ))}
+      </ul>
+    </BaseCard>
+  );
+}
+
+export default ActivityFeedSkeleton;

--- a/frontend/src/components/dashboard/DashboardError.tsx
+++ b/frontend/src/components/dashboard/DashboardError.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+import { BaseCard } from '@/components/cards';
+
+export interface DashboardErrorProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export function DashboardError({ message = 'Failed to load dashboard', onRetry }: DashboardErrorProps) {
+  return (
+    <BaseCard className="flex flex-col items-center justify-center text-center" padding="lg">
+      <div
+        className="w-12 h-12 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center text-red-600 dark:text-red-400 mb-4"
+        aria-hidden
+      >
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+      </div>
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Something went wrong</h3>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 max-w-sm">{message}</p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium rounded-lg transition-colors"
+        >
+          Try again
+        </button>
+      )}
+    </BaseCard>
+  );
+}
+
+export default DashboardError;

--- a/frontend/src/components/dashboard/DashboardHome.tsx
+++ b/frontend/src/components/dashboard/DashboardHome.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { MetricCard } from '@/components/cards';
+import { MetricCardSkeleton } from './MetricCardSkeleton';
+import { ActivityFeed } from './ActivityFeed';
+import { ActivityFeedSkeleton } from './ActivityFeedSkeleton';
+import { QuickActions } from './QuickActions';
+import { DashboardError } from './DashboardError';
+import { fetchDashboardData, type DashboardData } from '@/lib/dashboard';
+
+const PeopleIcon = () => (
+  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z" /></svg>
+);
+const CurrencyIcon = () => (
+  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path d="M8.433 7.418c.155-.103.346-.196.567-.267v1.698a2.305 2.305 0 01-.567-.267C8.07 8.34 8 8.114 8 8c0-.114.07-.34.433-.582zM11 12.849v-1.698c.22.071.412.164.567.267.364.243.433.468.433.582 0 .114-.07.34-.433.582a2.305 2.305 0 01-.567.267z" /><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676 1.096C6.97 7.087 6.905 7.5 7 8c.095.5.03.913-.324 1.204C6.3 9.47 6 10.036 6 11v.5a1 1 0 002 0v-.5c0-.364.14-.704.382-.958.243-.254.418-.582.418-.958V8.5a1 1 0 002 0v-.5c0-.364.14-.704.382-.958.243-.254.418-.582.418-.958V7a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676 1.096C6.97 7.087 6.905 7.5 7 8c.095.5.03.913-.324 1.204C6.3 9.47 6 10.036 6 11v.5a1 1 0 002 0v-.5c0-.364.14-.704.382-.958.243-.254.418-.582.418-.958V8.5a1 1 0 002 0v-.5c0-.364.14-.704.382-.958.243-.254.418-.582.418-.958V7z" clipRule="evenodd" /></svg>
+);
+const SubscriptionIcon = () => (
+  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 0l-2 2a1 1 0 101.414 1.414L8 10.414l1.293 1.293a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
+);
+const PlanIcon = () => (
+  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clipRule="evenodd" /></svg>
+);
+const UploadIcon = () => (
+  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clipRule="evenodd" /></svg>
+);
+
+export interface DashboardHomeProps {
+  onCreatePlan?: () => void;
+  onUploadContent?: () => void;
+}
+
+export function DashboardHome({ onCreatePlan, onUploadContent }: DashboardHomeProps) {
+  const [state, setState] = useState<'loading' | 'success' | 'error'>('loading');
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  const load = useCallback(async () => {
+    setState('loading');
+    setErrorMessage('');
+    try {
+      const result = await fetchDashboardData();
+      setData(result);
+      setState('success');
+    } catch (e) {
+      setState('error');
+      setErrorMessage(e instanceof Error ? e.message : 'Failed to load dashboard');
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (state === 'error') {
+    return (
+      <div className="grid gap-6">
+        <DashboardError message={errorMessage} onRetry={load} />
+      </div>
+    );
+  }
+
+  if (state === 'loading') {
+    return (
+      <div className="grid gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4" role="status" aria-label="Loading metrics">
+          <MetricCardSkeleton />
+          <MetricCardSkeleton />
+          <MetricCardSkeleton />
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2">
+            <ActivityFeedSkeleton />
+          </div>
+          <div>
+            <QuickActions
+              actions={[
+                { id: 'plan', label: 'Create plan', description: 'New subscription plan', onClick: onCreatePlan ?? (() => {}), icon: <PlanIcon /> },
+                { id: 'upload', label: 'Upload content', description: 'Publish new content', onClick: onUploadContent ?? (() => {}), icon: <UploadIcon /> },
+              ]}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { metrics, recentActivity } = data;
+
+  return (
+    <div className="grid gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <MetricCard
+          title="Total subscribers"
+          value={metrics.totalSubscribers}
+          changePercent={metrics.totalSubscribersChangePercent}
+          trend={metrics.totalSubscribersChangePercent >= 0 ? 'up' : 'down'}
+          comparisonLabel="vs last month"
+          icon={<PeopleIcon />}
+        />
+        <MetricCard
+          title="MRR"
+          value={metrics.mrr}
+          valuePrefix="$"
+          changePercent={metrics.mrrChangePercent}
+          trend={metrics.mrrChangePercent >= 0 ? 'up' : 'down'}
+          comparisonLabel="vs last month"
+          icon={<CurrencyIcon />}
+        />
+        <MetricCard
+          title="Active subscriptions"
+          value={metrics.activeSubscriptions}
+          changePercent={metrics.activeSubscriptionsChangePercent}
+          trend={metrics.activeSubscriptionsChangePercent >= 0 ? 'up' : 'down'}
+          comparisonLabel="vs last month"
+          icon={<SubscriptionIcon />}
+        />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2">
+          <ActivityFeed items={recentActivity} />
+        </div>
+        <div>
+          <QuickActions
+            actions={[
+              { id: 'plan', label: 'Create plan', description: 'New subscription plan', onClick: onCreatePlan ?? (() => {}), icon: <PlanIcon /> },
+              { id: 'upload', label: 'Upload content', description: 'Publish new content', onClick: onUploadContent ?? (() => {}), icon: <UploadIcon /> },
+            ]}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DashboardHome;

--- a/frontend/src/components/dashboard/MetricCardSkeleton.tsx
+++ b/frontend/src/components/dashboard/MetricCardSkeleton.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+import { BaseCard } from '@/components/cards';
+
+/**
+ * Skeleton for MetricCard. Matches card layout to prevent CLS.
+ */
+export function MetricCardSkeleton() {
+  return (
+    <BaseCard className="flex flex-col" padding="lg">
+      <div className="flex items-start justify-between mb-4">
+        <div className="flex-1">
+          <div className="h-4 w-24 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-1" />
+        </div>
+        <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-gray-200 dark:bg-gray-700 animate-pulse" />
+      </div>
+      <div className="h-8 w-28 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-2" />
+      <div className="flex items-center gap-2">
+        <div className="h-4 w-16 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+        <div className="h-3 w-20 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+      </div>
+    </BaseCard>
+  );
+}
+
+export default MetricCardSkeleton;

--- a/frontend/src/components/dashboard/QuickActions.tsx
+++ b/frontend/src/components/dashboard/QuickActions.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import React from 'react';
+import { BaseCard } from '@/components/cards';
+
+export interface QuickActionItem {
+  id: string;
+  label: string;
+  description?: string;
+  onClick: () => void;
+  icon: React.ReactNode;
+}
+
+export interface QuickActionsProps {
+  actions: QuickActionItem[];
+}
+
+export function QuickActions({ actions }: QuickActionsProps) {
+  return (
+    <BaseCard className="flex flex-col" padding="lg" as="section" aria-labelledby="quick-actions-heading">
+      <h2 id="quick-actions-heading" className="text-sm font-semibold text-gray-900 dark:text-white mb-4">
+        Quick actions
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {actions.map((action) => (
+          <button
+            key={action.id}
+            type="button"
+            onClick={action.onClick}
+            className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors text-left"
+          >
+            <span className="flex-shrink-0 w-10 h-10 rounded-lg bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 flex items-center justify-center">
+              {action.icon}
+            </span>
+            <div className="min-w-0">
+              <span className="text-sm font-medium text-gray-900 dark:text-white block">{action.label}</span>
+              {action.description && (
+                <span className="text-xs text-gray-500 dark:text-gray-400 block">{action.description}</span>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+    </BaseCard>
+  );
+}
+
+export default QuickActions;

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -1,0 +1,6 @@
+export { DashboardHome } from './DashboardHome';
+export { MetricCardSkeleton } from './MetricCardSkeleton';
+export { ActivityFeedSkeleton } from './ActivityFeedSkeleton';
+export { ActivityFeed } from './ActivityFeed';
+export { QuickActions } from './QuickActions';
+export { DashboardError } from './DashboardError';

--- a/frontend/src/lib/dashboard.ts
+++ b/frontend/src/lib/dashboard.ts
@@ -1,0 +1,58 @@
+/**
+ * Dashboard home types and data (API or mock).
+ */
+
+export interface DashboardMetrics {
+  totalSubscribers: number;
+  totalSubscribersChangePercent: number;
+  mrr: number;
+  mrrChangePercent: number;
+  activeSubscriptions: number;
+  activeSubscriptionsChangePercent: number;
+}
+
+export interface ActivityItem {
+  id: string;
+  type: 'subscription' | 'renewal' | 'cancellation' | 'content' | 'payout';
+  title: string;
+  description: string;
+  timestamp: string; // ISO
+  metadata?: string;
+}
+
+export interface DashboardData {
+  metrics: DashboardMetrics;
+  recentActivity: ActivityItem[];
+}
+
+const MOCK_METRICS: DashboardMetrics = {
+  totalSubscribers: 1247,
+  totalSubscribersChangePercent: 12.4,
+  mrr: 3840,
+  mrrChangePercent: 8.2,
+  activeSubscriptions: 892,
+  activeSubscriptionsChangePercent: -2.1,
+};
+
+const MOCK_ACTIVITY: ActivityItem[] = [
+  { id: '1', type: 'subscription', title: 'New subscriber', description: '@alex_fan subscribed to Premium', timestamp: new Date(Date.now() - 1000 * 60 * 5).toISOString(), metadata: '+$9.99' },
+  { id: '2', type: 'renewal', title: 'Renewal', description: '@jordan_art renewed Monthly', timestamp: new Date(Date.now() - 1000 * 60 * 32).toISOString(), metadata: '$4.99' },
+  { id: '3', type: 'content', title: 'Content published', description: 'New post: "Behind the scenes"', timestamp: new Date(Date.now() - 1000 * 60 * 90).toISOString() },
+  { id: '4', type: 'cancellation', title: 'Subscription cancelled', description: '@sam_user cancelled Premium', timestamp: new Date(Date.now() - 1000 * 60 * 120).toISOString() },
+  { id: '5', type: 'payout', title: 'Payout sent', description: 'Weekly payout completed', timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(), metadata: '$420.00' },
+];
+
+/**
+ * Fetch dashboard data. Replace with real API when available.
+ * @param options.simulateError - if true, rejects to test error state
+ */
+export async function fetchDashboardData(options?: { simulateError?: boolean }): Promise<DashboardData> {
+  if (options?.simulateError) {
+    await new Promise((_, reject) => setTimeout(() => reject(new Error('Failed to load dashboard')), 400));
+  }
+  await new Promise((r) => setTimeout(r, 800)); // simulate network
+  return {
+    metrics: MOCK_METRICS,
+    recentActivity: MOCK_ACTIVITY,
+  };
+}


### PR DESCRIPTION
## Description
Adds dashboard home for the creator dashboard with metric cards, recent activity feed, quick actions, loading skeletons, and error handling.

## Changes
- **Metric cards** — Total subscribers, MRR, and Active subscriptions with change indicators (vs last month) and trend icons (up/down).
- **Recent activity feed** — Last 5 items (subscriptions, renewals, content, cancellations, payouts) with type icons and relative timestamps.
- **Quick actions** — “Create plan” (scrolls to subscription plan form) and “Upload content” (placeholder for future flow).
- **Loading skeletons** — Metric and activity skeletons that match card layout to avoid layout shift (no CLS).
- **Error state** — Message and “Try again” button when dashboard data fetch fails.

## Technical notes
- Dashboard data is loaded via `fetchDashboardData()` in `frontend/src/lib/dashboard.ts` (mock data; can be swapped for API).
- Uses existing `MetricCard` and `BaseCard`; new dashboard components live under `frontend/src/components/dashboard/`.

## Acceptance criteria
- [x] Metric cards render with change indicators
- [x] Activity feed (last 5 items)
- [x] Loading skeletons matching card layout
- [x] Error state on fetch fail
- [x] No CLS (skeletons reserve same space as content)
closes #87 