### PR TITLE
Add Button Library & Wallet Display Component

### DIFF
--- a/frontend/README_COMPONENTS.md
+++ b/frontend/README_COMPONENTS.md
@@ -1,0 +1,80 @@
+# Component Documentation
+
+## Button
+
+Reusable button component with multiple variants, sizes, and states.
+
+### Props
+
+- `variant`: 'primary' | 'secondary' | 'tertiary' | 'wallet' (default: 'primary')
+- `size`: 'sm' | 'md' | 'lg' (default: 'md')
+- `loading`: boolean (default: false)
+- `disabled`: boolean (default: false)
+- `fullWidth`: boolean (default: false)
+
+### Variants
+
+- **Primary**: Blue background, white text
+- **Secondary**: Gray background, dark text
+- **Tertiary**: Transparent background, blue text
+- **Wallet**: Gradient purple-to-blue background
+
+### Accessibility
+
+- Keyboard navigation support
+- Focus visible ring indicators
+- `aria-busy` attribute when loading
+- Disabled state prevents interaction
+- Semantic button element
+
+### Usage
+
+```tsx
+import Button from '@/components/Button';
+
+<Button variant="primary" size="md">Click me</Button>
+<Button variant="wallet" loading>Connecting...</Button>
+<Button fullWidth disabled>Disabled</Button>
+```
+
+## WalletDisplay
+
+Displays connected wallet information with copy and disconnect functionality.
+
+### Props
+
+- `address`: string (wallet address)
+- `network`: string (default: 'Mainnet')
+- `onDisconnect`: () => void (callback for disconnect action)
+
+### Features
+
+- Formatted address display (0x1234...5678)
+- Copy to clipboard with visual feedback
+- Network indicator
+- Disconnect button
+- Handles disconnected state
+
+### Accessibility
+
+- `aria-label` for address and actions
+- `role="status"` for disconnected state
+- `aria-live="polite"` for state changes
+- Keyboard accessible buttons
+- Focus visible indicators
+
+### Usage
+
+```tsx
+import WalletDisplay from '@/components/WalletDisplay';
+
+<WalletDisplay 
+  address="0x1234567890abcdef1234567890abcdef12345678"
+  network="Mainnet"
+  onDisconnect={() => console.log('Disconnected')}
+/>
+```
+
+### Handling Extension Disconnect
+
+The component automatically shows a disconnected state when `address` is empty or undefined. Listen for wallet extension disconnect events and update the address prop accordingly.

