### PR TITLE
feat(logging): redact PII and secrets from logs

### DIFF
--- a/backend/src/common/middleware/logging.middleware.spec.ts
+++ b/backend/src/common/middleware/logging.middleware.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { LoggingMiddleware } from './logging.middleware';
+import { RequestContextService } from '../services/request-context.service';
+import { Request, Response, NextFunction } from 'express';
+import { REDACTED } from '../utils/redact';
+
+describe('LoggingMiddleware', () => {
+  let middleware: LoggingMiddleware;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LoggingMiddleware, RequestContextService],
+    }).compile();
+
+    middleware = module.get<LoggingMiddleware>(LoggingMiddleware);
+    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  function makeReq(overrides: Partial<Request> = {}): Partial<Request> {
+    return {
+      method: 'POST',
+      originalUrl: '/v1/auth/login',
+      ip: '127.0.0.1',
+      headers: {},
+      body: {},
+      ...overrides,
+    };
+  }
+
+  function makeRes(): Partial<Response> {
+    const listeners: Record<string, Array<() => void>> = {};
+    return {
+      statusCode: 200,
+      on: jest.fn((event: string, cb: () => void) => {
+        listeners[event] = listeners[event] ?? [];
+        listeners[event].push(cb);
+      }) as unknown as Response['on'],
+    } as Partial<Response>;
+  }
+
+  it('should be defined', () => {
+    expect(middleware).toBeDefined();
+  });
+
+  it('redacts Authorization header in request log', () => {
+    const req = makeReq({
+      headers: { authorization: 'Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig' },
+    });
+    const res = makeRes();
+    const next: NextFunction = jest.fn();
+
+    middleware.use(req as Request, res as Response, next);
+
+    const [[logged]] = logSpy.mock.calls as [[string]];
+    expect(logged).not.toContain('eyJhbGciOiJIUzI1NiJ9');
+    expect(logged).toContain(REDACTED);
+  });
+
+  it('redacts password in request body', () => {
+    const req = makeReq({
+      body: { password: 'supersecret', username: 'alice' },
+    });
+    const res = makeRes();
+    const next: NextFunction = jest.fn();
+
+    middleware.use(req as Request, res as Response, next);
+
+    const [[logged]] = logSpy.mock.calls as [[string]];
+    expect(logged).not.toContain('supersecret');
+    expect(logged).toContain(REDACTED);
+    expect(logged).toContain('alice');
+  });
+
+  it('redacts token and refresh_token in request body', () => {
+    const req = makeReq({
+      body: { token: 'tok_abc', refresh_token: 'rt_xyz', planId: 1 },
+    });
+    const res = makeRes();
+    const next: NextFunction = jest.fn();
+
+    middleware.use(req as Request, res as Response, next);
+
+    const [[logged]] = logSpy.mock.calls as [[string]];
+    expect(logged).not.toContain('tok_abc');
+    expect(logged).not.toContain('rt_xyz');
+    expect(logged).toContain(REDACTED);
+  });
+
+  it('redacts email in request body', () => {
+    const req = makeReq({ body: { email: 'user@example.com', name: 'Bob' } });
+    const res = makeRes();
+    const next: NextFunction = jest.fn();
+
+    middleware.use(req as Request, res as Response, next);
+
+    const [[logged]] = logSpy.mock.calls as [[string]];
+    expect(logged).not.toContain('user@example.com');
+    expect(logged).toContain(REDACTED);
+    expect(logged).toContain('Bob');
+  });
+
+  it('calls next()', () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next: NextFunction = jest.fn();
+
+    middleware.use(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/backend/src/common/middleware/logging.middleware.ts
+++ b/backend/src/common/middleware/logging.middleware.ts
@@ -1,66 +1,55 @@
 import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import { RequestContextService } from '../services/request-context.service';
+import { redact } from '../utils/redact';
 
 @Injectable()
 export class LoggingMiddleware implements NestMiddleware {
-    private readonly logger = new Logger('HTTP');
+  private readonly logger = new Logger('HTTP');
 
-    constructor(private readonly requestContextService: RequestContextService) {}
+  constructor(private readonly requestContextService: RequestContextService) {}
 
-    private redact(obj: any): any {
-        if (!obj || typeof obj !== 'object') return obj;
-        const redacted = { ...obj };
-        const sensitiveKeys = ['password', 'token', 'refresh_token', 'authorization'];
+  use(req: Request, res: Response, next: NextFunction) {
+    const { method, originalUrl, ip } = req;
+    const body = req.body as Record<string, unknown>;
+    const headers = req.headers as Record<string, unknown>;
+    const startTime = Date.now();
+    const correlationId = String(req.headers['x-correlation-id'] ?? '');
+    const requestId = String(req.headers['x-request-id'] ?? '');
 
-        for (const key of Object.keys(redacted)) {
-            if (sensitiveKeys.includes(key.toLowerCase())) {
-                redacted[key] = '***REDACTED***';
-            } else if (typeof redacted[key] === 'object') {
-                redacted[key] = this.redact(redacted[key]);
-            }
-        }
-        return redacted;
-    }
+    const redactedHeaders = redact(headers);
+    const redactedBody = redact(body);
 
-    use(req: Request, res: Response, next: NextFunction) {
-        const { method, originalUrl, ip, body, headers } = req;
-        const startTime = Date.now();
-        const correlationId = req.headers['x-correlation-id'];
-        const requestId = req.headers['x-request-id'];
+    this.logger.log(
+      `[${correlationId}] [${requestId}] Incoming Request: ${method} ${originalUrl} - IP: ${ip ?? ''} - Headers: ${JSON.stringify(redactedHeaders)} - Body: ${JSON.stringify(redactedBody)}`,
+    );
 
-        const redactedHeaders = this.redact(headers);
-        const redactedBody = this.redact(body);
+    // Set up cleanup on response finish
+    res.on('finish', () => {
+      const { statusCode } = res;
+      const duration = Date.now() - startTime;
+      const user = (req as Request & { user?: { id?: string } }).user;
+      const userId = user?.id ?? 'anonymous';
 
-        this.logger.log(
-            `[${correlationId}] [${requestId}] Incoming Request: ${method} ${originalUrl} - IP: ${ip} - Headers: ${JSON.stringify(redactedHeaders)} - Body: ${JSON.stringify(redactedBody)}`,
-        );
+      const message = `[${correlationId}] [${requestId}] Outgoing Response: ${method} ${originalUrl} - Status: ${statusCode} - Duration: ${duration}ms - User: ${userId}`;
 
-        // Set up cleanup on response finish
-        res.on('finish', () => {
-            const { statusCode } = res;
-            const duration = Date.now() - startTime;
-            const userId = (req as any).user?.id || 'anonymous';
+      if (statusCode >= 500) {
+        this.logger.error(message);
+      } else if (statusCode >= 400) {
+        this.logger.warn(message);
+      } else {
+        this.logger.log(message);
+      }
 
-            const message = `[${correlationId}] [${requestId}] Outgoing Response: ${method} ${originalUrl} - Status: ${statusCode} - Duration: ${duration}ms - User: ${userId}`;
+      // Clean up context after response is sent
+      this.requestContextService.clearContext();
+    });
 
-            if (statusCode >= 500) {
-                this.logger.error(message);
-            } else if (statusCode >= 400) {
-                this.logger.warn(message);
-            } else {
-                this.logger.log(message);
-            }
+    // Also clean up on close (in case connection is interrupted)
+    res.on('close', () => {
+      this.requestContextService.clearContext();
+    });
 
-            // Clean up context after response is sent
-            this.requestContextService.clearContext();
-        });
-
-        // Also clean up on close (in case connection is interrupted)
-        res.on('close', () => {
-            this.requestContextService.clearContext();
-        });
-
-        next();
-    }
+    next();
+  }
 }

--- a/backend/src/common/services/logger.service.ts
+++ b/backend/src/common/services/logger.service.ts
@@ -1,102 +1,127 @@
 import { Injectable, LoggerService as NestLoggerService } from '@nestjs/common';
 import { RequestContextService } from './request-context.service';
+import { redact } from '../utils/redact';
 
 @Injectable()
 export class LoggerService implements NestLoggerService {
-    private logger: NestLoggerService;
+  private logger: NestLoggerService;
 
-    constructor(private readonly requestContextService: RequestContextService) {
-        this.logger = new (class implements NestLoggerService {
-            log(message: any, context?: string) {
-                console.log(`[${context}] ${message}`);
-            }
-            error(message: any, trace?: string, context?: string) {
-                console.error(`[${context}] ${message}`, trace);
-            }
-            warn(message: any, context?: string) {
-                console.warn(`[${context}] ${message}`);
-            }
-            debug(message: any, context?: string) {
-                console.debug(`[${context}] ${message}`);
-            }
-            verbose(message: any, context?: string) {
-                console.log(`[${context}] ${message}`);
-            }
-        })();
+  constructor(private readonly requestContextService: RequestContextService) {
+    this.logger = new (class implements NestLoggerService {
+      log(message: any, context?: string) {
+        console.log(`[${context}] ${message}`);
+      }
+      error(message: any, trace?: string, context?: string) {
+        console.error(`[${context}] ${message}`, trace);
+      }
+      warn(message: any, context?: string) {
+        console.warn(`[${context}] ${message}`);
+      }
+      debug(message: any, context?: string) {
+        console.debug(`[${context}] ${message}`);
+      }
+      verbose(message: any, context?: string) {
+        console.log(`[${context}] ${message}`);
+      }
+    })();
+  }
+
+  private formatMessage(
+    message: any,
+    context?: string,
+  ): { message: any; context: string } {
+    const logContext = this.requestContextService.getLogContext();
+    const contextString = context || 'Application';
+
+    // Add request context to message if available
+    if (Object.keys(logContext).length > 0) {
+      const formattedMessage =
+        typeof message === 'string' ? message : JSON.stringify(message);
+      return {
+        message: `${formattedMessage} [Context: ${JSON.stringify(logContext)}]`,
+        context: contextString,
+      };
     }
 
-    private formatMessage(message: any, context?: string): { message: any; context: string } {
-        const logContext = this.requestContextService.getLogContext();
-        const contextString = context || 'Application';
-        
-        // Add request context to message if available
-        if (Object.keys(logContext).length > 0) {
-            const formattedMessage = typeof message === 'string' ? message : JSON.stringify(message);
-            return {
-                message: `${formattedMessage} [Context: ${JSON.stringify(logContext)}]`,
-                context: contextString
-            };
-        }
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      message,
+      context: contextString,
+    };
+  }
 
-        return {
-            message,
-            context: contextString
-        };
+  log(message: any, context?: string) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const { message: formattedMessage, context: formattedContext } =
+      this.formatMessage(message, context);
+    this.logger.log(formattedMessage, formattedContext);
+  }
+
+  error(message: any, trace?: string, context?: string) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const { message: formattedMessage, context: formattedContext } =
+      this.formatMessage(message, context);
+    this.logger.error(formattedMessage, trace, formattedContext);
+  }
+
+  warn(message: any, context?: string) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const { message: formattedMessage, context: formattedContext } =
+      this.formatMessage(message, context);
+    this.logger.warn(formattedMessage, formattedContext);
+  }
+
+  debug(message: any, context?: string) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const { message: formattedMessage, context: formattedContext } =
+      this.formatMessage(message, context);
+    this.logger?.debug?.(formattedMessage, formattedContext);
+  }
+
+  verbose(message: any, context?: string) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const { message: formattedMessage, context: formattedContext } =
+      this.formatMessage(message, context);
+    this.logger?.verbose?.(formattedMessage, formattedContext);
+  }
+
+  // Method for structured logging
+  logStructured(
+    level: 'info' | 'warn' | 'error' | 'debug',
+    message: string,
+
+    data?: unknown,
+    context?: string,
+  ) {
+    const logContext = this.requestContextService.getLogContext();
+
+    const redactedData = data !== undefined ? redact(data) : undefined;
+    const logEntry = {
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+      context: context || 'Application',
+      ...logContext,
+      ...(redactedData !== undefined && { data: redactedData }),
+    };
+
+    // In production, this would be handled by Winston's JSON format
+    // For now, we'll format it for console output
+
+    const formattedMessage = JSON.stringify(logEntry);
+
+    switch (level) {
+      case 'error':
+        this.logger.error(formattedMessage, '', context);
+        break;
+      case 'warn':
+        this.logger.warn(formattedMessage, context);
+        break;
+      case 'debug':
+        this.logger?.debug?.(formattedMessage, context);
+        break;
+      default:
+        this.logger.log(formattedMessage, context);
     }
-
-    log(message: any, context?: string) {
-        const { message: formattedMessage, context: formattedContext } = this.formatMessage(message, context);
-        this.logger.log(formattedMessage, formattedContext);
-    }
-
-    error(message: any, trace?: string, context?: string) {
-        const { message: formattedMessage, context: formattedContext } = this.formatMessage(message, context);
-        this.logger.error(formattedMessage, trace, formattedContext);
-    }
-
-    warn(message: any, context?: string) {
-        const { message: formattedMessage, context: formattedContext } = this.formatMessage(message, context);
-        this.logger.warn(formattedMessage, formattedContext);
-    }
-
-    debug(message: any, context?: string) {
-        const { message: formattedMessage, context: formattedContext } = this.formatMessage(message, context);
-        this.logger?.debug?.(formattedMessage, formattedContext);
-    }
-
-    verbose(message: any, context?: string) {
-        const { message: formattedMessage, context: formattedContext } = this.formatMessage(message, context);
-        this.logger?.verbose?.(formattedMessage, formattedContext);
-    }
-
-    // Method for structured logging
-    logStructured(level: 'info' | 'warn' | 'error' | 'debug', message: string, data?: any, context?: string) {
-        const logContext = this.requestContextService.getLogContext();
-        const logEntry = {
-            timestamp: new Date().toISOString(),
-            level,
-            message,
-            context: context || 'Application',
-            ...logContext,
-            ...(data && { data })
-        };
-
-        // In production, this would be handled by Winston's JSON format
-        // For now, we'll format it for console output
-        const formattedMessage = JSON.stringify(logEntry);
-        
-        switch (level) {
-            case 'error':
-                this.logger.error(formattedMessage, '', context);
-                break;
-            case 'warn':
-                this.logger.warn(formattedMessage, context);
-                break;
-            case 'debug':
-                this.logger?.debug?.(formattedMessage, context);
-                break;
-            default:
-                this.logger.log(formattedMessage, context);
-        }
-    }
+  }
 }

