### PR TITLE
fans profile creator

### DIFF
--- a/frontend/src/app/creator/[username]/page.tsx
+++ b/frontend/src/app/creator/[username]/page.tsx
@@ -1,0 +1,190 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import {
+  getCreatorByUsername,
+  getCreatorPlans,
+  getPreviewContent,
+  getPosts,
+  getCurrencySymbol,
+  type CreatorProfile,
+} from '@/lib/creator-profile';
+import { PlanCard } from '@/components/cards';
+import { ContentCard } from '@/components/cards';
+
+interface PageProps {
+  params: Promise<{ username: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { username } = await params;
+  const creator = getCreatorByUsername(username);
+  if (!creator) {
+    return { title: 'Creator Not Found' };
+  }
+  const title = `${creator.displayName} (@${creator.username}) | MyFans`;
+  const description = creator.bio || `Subscribe to ${creator.displayName} on MyFans`;
+  const url = `https://myfans.app/creator/${creator.username}`;
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: 'MyFans',
+      type: 'profile',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
+    alternates: { canonical: url },
+  };
+}
+
+export default async function CreatorProfilePage({ params }: PageProps) {
+  const { username } = await params;
+  const creator = getCreatorByUsername(username);
+  if (!creator) {
+    notFound();
+  }
+
+  const plans = getCreatorPlans(username);
+  const previewContent = getPreviewContent(username);
+  const posts = getPosts(username);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <CreatorHero creator={creator} />
+      <main className="max-w-5xl mx-auto px-4 py-8 sm:px-6">
+        <section className="mb-10" aria-labelledby="plans-heading">
+          <h2 id="plans-heading" className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+            Subscription plans
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {plans.map((plan) => (
+              <PlanCard
+                key={plan.id}
+                name={plan.name}
+                price={plan.price}
+                billingPeriod={plan.billingPeriod}
+                description={plan.description}
+                features={plan.features}
+                isPopular={plan.isPopular}
+                currencySymbol={getCurrencySymbol(plan.currency)}
+                actionButton={
+                  <Link
+                    href={`/subscribe?creator=${username}&plan=${plan.id}`}
+                    className="block w-full py-2 text-center text-sm font-medium rounded-lg bg-primary-600 hover:bg-primary-700 text-white transition-colors"
+                  >
+                    Subscribe
+                  </Link>
+                }
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className="mb-10" aria-labelledby="preview-heading">
+          <h2 id="preview-heading" className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+            Preview
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {previewContent.map((post) => (
+              <ContentCard
+                key={post.id}
+                title={post.title}
+                type={post.type}
+                thumbnailUrl={post.thumbnailUrl}
+                description={post.excerpt}
+                publishedAt={post.publishedAt}
+                viewCount={post.viewCount}
+                likeCount={post.likeCount}
+                status="published"
+                isLocked={post.isLocked}
+                creatorName={creator.displayName}
+                creatorAvatar={creator.avatarUrl}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section aria-labelledby="posts-heading">
+          <h2 id="posts-heading" className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+            Posts
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {posts.map((post) => (
+              <ContentCard
+                key={post.id}
+                title={post.title}
+                type={post.type}
+                thumbnailUrl={post.thumbnailUrl}
+                description={post.excerpt}
+                publishedAt={post.publishedAt}
+                viewCount={post.viewCount}
+                likeCount={post.likeCount}
+                status="published"
+                isLocked={post.isLocked}
+                creatorName={creator.displayName}
+                creatorAvatar={creator.avatarUrl}
+              />
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function CreatorHero({ creator }: { creator: CreatorProfile }) {
+  return (
+    <header className="relative">
+      <div className="h-40 sm:h-52 bg-gradient-to-br from-primary-500 to-primary-800 dark:from-primary-700 dark:to-primary-900" />
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 -mt-16 sm:-mt-20 relative">
+        <div className="flex flex-col sm:flex-row sm:items-end gap-4">
+          <div className="flex-shrink-0 w-24 h-24 sm:w-32 sm:h-32 rounded-full border-4 border-white dark:border-gray-900 bg-gray-200 dark:bg-gray-700 overflow-hidden flex items-center justify-center">
+            {creator.avatarUrl ? (
+              <Image src={creator.avatarUrl} alt="" width={128} height={128} className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-3xl sm:text-4xl font-bold text-gray-500 dark:text-gray-400">
+                {creator.displayName.charAt(0)}
+              </span>
+            )}
+          </div>
+          <div className="pb-1 flex-1">
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white">
+              {creator.displayName}
+            </h1>
+            <p className="text-gray-500 dark:text-gray-400">@{creator.username}</p>
+            <p className="mt-2 text-sm font-medium text-gray-600 dark:text-gray-300">
+              {creator.subscriberCount.toLocaleString()} subscribers
+            </p>
+            {creator.bio && (
+              <p className="mt-2 text-gray-600 dark:text-gray-300 max-w-2xl">{creator.bio}</p>
+            )}
+            {creator.socialLinks.length > 0 && (
+              <ul className="mt-3 flex flex-wrap gap-3" aria-label="Social links">
+                {creator.socialLinks.map((link) => (
+                  <li key={link.platform}>
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-primary-600 dark:text-primary-400 hover:underline"
+                    >
+                      {link.label ?? link.platform}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-gray-50 dark:bg-gray-900">
+      <h1 className="text-6xl font-bold text-gray-200 dark:text-gray-700">404</h1>
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mt-2">Page not found</h2>
+      <p className="text-gray-500 dark:text-gray-400 mt-2 text-center max-w-sm">
+        The page you’re looking for doesn’t exist or has been moved.
+      </p>
+      <Link
+        href="/"
+        className="mt-6 px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white font-medium rounded-lg transition-colors"
+      >
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -14,16 +14,21 @@ export default function Home() {
         <p className="mb-6">Built on Stellar with Soroban smart contracts</p>
         
         <div className="grid grid-cols-2 gap-4">
-          <Link href="/creators" className="p-6 border rounded hover:bg-gray-50">
+          <Link href="/creators" className="p-6 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
             <h3 className="text-xl font-semibold mb-2">For Creators</h3>
             <p>Create subscription plans and monetize your content</p>
           </Link>
           
-          <Link href="/subscribe" className="p-6 border rounded hover:bg-gray-50">
+          <Link href="/subscribe" className="p-6 border rounded hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800">
             <h3 className="text-xl font-semibold mb-2">For Fans</h3>
             <p>Subscribe to your favorite creators</p>
           </Link>
         </div>
+        <p className="mt-6 text-sm text-gray-500 dark:text-gray-400">
+          <Link href="/creator/jane" className="text-primary-600 dark:text-primary-400 hover:underline">
+            View sample creator profile
+          </Link>
+        </p>
       </main>
     </div>
   );

--- a/frontend/src/lib/creator-profile.ts
+++ b/frontend/src/lib/creator-profile.ts
@@ -1,0 +1,106 @@
+/**
+ * Creator profile data for public fan-facing page.
+ * Replace with API calls when backend is ready.
+ */
+
+export interface CreatorProfile {
+  username: string;
+  displayName: string;
+  bio: string;
+  avatarUrl?: string;
+  bannerUrl?: string;
+  subscriberCount: number;
+  socialLinks: { platform: string; url: string; label?: string }[];
+}
+
+export interface CreatorPlan {
+  id: string;
+  name: string;
+  price: number;
+  currency: string;
+  billingPeriod: 'month' | 'year';
+  description?: string;
+  features?: { text: string; included: boolean }[];
+  isPopular?: boolean;
+}
+
+export interface CreatorPost {
+  id: string;
+  title: string;
+  type: 'image' | 'video' | 'audio' | 'text';
+  thumbnailUrl?: string;
+  excerpt?: string;
+  publishedAt: string;
+  isLocked: boolean;
+  viewCount?: number;
+  likeCount?: number;
+}
+
+const MOCK_CREATORS: Record<string, CreatorProfile> = {
+  jane: {
+    username: 'jane',
+    displayName: 'Jane Doe',
+    bio: 'Digital artist and creator. Exclusive drops and behind-the-scenes for subscribers.',
+    subscriberCount: 12400,
+    socialLinks: [
+      { platform: 'twitter', url: 'https://twitter.com/janedoe', label: 'Twitter' },
+      { platform: 'instagram', url: 'https://instagram.com/janedoe', label: 'Instagram' },
+    ],
+  },
+  alex: {
+    username: 'alex',
+    displayName: 'Alex Chen',
+    bio: 'Photography and short films. Subscribe for early access and tutorials.',
+    subscriberCount: 8300,
+    socialLinks: [
+      { platform: 'youtube', url: 'https://youtube.com/@alexchen', label: 'YouTube' },
+    ],
+  },
+};
+
+const MOCK_PLANS: Record<string, CreatorPlan[]> = {
+  jane: [
+    { id: 'p1', name: 'Basic', price: 4.99, currency: 'USD', billingPeriod: 'month', description: 'Monthly drops and feed access.', isPopular: false },
+    { id: 'p2', name: 'Pro', price: 9.99, currency: 'USD', billingPeriod: 'month', description: 'All Basic + exclusive livestreams.', isPopular: true },
+    { id: 'p3', name: 'Premium', price: 19.99, currency: 'USD', billingPeriod: 'month', description: 'Everything + 1:1 feedback.', isPopular: false },
+  ],
+  alex: [
+    { id: 'a1', name: 'Supporter', price: 2.99, currency: 'USD', billingPeriod: 'month', description: 'Early access to new work.' },
+    { id: 'a2', name: 'Patron', price: 9.99, currency: 'USD', billingPeriod: 'month', description: 'Full library + Discord.', isPopular: true },
+  ],
+};
+
+const MOCK_PREVIEW: CreatorPost[] = [
+  { id: 'c1', title: 'Welcome post', type: 'text', excerpt: 'Thanks for visiting…', publishedAt: new Date(Date.now() - 86400000 * 2).toISOString(), isLocked: false },
+  { id: 'c2', title: 'Studio tour', type: 'video', publishedAt: new Date(Date.now() - 86400000 * 5).toISOString(), isLocked: true, viewCount: 1200 },
+  { id: 'c3', title: 'New artwork preview', type: 'image', publishedAt: new Date(Date.now() - 86400000 * 7).toISOString(), isLocked: true, likeCount: 340 },
+];
+
+const MOCK_POSTS: CreatorPost[] = [
+  ...MOCK_PREVIEW,
+  { id: 'c4', title: 'Q&A highlights', type: 'video', publishedAt: new Date(Date.now() - 86400000 * 10).toISOString(), isLocked: true, viewCount: 890 },
+  { id: 'c5', title: 'Work in progress', type: 'image', excerpt: 'Sneak peek…', publishedAt: new Date(Date.now() - 86400000 * 14).toISOString(), isLocked: false, likeCount: 120 },
+];
+
+export function getCreatorByUsername(username: string): CreatorProfile | null {
+  const key = username.toLowerCase();
+  return MOCK_CREATORS[key] ?? null;
+}
+
+export function getCreatorPlans(username: string): CreatorPlan[] {
+  const key = username.toLowerCase();
+  return MOCK_PLANS[key] ?? MOCK_PLANS.jane;
+}
+
+export function getPreviewContent(_username: string): CreatorPost[] {
+  return MOCK_PREVIEW;
+}
+
+export function getPosts(_username: string): CreatorPost[] {
+  return MOCK_POSTS;
+}
+
+export function getCurrencySymbol(currency: string): string {
+  const map: Record<string, string> = { USD: '$', EUR: '€', GBP: '£' };
+  return map[currency] ?? currency;
+}


### PR DESCRIPTION
## Description
Adds creator profile page for fans with hero, subscription plans, preview content, and posts feed. Includes SEO meta tags and 404 handling for unknown creators.

## Changes
- **Route** — `/creator/[username]` (e.g. `/creator/jane`, `/creator/alex`). Dynamic route; calls `notFound()` when creator does not exist.
- **Hero** — Banner (gradient), avatar (or initial), display name, @username, subscriber count, bio, social links (Twitter, Instagram, YouTube, etc.).
- **Plan cards** — “Subscription plans” section with grid of `PlanCard`s; Subscribe links to `/subscribe?creator=...&plan=...`. Mock data for `jane` and `alex`.
- **Preview content** — “Preview” section with content cards (some locked); uses existing `ContentCard`.
- **Posts feed** — “Posts” section with full feed of content cards (preview + more).
- **SEO** — `generateMetadata`: title `{displayName} (@{username}) | MyFans`, description from bio, Open Graph (title, description, url, siteName, type), Twitter card, canonical URL. Fallback when creator not found.
- **404** — Global `app/not-found.tsx` (message + “Go home”); profile page calls `notFound()` for unknown username.

## Technical notes
- Data and mocks in `frontend/src/lib/creator-profile.ts` (`getCreatorByUsername`, `getCreatorPlans`, `getPreviewContent`, `getPosts`). Replace with API when ready.
- Home page updated with “View sample creator profile” link to `/creator/jane` and dark mode styles on cards.

## Acceptance criteria
- [x] Creator profile page (hero, plans, preview, posts)
- [x] Plan cards with Subscribe
- [x] Preview content section
- [x] Posts feed
- [x] SEO meta tags (title, description, OG, Twitter, canonical)
- [x] 404 handling (unknown creator + global not-found page)

closes #94 