### PR TITLE
feat/observability-metrics-alerting

### DIFF
--- a/myfans-backend/package-lock.json
+++ b/myfans-backend/package-lock.json
@@ -21,6 +21,7 @@
         "class-validator": "^0.14.3",
         "ioredis": "^5.9.3",
         "pg": "^8.18.0",
+        "prom-client": "^15.1.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.28"
@@ -2588,6 +2589,15 @@
         "npm": ">=5.10.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -4240,6 +4250,12 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -8912,6 +8928,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-coalesce": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/promise-coalesce/-/promise-coalesce-1.5.0.tgz",
@@ -9894,6 +9923,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/terser": {

--- a/myfans-backend/package.json
+++ b/myfans-backend/package.json
@@ -32,6 +32,7 @@
     "class-validator": "^0.14.3",
     "ioredis": "^5.9.3",
     "pg": "^8.18.0",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.28"

--- a/myfans-backend/prometheus/alerts.yml
+++ b/myfans-backend/prometheus/alerts.yml
@@ -1,0 +1,47 @@
+# Prometheus alerting rules for myfans-backend.
+# Use with Prometheus 2.x (e.g. prometheus.yml: rule_files: ['alerts.yml']).
+# No PII in these rules; labels use method, route, status only.
+
+groups:
+  - name: myfans-backend
+    rules:
+      # High error rate: > 5% of requests in 5m window are 5xx
+      - alert: HighErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m])) by (app)
+          /
+          sum(rate(http_requests_total[5m])) by (app)
+          > 0.05
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High API error rate (5xx)"
+          description: "Error rate is above 5% for {{ $labels.app }} over the last 5 minutes."
+
+      # High latency: p99 > 2s for 5m
+      - alert: HighLatency
+        expr: |
+          histogram_quantile(0.99,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le, app)
+          ) > 2
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High API latency (p99 > 2s)"
+          description: "p99 request duration for {{ $labels.app }} is above 2 seconds."
+
+      # RPC errors (when RPC metrics are used)
+      - alert: RpcHighErrorRate
+        expr: |
+          sum(rate(rpc_call_errors_total[5m])) by (operation, app)
+          /
+          sum(rate(rpc_calls_total[5m])) by (operation, app)
+          > 0.1
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High RPC error rate"
+          description: "RPC operation {{ $labels.operation }} has >10% errors."

--- a/myfans-backend/src/app.module.ts
+++ b/myfans-backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import configuration from './config/configuration';
 import { validate } from './config/env.validation';
+import { MetricsModule } from './metrics/metrics.module';
 import { UsersModule } from './users/users.module';
 import { CreatorsModule } from './creators/creators.module';
 import { SubscriptionsModule } from './subscriptions/subscriptions.module';
