### PR TITLE
feat(posts): soft delete with audit trail

### DIFF
--- a/backend/src/events/domain-events.ts
+++ b/backend/src/events/domain-events.ts
@@ -65,10 +65,21 @@ export class PlanCreatedEvent {
   ) {}
 }
 
+// Post events
+export class PostDeletedEvent {
+  readonly type = 'post.deleted' as const;
+  constructor(
+    public readonly postId: string,
+    public readonly deletedBy: string,
+    public readonly timestamp: number = Date.now(),
+  ) {}
+}
+
 export type DomainEvent =
   | UserLoggedInEvent
   | SubscriptionCreatedEvent
   | SubscriptionRenewedEvent
   | SubscriptionCancelledEvent
   | SubscriptionExpiredEvent
-  | PlanCreatedEvent;
+  | PlanCreatedEvent
+  | PostDeletedEvent;

--- a/backend/src/posts/dto/post.dto.ts
+++ b/backend/src/posts/dto/post.dto.ts
@@ -37,6 +37,10 @@ export class PostDto {
   @ApiProperty()
   @Expose()
   updatedAt: Date;
+
+  @ApiPropertyOptional({ nullable: true })
+  @Expose()
+  deletedAt: Date | null;
 }
 
 export class CreatePostDto {

--- a/backend/src/posts/entities/post.entity.ts
+++ b/backend/src/posts/entities/post.entity.ts
@@ -4,6 +4,7 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
   OneToMany,
 } from 'typeorm';
 import { Like } from '../../likes/entities/like.entity';
@@ -39,4 +40,12 @@ export class Post {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  /** Soft-delete timestamp. Null when the post is active. */
+  @DeleteDateColumn({ nullable: true })
+  deletedAt: Date | null;
+
+  /** ID of the user who performed the soft delete (audit trail). */
+  @Column({ nullable: true, type: 'varchar' })
+  deletedBy: string | null;
 }

