### PR TITLE
fix(#631): align UserRole imports to src/common/enums

### DIFF
--- a/backend/src/auth-module/decorators/roles.decorator.ts
+++ b/backend/src/auth-module/decorators/roles.decorator.ts
@@ -1,5 +1,5 @@
 import { SetMetadata } from '@nestjs/common';
-import { UserRole } from '../../../common/enums/user-role.enum';
+import { UserRole } from '../../common/enums/user-role.enum';
 
 export const ROLES_KEY = 'roles';
 export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/backend/src/auth-module/dto/register.dto.ts
+++ b/backend/src/auth-module/dto/register.dto.ts
@@ -5,7 +5,7 @@ import {
   IsEnum,
   IsOptional,
 } from 'class-validator';
-import { UserRole } from '../../users/entities/user.entity';
+import { UserRole } from '../../common/enums/user-role.enum';
 
 export class RegisterDto {
   @IsEmail()

--- a/backend/src/auth-module/guards/roles.guard.spec.ts
+++ b/backend/src/auth-module/guards/roles.guard.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RolesGuard } from './roles.guard';
 import { Reflector } from '@nestjs/core';
-import { UserRole } from '../../../common/enums/user-role.enum';
+import { UserRole } from '../../common/enums/user-role.enum';
 import { ExecutionContext } from '@nestjs/common';
 
 describe('RolesGuard', () => {

--- a/backend/src/auth-module/guards/roles.guard.ts
+++ b/backend/src/auth-module/guards/roles.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { UserRole } from '../../../common/enums/user-role.enum';
+import { UserRole } from '../../common/enums/user-role.enum';
 
 @Injectable()
 export class RolesGuard implements CanActivate {


### PR DESCRIPTION
 Summary                                                                        
                                                                                 
  Closes #631  — fixes incorrect import paths for UserRole across auth-module,  
  ensuring all files source from the canonical src/common/enums/user-role.enum.  
                                                                                 
  Changes                                                                        
                                                                                 
  ┌──────┬─────┐                                                                 
  │ File │ Fix │                                                                 
  ├──────┼─────┤                                                                 
                                                 │                               
  ├─────────────────────────────────────────────┼────────────────────────────────
  ───────────────────┤                                                           
  │ `auth-module/decorators/roles.decorator.ts` │ `../../../` →                  
  `../../common/enums/user-role.enum` │                                          
  │  │                                                                           
  `../../common/enums/user-role.enum` │                                          
  │  │                                                                           
  `../../common/enums/user-role.enum` │                                          
  │  │                                                                           
  `../../common/enums/user-role.enum` │                                          
  └─────────────────────────────────────────────┴────────────────────────────────
  ────────────────────────────────────┘                                          
                                                                                 
  Root Cause                                                                     
                                                                                 
  auth-module/decorators/ and auth-module/guards/ are 2 levels deep from src/,   
  not 3 — the ../../../ paths resolved to a non-existent location.               
  register.dto.ts was importing UserRole as a side-effect from the user entity   
  instead of the dedicated enum file.                                            
                                                                                 
  Checklist                                                                      
                                                                                 
  - [ ] tsc --noEmit passes with no path errors                                  
  - [ ] Auth and roles guard tests pass                                          
  - [ ] No regressions in auth/subscription flows                                
                                    