@@ -18,6 +19,7 @@ import { redisStore } from 'cache-manager-redis-yet';
 
 @Module({
   imports: [
+    MetricsModule,
     ConfigModule.forRoot({
       isGlobal: true,
       load: [configuration],

--- a/myfans-backend/src/earnings/dto/earnings-summary.dto.ts
+++ b/myfans-backend/src/earnings/dto/earnings-summary.dto.ts
@@ -1,28 +1,28 @@
 export class EarningsSummaryDto {
-  total_earnings: string;
-  total_earnings_usd: number;
-  pending_amount: string;
-  available_for_withdrawal: string;
-  currency: string;
-  period_start: string;
-  period_end: string;
+  total_earnings!: string;
+  total_earnings_usd!: number;
+  pending_amount!: string;
+  available_for_withdrawal!: string;
+  currency!: string;
+  period_start!: string;
+  period_end!: string;
 }
 
 export class EarningsBreakdownDto {
-  by_time: Array<{
+  by_time!: Array<{
     date: string;
     amount: string;
     currency: string;
     count: number;
   }>;
-  by_plan: Array<{
+  by_plan!: Array<{
     plan_id: string;
     plan_name: string;
     total_amount: string;
     currency: string;
     subscriber_count: number;
   }>;
-  by_asset: Array<{
+  by_asset!: Array<{
     asset: string;
     total_amount: string;
     percentage: number;
@@ -30,45 +30,45 @@ export class EarningsBreakdownDto {
 }
 
 export class TransactionHistoryDto {
-  id: string;
-  date: string;
-  type: 'subscription' | 'post_purchase' | 'tip' | 'withdrawal' | 'fee';
-  description: string;
-  amount: string;
-  currency: string;
-  status: 'completed' | 'pending' | 'failed';
+  id!: string;
+  date!: string;
+  type!: 'subscription' | 'post_purchase' | 'tip' | 'withdrawal' | 'fee';
+  description!: string;
+  amount!: string;
+  currency!: string;
+  status!: 'completed' | 'pending' | 'failed';
   reference_id?: string;
   tx_hash?: string;
 }
 
 export class WithdrawalRequestDto {
-  amount: string;
-  currency: string;
-  destination_address: string;
-  method: 'wallet' | 'bank';
+  amount!: string;
+  currency!: string;
+  destination_address!: string;
+  method!: 'wallet' | 'bank';
 }
 
 export class WithdrawalDto {
-  id: string;
-  amount: string;
-  currency: string;
-  status: 'pending' | 'processing' | 'completed' | 'failed';
-  created_at: string;
+  id!: string;
+  amount!: string;
+  currency!: string;
+  status!: 'pending' | 'processing' | 'completed' | 'failed';
+  created_at!: string;
   completed_at?: string;
-  destination_address: string;
+  destination_address!: string;
   tx_hash?: string;
-  fee: string;
-  net_amount: string;
+  fee!: string;
+  net_amount!: string;
 }
 
 export class FeeTransparencyDto {
-  protocol_fee_bps: number;
-  protocol_fee_percentage: number;
-  withdrawal_fee_fixed: string;
-  withdrawal_fee_percentage: number;
-  example_earnings: string;
-  example_protocol_fee: string;
-  example_net_earnings: string;
-  example_withdrawal_fee: string;
-  example_final_amount: string;
+  protocol_fee_bps!: number;
+  protocol_fee_percentage!: number;
+  withdrawal_fee_fixed!: string;
+  withdrawal_fee_percentage!: number;
+  example_earnings!: string;
+  example_protocol_fee!: string;
+  example_net_earnings!: string;
+  example_withdrawal_fee!: string;
+  example_final_amount!: string;
 }

--- a/myfans-backend/src/metrics/README.md
+++ b/myfans-backend/src/metrics/README.md
@@ -1,0 +1,6 @@
+# Metrics & Observability
+
+- **HTTP:** Request count, latency histogram, and status code are recorded by `MetricsMiddleware`. Paths are normalized (UUIDs/numeric IDs replaced with `_id`) so no PII appears in labels.
+- **RPC:** Use `MetricsService.recordRpcCall(operation, durationSeconds, error)` or `withRpcMetrics(metrics, operation, fn)` when calling Soroban RPC or other external RPCs. Use generic operation names (e.g. `getLedger`, `simulate`); do not put user/account IDs in labels.
+- **Exposure:** `GET /metrics` returns Prometheus text format. Point Prometheus at `http://<host>:<PORT>/metrics` to scrape.
+- **Alerting:** See `prometheus/alerts.yml` for rules (high error rate, high latency, RPC errors). Load this file in your Prometheus `rule_files` and configure Alertmanager if needed.

--- a/myfans-backend/src/metrics/metrics.controller.ts
+++ b/myfans-backend/src/metrics/metrics.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { MetricsService } from './metrics.service';
+
+@Controller()
+export class MetricsController {
+  constructor(private readonly metrics: MetricsService) {}
+
+  @Get('metrics')
+  @Header('Content-Type', 'text/plain; charset=utf-8')
+  async getMetrics(): Promise<string> {
+    return this.metrics.getMetrics();
+  }
+}

--- a/myfans-backend/src/metrics/metrics.middleware.ts
+++ b/myfans-backend/src/metrics/metrics.middleware.ts
@@ -1,0 +1,23 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { MetricsService } from './metrics.service';
+
+@Injectable()
+export class MetricsMiddleware implements NestMiddleware {
+  constructor(private readonly metrics: MetricsService) {}
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    const start = performance.now();
+    res.on('finish', () => {
+      const duration = (performance.now() - start) / 1000;
+      const route = req.route?.path ?? req.path ?? req.url ?? '';
+      this.metrics.recordHttpRequest(
+        req.method,
+        route,
+        res.statusCode,
+        duration,
+      );
+    });
+    next();
+  }
+}

--- a/myfans-backend/src/metrics/metrics.module.ts
+++ b/myfans-backend/src/metrics/metrics.module.ts
@@ -1,0 +1,15 @@
+import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
+import { MetricsService } from './metrics.service';
+import { MetricsController } from './metrics.controller';
+import { MetricsMiddleware } from './metrics.middleware';
+
+@Module({
+  controllers: [MetricsController],
+  providers: [MetricsService, MetricsMiddleware],
+  exports: [MetricsService],
+})
+export class MetricsModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(MetricsMiddleware).exclude('/metrics').forRoutes('*');
+  }
+}

--- a/myfans-backend/src/metrics/metrics.service.ts
+++ b/myfans-backend/src/metrics/metrics.service.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@nestjs/common';
+import {
+  Registry,
+  Counter,
+  Histogram,
+  collectDefaultMetrics,
+} from 'prom-client';
+
+/** Normalize path for metrics: replace UUID-like segments with _id to avoid PII in labels. */
+export function normalizePath(path: string): string {
+  if (!path || path === '/') return path;
+  const segments = path.split('/').filter(Boolean);
+  const normalized = segments.map((seg) => {
+    if (
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        seg,
+      )
+    ) {
+      return '_id';
+    }
+    if (/^\d+$/.test(seg)) return '_id';
+    return seg;
+  });
+  return '/' + normalized.join('/');
+}
+
+@Injectable()
+export class MetricsService {
+  readonly registry: Registry;
+  readonly httpRequestTotal: Counter<string>;
+  readonly httpRequestDuration: Histogram<string>;
+  readonly rpcCallTotal: Counter<string>;
+  readonly rpcCallErrors: Counter<string>;
+  readonly rpcCallDuration: Histogram<string>;
+
+  constructor() {
+    this.registry = new Registry();
+    this.registry.setDefaultLabels({ app: 'myfans-backend' });
+
+    this.httpRequestTotal = new Counter({
+      name: 'http_requests_total',
+      help: 'Total HTTP requests',
+      labelNames: ['method', 'route', 'status'],
+      registers: [this.registry],
+    });
+
+    this.httpRequestDuration = new Histogram({
+      name: 'http_request_duration_seconds',
+      help: 'HTTP request latency in seconds',
+      labelNames: ['method', 'route'],
+      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+      registers: [this.registry],
+    });
+
+    this.rpcCallTotal = new Counter({
+      name: 'rpc_calls_total',
+      help: 'Total RPC calls (e.g. Soroban RPC)',
+      labelNames: ['operation', 'status'],
+      registers: [this.registry],
+    });
+
+    this.rpcCallErrors = new Counter({
+      name: 'rpc_call_errors_total',
+      help: 'Total RPC call errors',
+      labelNames: ['operation'],
+      registers: [this.registry],
+    });
+
+    this.rpcCallDuration = new Histogram({
+      name: 'rpc_call_duration_seconds',
+      help: 'RPC call latency in seconds',
+      labelNames: ['operation'],
+      buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+      registers: [this.registry],
+    });
+
+    collectDefaultMetrics({ register: this.registry });
+  }
+
+  recordHttpRequest(
+    method: string,
+    route: string,
+    status: number,
+    durationSeconds: number,
+  ): void {
+    const routeNorm = normalizePath(route);
+    const statusStr = String(status);
+    this.httpRequestTotal.inc({ method, route: routeNorm, status: statusStr });
+    this.httpRequestDuration.observe(
+      { method, route: routeNorm },
+      durationSeconds,
+    );
+  }
+
+  recordRpcCall(
+    operation: string,
+    durationSeconds: number,
+    error: boolean,
+  ): void {
+    const status = error ? 'error' : 'success';
+    this.rpcCallTotal.inc({ operation, status });
+    if (error) {
+      this.rpcCallErrors.inc({ operation });
+    }
+    this.rpcCallDuration.observe({ operation }, durationSeconds);
+  }
+
+  async getMetrics(): Promise<string> {
+    return this.registry.metrics();
+  }
+}

--- a/myfans-backend/src/metrics/rpc-metrics.helper.ts
+++ b/myfans-backend/src/metrics/rpc-metrics.helper.ts
@@ -1,0 +1,32 @@
+import { MetricsService } from './metrics.service';
+
+/**
+ * Wrap an async RPC call and record count, latency, and errors.
+ * Use for Soroban RPC or any external RPC. No PII in operation label.
+ *
+ * @param metrics - MetricsService (inject where RPC is used)
+ * @param operation - Label for the operation (e.g. 'getLedger', 'simulate'). Do not include user/account IDs.
+ */
+export async function withRpcMetrics<T>(
+  metrics: MetricsService,
+  operation: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const start = performance.now();
+  try {
+    const result = await fn();
+    metrics.recordRpcCall(
+      operation,
+      (performance.now() - start) / 1000,
+      false,
+    );
+    return result;
+  } catch (err) {
+    metrics.recordRpcCall(
+      operation,
+      (performance.now() - start) / 1000,
+      true,
+    );
+    throw err;
+  }
+}


### PR DESCRIPTION
## feat(observability): add Prometheus metrics and alerting

### Summary
Add request rate, latency, and error metrics for the API and a place for Soroban RPC metrics. Expose `/metrics` for Prometheus and add alert rules for high error rate and latency.
closes #234 
### Motivation
Improve production observability so we can monitor API health and, when added, RPC usage. Metrics are suitable for dashboards and alerting without exposing PII.

### Changes
- **HTTP metrics:** `MetricsMiddleware` records request count (`http_requests_total`), latency histogram (`http_request_duration_seconds`), and status. Paths are normalized (UUIDs/numeric segments → `_id`) so labels stay free of PII.
- **RPC metrics:** `MetricsService` exposes `rpc_calls_total`, `rpc_call_errors_total`, and `rpc_call_duration_seconds`. Use `withRpcMetrics(metrics, operation, fn)` when adding Soroban or other RPC calls; use generic `operation` names only.
- **Exposure:** `GET /metrics` returns Prometheus text format (plus default Node/process metrics).
- **Alert rules:** `prometheus/alerts.yml` — HighErrorRate (5xx > 5%), HighLatency (p99 > 2s), RpcHighErrorRate (> 10% when RPC metrics are used). Load in Prometheus `rule_files` and wire to Alertmanager as needed.
- **Earnings DTO:** Definite assignment assertions added in `earnings-summary.dto.ts` so the project builds with strict property initialization.

### Acceptance
- [x] Metrics visible: scrape `http://<host>:<PORT>/metrics` and use in a dashboard.
- [x] Alerts fire when thresholds are exceeded (after Prometheus is configured with the rule file).
- [x] No PII in metric labels (method, normalized route, status, operation only).