--- a/backend/src/posts/posts.controller.ts
+++ b/backend/src/posts/posts.controller.ts
@@ -23,7 +23,11 @@ export class PostsController {
 
   @Post()
   @ApiOperation({ summary: 'Create a new post' })
-  @ApiResponse({ status: 201, description: 'Post created successfully', type: PostDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Post created successfully',
+    type: PostDto,
+  })
   async create(@Body() dto: CreatePostDto): Promise<PostDto> {
     // TODO: Get author ID from auth token/session
     const authorId = 'temp-author-id';
@@ -33,7 +37,9 @@ export class PostsController {
   @Get()
   @ApiOperation({ summary: 'List all posts (paginated)' })
   @ApiResponse({ status: 200, description: 'Paginated posts list' })
-  async findAll(@Query() pagination: PaginationDto): Promise<PaginatedResponseDto<PostDto>> {
+  async findAll(
+    @Query() pagination: PaginationDto,
+  ): Promise<PaginatedResponseDto<PostDto>> {
     return this.postsService.findAll(pagination);
   }
 
@@ -56,15 +62,25 @@ export class PostsController {
 
   @Put(':id')
   @ApiOperation({ summary: 'Update a post' })
-  @ApiResponse({ status: 200, description: 'Post updated successfully', type: PostDto })
-  async update(@Param('id') id: string, @Body() dto: UpdatePostDto): Promise<PostDto> {
+  @ApiResponse({
+    status: 200,
+    description: 'Post updated successfully',
+    type: PostDto,
+  })
+  async update(
+    @Param('id') id: string,
+    @Body() dto: UpdatePostDto,
+  ): Promise<PostDto> {
     return this.postsService.update(id, dto);
   }
 
   @Delete(':id')
-  @ApiOperation({ summary: 'Delete a post' })
-  @ApiResponse({ status: 204, description: 'Post deleted successfully' })
-  async remove(@Param('id') id: string): Promise<void> {
-    return this.postsService.remove(id);
+  @ApiOperation({ summary: 'Soft-delete a post (sets deletedAt / deletedBy)' })
+  @ApiResponse({ status: 204, description: 'Post soft-deleted successfully' })
+  async remove(
+    @Param('id') id: string,
+    @Query('deletedBy') deletedBy?: string,
+  ): Promise<void> {
+    return this.postsService.softDelete(id, deletedBy ?? 'unknown');
   }
 }

--- a/backend/src/posts/posts.module.ts
+++ b/backend/src/posts/posts.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { PostsController } from './posts.controller';
 import { PostsService } from './posts.service';
 import { Post } from './entities/post.entity';
+import { EventsModule } from '../events/events.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Post])],
+  imports: [TypeOrmModule.forFeature([Post]), EventsModule],
   controllers: [PostsController],
   providers: [PostsService],
   exports: [PostsService],

--- a/backend/src/posts/posts.service.spec.ts
+++ b/backend/src/posts/posts.service.spec.ts
@@ -1,0 +1,178 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { PostsService } from './posts.service';
+import { Post } from './entities/post.entity';
+import { EventBus } from '../events/event-bus';
+import { PostDeletedEvent } from '../events/domain-events';
+
+const makePost = (overrides: Partial<Post> = {}): Post =>
+  ({
+    id: 'post-1',
+    title: 'Hello',
+    content: 'World',
+    authorId: 'author-1',
+    isPublished: false,
+    isPremium: false,
+    likesCount: 0,
+    likes: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    deletedBy: null,
+    ...overrides,
+  }) as Post;
+
+describe('PostsService', () => {
+  let service: PostsService;
+  let repo: {
+    create: jest.Mock;
+    save: jest.Mock;
+    findOne: jest.Mock;
+    findAndCount: jest.Mock;
+    delete: jest.Mock;
+  };
+  let eventBus: { publish: jest.Mock };
+
+  beforeEach(async () => {
+    repo = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+      findAndCount: jest.fn(),
+      delete: jest.fn(),
+    };
+    eventBus = { publish: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PostsService,
+        { provide: getRepositoryToken(Post), useValue: repo },
+        { provide: EventBus, useValue: eventBus },
+      ],
+    }).compile();
+
+    service = module.get(PostsService);
+  });
+
+  describe('findAll', () => {
+    it('excludes soft-deleted posts', async () => {
+      const active = makePost();
+      repo.findAndCount.mockResolvedValue([[active], 1]);
+
+      const result = await service.findAll({ page: 1, limit: 20 });
+
+      expect(result.total).toBe(1);
+      // Verify the query filters by deletedAt: IsNull()
+      const [options] = repo.findAndCount.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ];
+      expect(Object.keys(options.where)).toContain('deletedAt');
+    });
+  });
+
+  describe('findByAuthor', () => {
+    it('excludes soft-deleted posts for the author', async () => {
+      repo.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findByAuthor('author-1', { page: 1, limit: 20 });
+
+      const [options] = repo.findAndCount.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ];
+      expect(options.where).toHaveProperty('authorId', 'author-1');
+      expect(Object.keys(options.where)).toContain('deletedAt');
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns the post when active', async () => {
+      const post = makePost();
+      repo.findOne.mockResolvedValue(post);
+
+      const result = await service.findOne('post-1');
+
+      expect(result.id).toBe('post-1');
+    });
+
+    it('throws NotFoundException for a soft-deleted post', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('post-1')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('softDelete', () => {
+    it('sets deletedAt and deletedBy then saves', async () => {
+      const post = makePost();
+      repo.findOne.mockResolvedValue(post);
+      repo.save.mockResolvedValue({
+        ...post,
+        deletedAt: new Date(),
+        deletedBy: 'user-99',
+      });
+
+      await service.softDelete('post-1', 'user-99');
+
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ deletedBy: 'user-99' }),
+      );
+      expect(post.deletedAt).not.toBeNull();
+    });
+
+    it('emits PostDeletedEvent with correct postId and deletedBy', async () => {
+      const post = makePost();
+      repo.findOne.mockResolvedValue(post);
+      repo.save.mockResolvedValue(post);
+
+      await service.softDelete('post-1', 'user-99');
+
+      expect(eventBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'post.deleted',
+          postId: 'post-1',
+          deletedBy: 'user-99',
+        }),
+      );
+    });
+
+    it('throws NotFoundException when post does not exist', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.softDelete('missing', 'user-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(eventBus.publish).not.toHaveBeenCalled();
+    });
+
+    it('does not emit event when post is already soft-deleted (not found)', async () => {
+      repo.findOne.mockResolvedValue(null); // filtered out by IsNull()
+
+      await expect(
+        service.softDelete('post-1', 'user-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(eventBus.publish).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    it('throws NotFoundException for a soft-deleted post', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.update('post-1', { title: 'New' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('PostDeletedEvent', () => {
+    it('has the correct type discriminant', () => {
+      const event = new PostDeletedEvent('p1', 'u1');
+      expect(event.type).toBe('post.deleted');
+      expect(event.postId).toBe('p1');
+      expect(event.deletedBy).toBe('u1');
+    });
+  });
+});

--- a/backend/src/posts/posts.service.ts
+++ b/backend/src/posts/posts.service.ts
@@ -1,16 +1,19 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { plainToInstance } from 'class-transformer';
 import { Post } from './entities/post.entity';
 import { CreatePostDto, PostDto, UpdatePostDto } from './dto';
 import { PaginationDto, PaginatedResponseDto } from '../common/dto';
+import { EventBus } from '../events/event-bus';
+import { PostDeletedEvent } from '../events/domain-events';
 
 @Injectable()
 export class PostsService {
   constructor(
     @InjectRepository(Post)
     private readonly postRepo: Repository<Post>,
+    private readonly eventBus: EventBus,
   ) {}
 
   private toDto(post: Post): PostDto {
@@ -35,6 +38,7 @@ export class PostsService {
     const page = pagination.page ?? 1;
     const limit = pagination.limit ?? 20;
     const [items, total] = await this.postRepo.findAndCount({
+      where: { deletedAt: IsNull() },
       order: { createdAt: 'DESC' },
       skip: (page - 1) * limit,
       take: limit,
@@ -54,7 +58,7 @@ export class PostsService {
     const page = pagination.page ?? 1;
     const limit = pagination.limit ?? 20;
     const [items, total] = await this.postRepo.findAndCount({
-      where: { authorId },
+      where: { authorId, deletedAt: IsNull() },
       order: { createdAt: 'DESC' },
       skip: (page - 1) * limit,
       take: limit,
@@ -68,7 +72,9 @@ export class PostsService {
   }
 
   async findOne(id: string): Promise<PostDto> {
-    const post = await this.postRepo.findOne({ where: { id } });
+    const post = await this.postRepo.findOne({
+      where: { id, deletedAt: IsNull() },
+    });
     if (!post) {
       throw new NotFoundException(`Post with ID ${id} not found`);
     }
@@ -76,7 +82,9 @@ export class PostsService {
   }
 
   async update(id: string, dto: UpdatePostDto): Promise<PostDto> {
-    const post = await this.postRepo.findOne({ where: { id } });
+    const post = await this.postRepo.findOne({
+      where: { id, deletedAt: IsNull() },
+    });
     if (!post) {
       throw new NotFoundException(`Post with ID ${id} not found`);
     }
@@ -85,6 +93,24 @@ export class PostsService {
     return this.toDto(saved);
   }
 
+  /**
+   * Soft-delete a post: sets deletedAt and deletedBy, then emits a
+   * PostDeletedEvent for the audit trail.
+   */
+  async softDelete(id: string, deletedBy: string): Promise<void> {
+    const post = await this.postRepo.findOne({
+      where: { id, deletedAt: IsNull() },
+    });
+    if (!post) {
+      throw new NotFoundException(`Post with ID ${id} not found`);
+    }
+    post.deletedAt = new Date();
+    post.deletedBy = deletedBy;
+    await this.postRepo.save(post);
+    this.eventBus.publish(new PostDeletedEvent(id, deletedBy));
+  }
+
+  /** @deprecated Use softDelete instead. Hard-deletes the post. */
   async remove(id: string): Promise<void> {
     const res = await this.postRepo.delete(id);
     if (!res.affected) {


### PR DESCRIPTION
Implements ISSUES.md item 13 (issue #732).

to close: #732 

What changed:
- Post entity: added @DeleteDateColumn deletedAt (nullable) and @Column deletedBy (nullable varchar) for the audit trail.
- PostsService:
  - findAll / findByAuthor / findOne / update: filter by deletedAt: IsNull() so soft-deleted posts are excluded from all default reads.
  - softDelete(id, deletedBy): sets deletedAt + deletedBy, saves, then publishes PostDeletedEvent for the audit trail.
  - remove(): kept as hard-delete for internal/admin use; marked @deprecated in JSDoc.
- PostsController: DELETE :id now calls softDelete; accepts optional ?deletedBy query param (defaults to 'unknown' until auth is wired).
- PostDto: exposes deletedAt field.
- PostsModule: imports EventsModule so EventBus is available.
- domain-events.ts: added PostDeletedEvent (type 'post.deleted') and included it in the DomainEvent union.
- posts.service.spec.ts: 10 unit tests covering findAll/findByAuthor filter behaviour, findOne 404 on deleted, softDelete happy path, event emission, NotFoundException on missing/already-deleted post, update 404 on deleted, and PostDeletedEvent shape.

Why:
Soft delete preserves post data for moderation and audit purposes while hiding deleted posts from all public-facing list and detail endpoints. The PostDeletedEvent enables downstream consumers (indexers, notifications) to react to deletions without polling.

Assumptions:
- deletedBy is populated from the ?deletedBy query param for now; once auth middleware is wired to the controller the value should come from the JWT subject instead.
- No database migration file is added here; TypeORM synchronize or a separate migration run will add the two new columns.