--- a/backend/src/common/utils/index.ts
+++ b/backend/src/common/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './pagination.util';
+export * from './redact';

--- a/backend/src/common/utils/redact.spec.ts
+++ b/backend/src/common/utils/redact.spec.ts
@@ -1,0 +1,101 @@
+import { redact, REDACTED, SENSITIVE_KEYS } from './redact';
+
+describe('redact', () => {
+  it('returns primitives unchanged', () => {
+    expect(redact('hello')).toBe('hello');
+    expect(redact(42)).toBe(42);
+    expect(redact(true)).toBe(true);
+    expect(redact(null)).toBeNull();
+    expect(redact(undefined)).toBeUndefined();
+  });
+
+  it('redacts known sensitive keys (case-insensitive)', () => {
+    const input: Record<string, string> = {
+      password: 'secret123',
+      token: 'tok_abc',
+      access_token: 'at_xyz',
+      refresh_token: 'rt_xyz',
+      authorization: 'Bearer eyJ...',
+      secret: 'my-secret',
+      private_key: 'SXXXXX',
+      seed: 'word1 word2',
+      email: 'user@example.com',
+      api_key: 'key-123',
+    };
+
+    const result = redact(input);
+
+    for (const key of Object.keys(input)) {
+      expect(result[key]).toBe(REDACTED);
+    }
+  });
+
+  it('preserves non-sensitive fields', () => {
+    const input = { username: 'alice', role: 'fan', planId: 7 };
+    expect(redact(input)).toEqual(input);
+  });
+
+  it('redacts nested sensitive fields', () => {
+    const input = {
+      user: {
+        email: 'user@example.com',
+        profile: {
+          token: 'nested-token',
+          displayName: 'Alice',
+        },
+      },
+    };
+
+    const result = redact(input);
+    expect(result.user.email).toBe(REDACTED);
+    expect(result.user.profile.token).toBe(REDACTED);
+    expect(result.user.profile.displayName).toBe('Alice');
+  });
+
+  it('redacts sensitive fields inside arrays', () => {
+    const input = [
+      { password: 'p1', name: 'a' },
+      { password: 'p2', name: 'b' },
+    ];
+
+    const result = redact(input);
+    expect(result[0].password).toBe(REDACTED);
+    expect(result[0].name).toBe('a');
+    expect(result[1].password).toBe(REDACTED);
+    expect(result[1].name).toBe('b');
+  });
+
+  it('does not mutate the original object', () => {
+    const input = { password: 'original', name: 'alice' };
+    redact(input);
+    expect(input.password).toBe('original');
+  });
+
+  it('redacts Authorization header regardless of casing', () => {
+    const headers: Record<string, string> = {
+      Authorization: 'Bearer token123',
+    };
+    const result = redact(headers);
+    expect(result['Authorization']).toBe(REDACTED);
+  });
+
+  it('redacts wallet-related keys', () => {
+    const input: Record<string, string> = {
+      wallet_address: 'GABC123',
+      stellar_secret: 'SXXX',
+      privatekey: 'raw-key',
+    };
+    const result = redact(input);
+    expect(result['wallet_address']).toBe(REDACTED);
+    expect(result['stellar_secret']).toBe(REDACTED);
+    expect(result['privatekey']).toBe(REDACTED);
+  });
+
+  it('SENSITIVE_KEYS set contains expected entries', () => {
+    expect(SENSITIVE_KEYS.has('password')).toBe(true);
+    expect(SENSITIVE_KEYS.has('authorization')).toBe(true);
+    expect(SENSITIVE_KEYS.has('email')).toBe(true);
+    expect(SENSITIVE_KEYS.has('private_key')).toBe(true);
+    expect(SENSITIVE_KEYS.has('stellar_secret')).toBe(true);
+  });
+});

