### PR TITLE
update vulnerability audit counts and add CI checks

### DIFF
--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -1,0 +1,102 @@
+name: 🔐 Audit & Vulnerability Check
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+  schedule:
+    - cron: "0 0 * * 0"  # Weekly on Sunday
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    name: Check Dependencies & Audits
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: 📦 Check backend audits
+        id: backend-audit
+        working-directory: ./backend
+        run: |
+          npm install --prefer-offline --no-audit 2>&1 | head -20
+          AUDIT_JSON=$(npm audit --json 2>/dev/null || echo '{"metadata":{"vulnerabilities":{"critical":0,"high":0,"moderate":0}}}')
+          
+          CRITICAL=$(echo "$AUDIT_JSON" | jq '.metadata.vulnerabilities.critical // 0')
+          HIGH=$(echo "$AUDIT_JSON" | jq '.metadata.vulnerabilities.high // 0')
+          MODERATE=$(echo "$AUDIT_JSON" | jq '.metadata.vulnerabilities.moderate // 0')
+          
+          echo "backend_critical=$CRITICAL" >> $GITHUB_OUTPUT
+          echo "backend_high=$HIGH" >> $GITHUB_OUTPUT
+          echo "backend_moderate=$MODERATE" >> $GITHUB_OUTPUT
+          
+          echo "### 🔍 Backend Audit Results" >> $GITHUB_STEP_SUMMARY
+          echo "| Severity | Count |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Critical | $CRITICAL |" >> $GITHUB_STEP_SUMMARY
+          echo "| High | $HIGH |" >> $GITHUB_STEP_SUMMARY
+          echo "| Moderate | $MODERATE |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if (( CRITICAL > 0 )); then
+            echo "❌ **CRITICAL vulnerabilities detected**" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Critical vulnerabilities in backend: $CRITICAL"
+            exit 1
+          fi
+
+      - name: 📦 Check frontend audits
+        id: frontend-audit
+        working-directory: ./frontend
+        run: |
+          npm install --prefer-offline --no-audit 2>&1 | head -20
+          AUDIT_JSON=$(npm audit --json 2>/dev/null || echo '{"metadata":{"vulnerabilities":{"critical":0,"high":0,"moderate":0}}}')
+          
+          CRITICAL=$(echo "$AUDIT_JSON" | jq '.metadata.vulnerabilities.critical // 0')
+          HIGH=$(echo "$AUDIT_JSON" | jq '.metadata.vulnerabilities.high // 0')
+          MODERATE=$(echo "$AUDIT_JSON" | jq '.metadata.vulnerabilities.moderate // 0')
+          
+          echo "frontend_critical=$CRITICAL" >> $GITHUB_OUTPUT
+          echo "frontend_high=$HIGH" >> $GITHUB_OUTPUT
+          echo "frontend_moderate=$MODERATE" >> $GITHUB_OUTPUT
+          
+          echo "### 🔍 Frontend Audit Results" >> $GITHUB_STEP_SUMMARY
+          echo "| Severity | Count |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Critical | $CRITICAL |" >> $GITHUB_STEP_SUMMARY
+          echo "| High | $HIGH |" >> $GITHUB_STEP_SUMMARY
+          echo "| Moderate | $MODERATE |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if (( CRITICAL > 0 )); then
+            echo "❌ **CRITICAL vulnerabilities detected**" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Critical vulnerabilities in frontend: $CRITICAL"
+            exit 1
+          fi
+
+      - name: 📝 Comment on PR with audit summary
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: >-
+            const backendCritical = '${{ steps.backend-audit.outputs.backend_critical }}' || '0';
+            const backendHigh = '${{ steps.backend-audit.outputs.backend_high }}' || '0';
+            const frontendCritical = '${{ steps.frontend-audit.outputs.frontend_critical }}' || '0';
+            const frontendHigh = '${{ steps.frontend-audit.outputs.frontend_high }}' || '0';
+            const comment = '## 🔐 Security Audit Summary\n\n**Backend:**\n- 🔴 Critical: ' + backendCritical + '\n- 🟠 High: ' + backendHigh + '\n\n**Frontend:**\n- 🔴 Critical: ' + frontendCritical + '\n- 🟠 High: ' + frontendHigh + '\n\nRun locally with: `./scripts/check-audits.sh`';
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });

--- a/SETUP_STATUS.md
+++ b/SETUP_STATUS.md
@@ -8,7 +8,11 @@
 
 2. **Backend Dependencies** - Installed successfully (809 packages)
    - Minor warnings about deprecated packages (non-critical)
-   - 6 moderate vulnerabilities (run `npm audit fix` if needed)
+   - **Vulnerabilities** (Last updated: 2026-04-22 via `npm audit`):
+     - 🔴 **1 Critical**
+     - 🟠 **5 High**
+     - 🟡 **9 Moderate**
+     - Total: **15 vulnerabilities** (tracked in PR validation)
 
 3. **Environment Files** - Created
    - `frontend/.env.local` ✅
@@ -108,10 +112,25 @@ npm run dev
 
 ## 📚 Documentation
 
+- **README.md** - Project overview & roadmap
 - **QUICKSTART.md** - Detailed setup guide
+- **docs/adr/** - Architecture Decision Records (including backend strategy)
 - **DEPLOYMENT.md** - Production deployment
 - **INTEGRATION.md** - Technical integration details
-- **README.md** - Project overview
+
+## 🔐 Security & Audits
+
+Vulnerability checks are automated in CI via `npm audit`. Current audit status:
+- **Backend**: See above
+- **Frontend**: Check with `cd frontend && npm audit`
+- **Contract**: Checked via `cargo audit` (if Rust installed)
+
+To run audits locally:
+```bash
+./scripts/check-audits.sh
+```
+
+GitHub Actions auto-runs audit checks on every PR and weekly. **Critical vulnerabilities** will fail the build.
 
 ## 🆘 Need Help?
 

--- a/scripts/check-audits.sh
+++ b/scripts/check-audits.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configurable thresholds
+CRITICAL_THRESHOLD=0
+HIGH_THRESHOLD=5
+MODERATE_THRESHOLD=10
+WARN_THRESHOLD=10
+
+echo -e "${BLUE}🔍 Running npm audit checks...${NC}"
+
+# Track overall status
+FAILED=0
+declare -A AUDIT_RESULTS
+
+# Check backend
+if [ -d "$REPO_ROOT/backend" ]; then
+  echo -e "\n${YELLOW}Checking backend/ audits...${NC}"
+  cd "$REPO_ROOT/backend"
+
+  AUDIT_OUTPUT=$(npm audit --json 2>/dev/null || true)
+  CRITICAL=$(echo "$AUDIT_OUTPUT" | jq '.metadata.vulnerabilities.critical // 0')
+  HIGH=$(echo "$AUDIT_OUTPUT" | jq '.metadata.vulnerabilities.high // 0')
+  MODERATE=$(echo "$AUDIT_OUTPUT" | jq '.metadata.vulnerabilities.moderate // 0')
+  LOW=$(echo "$AUDIT_OUTPUT" | jq '.metadata.vulnerabilities.low // 0')
+
+  echo "Backend audit results (npm):"
+  echo "  Critical:  $CRITICAL"
+  echo "  High:      $HIGH"
+  echo "  Moderate:  $MODERATE"
+  echo "  Low:       $LOW"
+
+  AUDIT_RESULTS["backend_critical"]=$CRITICAL
+  AUDIT_RESULTS["backend_high"]=$HIGH
+  AUDIT_RESULTS["backend_moderate"]=$MODERATE
+
+  if (( CRITICAL > CRITICAL_THRESHOLD )); then
+    echo -e "${RED}❌ CRITICAL: $CRITICAL vulnerabilities exceed threshold of $CRITICAL_THRESHOLD${NC}"
+    FAILED=1
+  fi
+
+  if (( HIGH > HIGH_THRESHOLD )); then
+    echo -e "${YELLOW}⚠️  HIGH: $HIGH vulnerabilities exceed threshold of $HIGH_THRESHOLD${NC}"
+  fi
+
+  if (( MODERATE > MODERATE_THRESHOLD )); then
+    echo -e "${YELLOW}⚠️  MODERATE: $MODERATE vulnerabilities exceed threshold of $MODERATE_THRESHOLD${NC}"
+  fi
+fi
+
+# Check frontend
+if [ -d "$REPO_ROOT/frontend" ]; then
+  echo -e "\n${YELLOW}Checking frontend/ audits...${NC}"
+  cd "$REPO_ROOT/frontend"
+
+  AUDIT_OUTPUT=$(npm audit --json 2>/dev/null || true)
+  CRITICAL=$(echo "$AUDIT_OUTPUT" | jq '.metadata.vulnerabilities.critical // 0')
+  HIGH=$(echo "$AUDIT_OUTPUT" | jq '.metadata.vulnerabilities.high // 0')
+  MODERATE=$(echo "$AUDIT_OUTPUT" | jq '.metadata.vulnerabilities.moderate // 0')
+  LOW=$(echo "$AUDIT_OUTPUT" | jq '.metadata.vulnerabilities.low // 0')
+
+  echo "Frontend audit results (npm):"
+  echo "  Critical:  $CRITICAL"
+  echo "  High:      $HIGH"
+  echo "  Moderate:  $MODERATE"
+  echo "  Low:       $LOW"
+
+  AUDIT_RESULTS["frontend_critical"]=$CRITICAL
+  AUDIT_RESULTS["frontend_high"]=$HIGH
+  AUDIT_RESULTS["frontend_moderate"]=$MODERATE
+
+  if (( CRITICAL > CRITICAL_THRESHOLD )); then
+    echo -e "${RED}❌ CRITICAL: $CRITICAL vulnerabilities exceed threshold of $CRITICAL_THRESHOLD${NC}"
+    FAILED=1
+  fi
+
+  if (( HIGH > HIGH_THRESHOLD )); then
+    echo -e "${YELLOW}⚠️  HIGH: $HIGH vulnerabilities exceed threshold of $HIGH_THRESHOLD${NC}"
+  fi
+fi
+
+# Check contract (Rust/Cargo if applicable)
+if [ -d "$REPO_ROOT/contract" ] && command -v cargo &> /dev/null; then
+  echo -e "\n${YELLOW}Checking contract/ audits (Cargo)...${NC}"
+  cd "$REPO_ROOT/contract"
+
+  if [ -f "Cargo.toml" ]; then
+    # Try to run cargo audit if installed
+    if command -v cargo-audit &> /dev/null || cargo install cargo-audit 2>/dev/null; then
+      CARGO_AUDIT=$(cargo audit --json 2>/dev/null || echo '{"vulnerabilities":[]}')
+      CARGO_VULNS=$(echo "$CARGO_AUDIT" | jq '.vulnerabilities | length' 2>/dev/null || echo "0")
+
+      echo "Contract audit results (Cargo):"
+      echo "  Vulnerabilities found: $CARGO_VULNS"
+
+      AUDIT_RESULTS["contract_vulnerabilities"]=$CARGO_VULNS
+
+      if (( CARGO_VULNS > 0 )); then
+        echo -e "${YELLOW}⚠️  CARGO: Found $CARGO_VULNS Cargo vulnerabilities${NC}"
+        echo "$CARGO_AUDIT" | jq '.vulnerabilities[] | {advisory, versions}' 2>/dev/null || true
+      fi
+    fi
+  fi
+fi
+
+# Print summary
+echo -e "\n${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BLUE}📊 Audit Summary${NC}"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+for key in "${!AUDIT_RESULTS[@]}"; do
+  echo "${key}: ${AUDIT_RESULTS[$key]}"
+done
+
+if [ $FAILED -eq 1 ]; then
+  echo -e "\n${RED}❌ Audit check FAILED - Critical vulnerabilities detected${NC}"
+  exit 1
+else
+  echo -e "\n${GREEN}✅ Audit check PASSED${NC}"
+  exit 0
+fi


### PR DESCRIPTION
this pr closes #753 
this pr closes #751 
this pr closes #754 
- Update SETUP_STATUS.md with accurate npm audit results (1 critical, 5 high, 9 moderate)
- Add timestamp to vulnerability counts for traceability
- Create .github/workflows/audit-check.yml for automated CI audits
- Add scripts/check-audits.sh for local audit verification
- CI fails on critical vulnerabilities, warns on high/moderate
- Prevent stale vulnerability documentation in future