### PR TITLE
subscription management

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -24,9 +24,12 @@ export default function Home() {
             <p>Subscribe to your favorite creators</p>
           </Link>
         </div>
-        <p className="mt-6 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mt-6 text-sm text-gray-500 dark:text-gray-400 space-x-4">
           <Link href="/creator/jane" className="text-primary-600 dark:text-primary-400 hover:underline">
             View sample creator profile
+          </Link>
+          <Link href="/subscriptions" className="text-primary-600 dark:text-primary-400 hover:underline">
+            My subscriptions
           </Link>
         </p>
       </main>

--- a/frontend/src/app/subscriptions/page.tsx
+++ b/frontend/src/app/subscriptions/page.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import Link from 'next/link';
+import {
+  MOCK_ACTIVE,
+  MOCK_HISTORY,
+  MOCK_PAYMENTS,
+  getCurrencySymbol,
+  formatDate,
+  type ActiveSubscription,
+  type SubscriptionHistoryItem,
+  type PaymentRecord,
+} from '@/lib/subscriptions';
+import { BaseCard } from '@/components/cards/BaseCard';
+
+export default function SubscriptionsPage() {
+  const [activeList, setActiveList] = useState<ActiveSubscription[]>(MOCK_ACTIVE);
+  const [cancelTarget, setCancelTarget] = useState<ActiveSubscription | null>(null);
+  const [isCancelling, setIsCancelling] = useState(false);
+
+  const handleCancelConfirm = useCallback(async () => {
+    if (!cancelTarget) return;
+    setIsCancelling(true);
+    try {
+      // Replace with API: await cancelSubscription(cancelTarget.id);
+      setActiveList((prev) => prev.filter((s) => s.id !== cancelTarget.id));
+      setCancelTarget(null);
+    } finally {
+      setIsCancelling(false);
+    }
+  }, [cancelTarget]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+        <div className="max-w-4xl mx-auto px-4 py-6">
+          <Link href="/" className="text-sm text-primary-600 dark:text-primary-400 hover:underline mb-2 inline-block">
+            ← Back to MyFans
+          </Link>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">My subscriptions</h1>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">Manage your active subscriptions and view history.</p>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-4 py-8 space-y-10">
+        {/* Active subscriptions */}
+        <section aria-labelledby="active-heading">
+          <h2 id="active-heading" className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            Active subscriptions
+          </h2>
+          {activeList.length === 0 ? (
+            <EmptyState
+              title="No active subscriptions"
+              description="You don’t have any active subscriptions. Subscribe to creators to support them and get access to exclusive content."
+              actionLabel="Discover creators"
+              actionHref="/"
+            />
+          ) : (
+            <ul className="space-y-3">
+              {activeList.map((sub) => (
+                <li key={sub.id}>
+                  <BaseCard padding="md" className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                    <div>
+                      <p className="font-medium text-gray-900 dark:text-white">
+                        <Link href={`/creator/${sub.creatorUsername}`} className="hover:underline">
+                          {sub.creatorName}
+                        </Link>
+                        <span className="text-gray-500 dark:text-gray-400 font-normal"> · {sub.planName}</span>
+                      </p>
+                      <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                        {getCurrencySymbol(sub.currency)}{sub.price.toFixed(2)}/{sub.interval} · Renews {formatDate(sub.currentPeriodEnd)}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setCancelTarget(sub)}
+                      className="flex-shrink-0 px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+                    >
+                      Cancel subscription
+                    </button>
+                  </BaseCard>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Subscription history */}
+        <section aria-labelledby="history-heading">
+          <h2 id="history-heading" className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            Subscription history
+          </h2>
+          {MOCK_HISTORY.length === 0 ? (
+            <EmptyState
+              title="No subscription history"
+              description="Cancelled subscriptions will appear here."
+            />
+          ) : (
+            <ul className="space-y-3">
+              {MOCK_HISTORY.map((item) => (
+                <HistoryCard key={item.id} item={item} />
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Payment history */}
+        <section aria-labelledby="payments-heading">
+          <h2 id="payments-heading" className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            Payment history
+          </h2>
+          {MOCK_PAYMENTS.length === 0 ? (
+            <EmptyState
+              title="No payments yet"
+              description="Payment records will appear here when you subscribe to creators."
+            />
+          ) : (
+            <ul className="space-y-3">
+              {MOCK_PAYMENTS.map((payment) => (
+                <PaymentCard key={payment.id} payment={payment} />
+              ))}
+            </ul>
+          )}
+        </section>
+      </main>
+
+      {/* Cancel confirmation modal */}
+      {cancelTarget && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cancel-dialog-title"
+        >
+          <BaseCard padding="lg" className="max-w-md w-full">
+            <h3 id="cancel-dialog-title" className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+              Cancel subscription?
+            </h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+              You will lose access to {cancelTarget.creatorName}&apos;s {cancelTarget.planName} content at the end of your current billing period ({formatDate(cancelTarget.currentPeriodEnd)}). You can resubscribe anytime.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                type="button"
+                onClick={() => setCancelTarget(null)}
+                disabled={isCancelling}
+                className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+              >
+                Keep subscription
+              </button>
+              <button
+                type="button"
+                onClick={handleCancelConfirm}
+                disabled={isCancelling}
+                className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white font-medium rounded-lg disabled:opacity-50"
+              >
+                {isCancelling ? 'Cancelling…' : 'Cancel subscription'}
+              </button>
+            </div>
+          </BaseCard>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({
+  title,
+  description,
+  actionLabel,
+  actionHref,
+}: {
+  title: string;
+  description: string;
+  actionLabel?: string;
+  actionHref?: string;
+}) {
+  return (
+    <BaseCard padding="lg" className="text-center">
+      <div className="w-12 h-12 mx-auto rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center text-gray-400 dark:text-gray-500 mb-4" aria-hidden>
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0a2 2 0 01-2 2H6a2 2 0 01-2-2m16 0V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0V6a2 2 0 00-2-2H6a2 2 0 00-2 2v5" />
+        </svg>
+      </div>
+      <h3 className="font-medium text-gray-900 dark:text-white">{title}</h3>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 max-w-sm mx-auto">{description}</p>
+      {actionLabel && actionHref && (
+        <Link
+          href={actionHref}
+          className="mt-4 inline-block px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium rounded-lg transition-colors"
+        >
+          {actionLabel}
+        </Link>
+      )}
+    </BaseCard>
+  );
+}
+
+function HistoryCard({ item }: { item: SubscriptionHistoryItem }) {
+  return (
+    <BaseCard padding="md">
+      <p className="font-medium text-gray-900 dark:text-white">
+        {item.creatorName} · {item.planName}
+      </p>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+        {getCurrencySymbol(item.currency)}{item.price.toFixed(2)} · {formatDate(item.startedAt)} – {formatDate(item.endedAt)}
+      </p>
+      {item.cancelReason && (
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">{item.cancelReason}</p>
+      )}
+    </BaseCard>
+  );
+}
+
+function PaymentCard({ payment }: { payment: PaymentRecord }) {
+  const statusColor =
+    payment.status === 'completed'
+      ? 'text-green-600 dark:text-green-400'
+      : payment.status === 'failed' || payment.status === 'refunded'
+        ? 'text-red-600 dark:text-red-400'
+        : 'text-gray-600 dark:text-gray-400';
+  return (
+    <BaseCard padding="md" className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+      <div>
+        <p className="font-medium text-gray-900 dark:text-white">
+          {payment.creatorName} · {payment.planName}
+        </p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{formatDate(payment.date)}</p>
+      </div>
+      <div className="flex items-center gap-2 sm:gap-4">
+        <span className="font-medium text-gray-900 dark:text-white">
+          {getCurrencySymbol(payment.currency)}{payment.amount.toFixed(2)}
+        </span>
+        <span className={`text-sm capitalize ${statusColor}`}>{payment.status}</span>
+      </div>
+    </BaseCard>
+  );
+}

--- a/frontend/src/lib/subscriptions.ts
+++ b/frontend/src/lib/subscriptions.ts
@@ -1,0 +1,99 @@
+/**
+ * Fan subscription management: active list, history, payment history.
+ * Replace with API when backend is ready.
+ */
+
+export interface ActiveSubscription {
+  id: string;
+  creatorId: string;
+  creatorName: string;
+  creatorUsername: string;
+  planName: string;
+  price: number;
+  currency: string;
+  interval: 'month' | 'year';
+  currentPeriodEnd: string; // ISO
+  status: 'active';
+}
+
+export interface SubscriptionHistoryItem {
+  id: string;
+  creatorName: string;
+  creatorUsername: string;
+  planName: string;
+  price: number;
+  currency: string;
+  startedAt: string;
+  endedAt: string;
+  cancelReason?: string;
+}
+
+export interface PaymentRecord {
+  id: string;
+  date: string; // ISO
+  creatorName: string;
+  planName: string;
+  amount: number;
+  currency: string;
+  status: 'completed' | 'pending' | 'failed' | 'refunded';
+  description?: string;
+}
+
+const now = new Date();
+const fmt = (d: Date, days: number) => new Date(d.getTime() + days * 86400000).toISOString();
+
+export const MOCK_ACTIVE: ActiveSubscription[] = [
+  {
+    id: 'sub-1',
+    creatorId: 'c1',
+    creatorName: 'Jane Doe',
+    creatorUsername: 'jane',
+    planName: 'Pro',
+    price: 9.99,
+    currency: 'USD',
+    interval: 'month',
+    currentPeriodEnd: fmt(now, 12),
+    status: 'active',
+  },
+  {
+    id: 'sub-2',
+    creatorId: 'c2',
+    creatorName: 'Alex Chen',
+    creatorUsername: 'alex',
+    planName: 'Patron',
+    price: 9.99,
+    currency: 'USD',
+    interval: 'month',
+    currentPeriodEnd: fmt(now, 25),
+    status: 'active',
+  },
+];
+
+export const MOCK_HISTORY: SubscriptionHistoryItem[] = [
+  {
+    id: 'hist-1',
+    creatorName: 'Studio Art',
+    creatorUsername: 'studioart',
+    planName: 'Basic',
+    price: 4.99,
+    currency: 'USD',
+    startedAt: fmt(now, -60),
+    endedAt: fmt(now, -5),
+    cancelReason: 'Cancelled by user',
+  },
+];
+
+export const MOCK_PAYMENTS: PaymentRecord[] = [
+  { id: 'pay-1', date: fmt(now, -2), creatorName: 'Jane Doe', planName: 'Pro', amount: 9.99, currency: 'USD', status: 'completed' },
+  { id: 'pay-2', date: fmt(now, -32), creatorName: 'Alex Chen', planName: 'Patron', amount: 9.99, currency: 'USD', status: 'completed' },
+  { id: 'pay-3', date: fmt(now, -62), creatorName: 'Studio Art', planName: 'Basic', amount: 4.99, currency: 'USD', status: 'completed' },
+];
+
+export function getCurrencySymbol(currency: string): string {
+  const map: Record<string, string> = { USD: '$', EUR: '€', GBP: '£' };
+  return map[currency] ?? currency;
+}
+
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}


### PR DESCRIPTION
## Description
Adds fan subscription management: active subscriptions list, cancel flow with confirmation, subscription history, payment history, and empty states.

## Changes
- **Route** — `/subscriptions` (“My subscriptions”) with link from home.
- **Active subscriptions list** — Cards with creator name (link to profile), plan, price/interval, renewal date, and “Cancel subscription” button. List updates when a subscription is cancelled.
- **Cancel flow** — Confirmation modal: “Cancel subscription?” with explanation (access until period end, can resubscribe). Buttons: Keep subscription / Cancel subscription; loading state while cancelling.
- **Subscription history** — Section listing past subscriptions (creator, plan, price, start/end dates, cancel reason). Mock: one item.
- **Payment history** — Section listing payments (date, creator, plan, amount, status: completed/pending/failed/refunded). Mock: three items.
- **Empty states** — Dedicated empty state for each section: icon, title, short description. Active: “Discover creators” CTA to `/`. History and Payments: copy only.

## Technical notes
- Types and mock data in `frontend/src/lib/subscriptions.ts`. Replace with API when ready.
- Page is client-side for cancel modal and list state.

## Acceptance criteria
- [x] Active list
- [x] Cancel with confirmation
- [x] Subscription history
- [x] Payment history
- [x] Empty state for each section
closes #96 