--- a/backend/src/common/utils/redact.ts
+++ b/backend/src/common/utils/redact.ts
@@ -1,0 +1,50 @@
+/**
+ * Sensitive field names whose values must never appear in logs.
+ * Keys are matched case-insensitively.
+ */
+export const SENSITIVE_KEYS = new Set([
+  'password',
+  'token',
+  'access_token',
+  'refresh_token',
+  'id_token',
+  'authorization',
+  'secret',
+  'private_key',
+  'privatekey',
+  'seed',
+  'mnemonic',
+  'jwt',
+  'api_key',
+  'apikey',
+  'email',
+  'wallet_address',
+  'walletaddress',
+  'stellar_secret',
+  'stellarsecret',
+]);
+
+/** Placeholder substituted for redacted values. */
+export const REDACTED = '[REDACTED]';
+
+/**
+ * Recursively redact sensitive fields from an object or array.
+ * Returns a new value; the original is not mutated.
+ */
+export function redact<T>(value: T): T {
+  if (value === null || value === undefined) return value;
+
+  if (Array.isArray(value)) {
+    return value.map(redact) as unknown as T;
+  }
+
+  if (typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = SENSITIVE_KEYS.has(k.toLowerCase()) ? REDACTED : redact(v);
+    }
+    return result as T;
+  }
+
+  return value;
+}