--- a/frontend/src/components/Button.stories.tsx
+++ b/frontend/src/components/Button.stories.tsx
@@ -1,0 +1,89 @@
+import Button from './Button';
+
+export default {
+  title: 'Components/Button',
+  component: Button,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'wallet']
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg']
+    },
+    loading: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    fullWidth: { control: 'boolean' }
+  }
+};
+
+export const Primary = {
+  args: {
+    children: 'Primary Button',
+    variant: 'primary'
+  }
+};
+
+export const Secondary = {
+  args: {
+    children: 'Secondary Button',
+    variant: 'secondary'
+  }
+};
+
+export const Tertiary = {
+  args: {
+    children: 'Tertiary Button',
+    variant: 'tertiary'
+  }
+};
+
+export const Wallet = {
+  args: {
+    children: 'Connect Wallet',
+    variant: 'wallet'
+  }
+};
+
+export const Loading = {
+  args: {
+    children: 'Loading...',
+    loading: true
+  }
+};
+
+export const Disabled = {
+  args: {
+    children: 'Disabled Button',
+    disabled: true
+  }
+};
+
+export const Sizes = {
+  render: () => (
+    <div className="flex gap-4 items-center">
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+  )
+};
+
+export const FullWidth = {
+  args: {
+    children: 'Full Width Button',
+    fullWidth: true
+  }
+};
+
+export const AllVariants = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Button variant="primary">Primary</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="tertiary">Tertiary</Button>
+      <Button variant="wallet">Connect Wallet</Button>
+    </div>
+  )
+};

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,54 @@
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+
+type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'wallet';
+type ButtonSize = 'sm' | 'md' | 'lg';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  loading?: boolean;
+  fullWidth?: boolean;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', size = 'md', loading = false, fullWidth = false, disabled, className = '', children, ...props }, ref) => {
+    const baseStyles = 'inline-flex items-center justify-center font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none';
+    
+    const variants = {
+      primary: 'bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-600',
+      secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300 focus-visible:ring-gray-500',
+      tertiary: 'bg-transparent text-blue-600 hover:bg-blue-50 focus-visible:ring-blue-600',
+      wallet: 'bg-gradient-to-r from-purple-600 to-blue-600 text-white hover:from-purple-700 hover:to-blue-700 focus-visible:ring-purple-600'
+    };
+    
+    const sizes = {
+      sm: 'h-8 px-3 text-sm rounded',
+      md: 'h-10 px-4 text-base rounded-md',
+      lg: 'h-12 px-6 text-lg rounded-lg'
+    };
+    
+    const widthClass = fullWidth ? 'w-full' : '';
+    
+    return (
+      <button
+        ref={ref}
+        disabled={disabled || loading}
+        className={`${baseStyles} ${variants[variant]} ${sizes[size]} ${widthClass} ${className}`}
+        aria-busy={loading}
+        {...props}
+      >
+        {loading && (
+          <svg className="animate-spin -ml-1 mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+        )}
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';
+
+export default Button;

--- a/frontend/src/components/WalletDisplay.stories.tsx
+++ b/frontend/src/components/WalletDisplay.stories.tsx
@@ -1,0 +1,30 @@
+import WalletDisplay from './WalletDisplay';
+
+export default {
+  title: 'Components/WalletDisplay',
+  component: WalletDisplay,
+  argTypes: {
+    onDisconnect: { action: 'disconnected' }
+  }
+};
+
+export const Connected = {
+  args: {
+    address: '0x1234567890abcdef1234567890abcdef12345678',
+    network: 'Mainnet'
+  }
+};
+
+export const Testnet = {
+  args: {
+    address: '0xabcdef1234567890abcdef1234567890abcdef12',
+    network: 'Testnet'
+  }
+};
+
+export const Disconnected = {
+  args: {
+    address: '',
+    network: 'Mainnet'
+  }
+};

--- a/frontend/src/components/WalletDisplay.tsx
+++ b/frontend/src/components/WalletDisplay.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+
+interface WalletDisplayProps {
+  address: string;
+  network?: string;
+  onDisconnect: () => void;
+}
+
+export default function WalletDisplay({ address, network = 'Mainnet', onDisconnect }: WalletDisplayProps) {
+  const [copied, setCopied] = useState(false);
+
+  const formatAddress = (addr: string) => {
+    if (!addr) return '';
+    return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
+  if (!address) {
+    return (
+      <div className="flex items-center gap-2 px-4 py-2 bg-gray-100 rounded-lg" role="status" aria-live="polite">
+        <span className="text-sm text-gray-600">Wallet disconnected</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 rounded-lg">
+      <div className="flex flex-col">
+        <span className="text-xs text-gray-500">{network}</span>
+        <span className="text-sm font-mono font-medium" aria-label={`Wallet address ${address}`}>
+          {formatAddress(address)}
+        </span>
+      </div>
+      
+      <button
+        onClick={handleCopy}
+        className="p-1.5 hover:bg-gray-100 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600"
+        aria-label={copied ? 'Address copied' : 'Copy address'}
+      >
+        {copied ? (
+          <svg className="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        ) : (
+          <svg className="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+        )}
+      </button>
+
+      <button
+        onClick={onDisconnect}
+        className="ml-2 px-3 py-1 text-sm text-red-600 hover:bg-red-50 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+        aria-label="Disconnect wallet"
+      >
+        Disconnect
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Implements a reusable Button component system (Primary, Secondary, Tertiary, Wallet Connect) with loading/disabled states, sizes, full-width support, accessibility, and Storybook documentation.
Also adds a reusable Wallet Display component with address, copy functionality, network indicator, disconnect action, extension handling, and disconnected state.
All acceptance criteria are met.
closes #102 #104 