### PR DESCRIPTION
Implements ISSUES.md item 32 (issue #717).

to close: #717 

What changed:
- Added src/common/utils/redact.ts: shared recursive redaction utility with an explicit SENSITIVE_KEYS set covering passwords, tokens, auth headers, email, private keys, seeds, wallet addresses, and Stellar secrets. Returns a new value; never mutates the original.
- Updated LoggingMiddleware to use the shared redact() helper instead of the previous inline redact() that only covered 4 keys. Now covers all SENSITIVE_KEYS for both request headers and body.
- Updated LoggerService.logStructured() to pass the data argument through redact() before serialising to JSON, ensuring structured log entries never leak sensitive fields.
- Exported redact from src/common/utils/index.ts for reuse.
- Added unit tests (redact.spec.ts, logging.middleware.spec.ts) covering: primitives, sensitive key redaction, nested objects, arrays, immutability, auth headers, wallet keys, and middleware integration (Authorization, password, token, email).

Why:
Logs must never contain full tokens, private keys, or PII (email, wallet address) to comply with security policy and avoid credential leakage in log aggregation systems.

Assumptions:
- Wallet addresses (public keys) are treated as PII per policy; partial addresses already used in subscription-lifecycle-indexer (fan.slice(0,8)) are unaffected.
- The no-unsafe-assignment eslint suppressions in logger.service.ts are confined to the pre-existing any-typed NestLoggerService interface parameters; no new unsafe patterns were introduced.