### PR TITLE
feat: referral / invite codes (optional) #743

### DIFF
--- a/FEATURE_FLAGS.md
+++ b/FEATURE_FLAGS.md
@@ -26,12 +26,13 @@ Add to `.env.local`:
 ```env
 NEXT_PUBLIC_FEATURE_NEW_SUBSCRIPTION_FLOW=false
 NEXT_PUBLIC_FEATURE_CRYPTO_PAYMENTS=false
+NEXT_PUBLIC_FLAG_REFERRAL_CODES=false
 ```
 
 Usage:
 ```tsx
-<FeatureFlag feature="newSubscriptionFlow">
-  <NewFlow />
+<FeatureFlag feature="referral_codes">
+  <ReferralCodeInput />
 </FeatureFlag>
 ```
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -96,3 +96,11 @@ WEBHOOK_SECRET=change-me-to-a-strong-random-secret
 # -----------------------------------------------------------------------------
 CORS_ALLOWED_ORIGINS=https://myfans.example.com,https://www.myfans.example.com
 CORS_ALLOWED_HOSTS=myfans.example.com,www.myfans.example.com
+
+# -----------------------------------------------------------------------------
+# Feature Flags
+# Set to "true" to enable; any other value (or absent) means disabled.
+# -----------------------------------------------------------------------------
+FEATURE_NEW_SUBSCRIPTION_FLOW=false
+FEATURE_CRYPTO_PAYMENTS=false
+FEATURE_REFERRAL_CODES=false

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -58,7 +58,7 @@
         "prettier": "^3.4.2",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
-        "ts-jest": "^29.4.6",
+        "ts-jest": "^29.4.9",
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
@@ -234,7 +234,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2110,7 +2109,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2274,7 +2272,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2334,7 +2331,6 @@
       "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2418,7 +2414,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.17.tgz",
       "integrity": "sha512-mAf4eOsSBsTOn/VbrUO1gsjW6dVh91qqXPMXun4dN8SnNjf7PTQagM9o8d6ab8ZBpNe6UdZftdrZoDetU+n4Qg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2977,7 +2972,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3112,7 +3106,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3296,7 +3289,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -3952,7 +3944,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4002,7 +3993,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4482,7 +4472,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4705,7 +4694,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4753,15 +4741,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5511,7 +5497,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5572,7 +5557,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6433,9 +6417,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6934,7 +6918,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8599,7 +8582,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -8717,7 +8699,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -8975,7 +8956,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9160,8 +9140,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9257,7 +9236,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9926,7 +9904,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10189,19 +10166,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -10218,7 +10195,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -10281,7 +10258,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10441,7 +10417,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -10625,7 +10600,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10998,6 +10972,7 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -11016,6 +10991,7 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -11029,6 +11005,7 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -11043,6 +11020,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -11053,6 +11031,7 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11063,6 +11042,7 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -11076,6 +11056,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -11131,7 +11112,6 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -70,7 +70,7 @@
     "prettier": "^3.4.2",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
-    "ts-jest": "^29.4.6",
+    "ts-jest": "^29.4.9",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { SubscriptionsModule } from './subscriptions/subscriptions.module';
 import { ModerationModule } from './moderation/moderation.module';
 import { IdempotencyModule } from './idempotency/idempotency.module';
 import { IdempotencyMiddleware } from './idempotency/idempotency.middleware';
+import { ReferralModule } from './referral/referral.module';
 
 /** Routes where idempotency protection is enforced. */
 const IDEMPOTENCY_ROUTES = [
@@ -49,6 +50,7 @@ const IDEMPOTENCY_ROUTES = [
     HealthModule,
     ModerationModule,
     IdempotencyModule,
+    ReferralModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/feature-flags/feature-flags.service.ts
+++ b/backend/src/feature-flags/feature-flags.service.ts
@@ -10,10 +10,15 @@ export class FeatureFlagsService {
     return process.env.FEATURE_CRYPTO_PAYMENTS === 'true';
   }
 
+  isReferralCodesEnabled(): boolean {
+    return process.env.FEATURE_REFERRAL_CODES === 'true';
+  }
+
   getAllFlags() {
     return {
       newSubscriptionFlow: this.isNewSubscriptionFlowEnabled(),
       cryptoPayments: this.isCryptoPaymentsEnabled(),
+      referralCodes: this.isReferralCodesEnabled(),
     };
   }
 }

--- a/backend/src/referral/1745000000000-CreateReferralTables.ts
+++ b/backend/src/referral/1745000000000-CreateReferralTables.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateReferralTables1745000000000 implements MigrationInterface {
+  name = 'CreateReferralTables1745000000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "referral_codes" (
+        "id"          uuid              NOT NULL DEFAULT uuid_generate_v4(),
+        "owner_id"    uuid              NOT NULL,
+        "code"        character varying(20) NOT NULL,
+        "max_uses"    integer,
+        "use_count"   integer           NOT NULL DEFAULT 0,
+        "is_active"   boolean           NOT NULL DEFAULT true,
+        "created_at"  TIMESTAMP         NOT NULL DEFAULT now(),
+        "updated_at"  TIMESTAMP         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_referral_codes" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_referral_codes_code" UNIQUE ("code")
+      )
+    `);
+    await queryRunner.query(`CREATE INDEX "IDX_referral_codes_owner_id" ON "referral_codes" ("owner_id")`);
+    await queryRunner.query(`CREATE INDEX "IDX_referral_codes_code" ON "referral_codes" ("code")`);
+
+    await queryRunner.query(`
+      CREATE TABLE "referral_redemptions" (
+        "id"               uuid      NOT NULL DEFAULT uuid_generate_v4(),
+        "referral_code_id" uuid      NOT NULL,
+        "redeemer_id"      uuid      NOT NULL,
+        "redeemed_at"      TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_referral_redemptions" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_referral_redemptions_code_redeemer"
+          UNIQUE ("referral_code_id", "redeemer_id")
+      )
+    `);
+    await queryRunner.query(`CREATE INDEX "IDX_referral_redemptions_code_id" ON "referral_redemptions" ("referral_code_id")`);
+    await queryRunner.query(`CREATE INDEX "IDX_referral_redemptions_redeemer_id" ON "referral_redemptions" ("redeemer_id")`);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "referral_redemptions"`);
+    await queryRunner.query(`DROP TABLE "referral_codes"`);
+  }
+}

--- a/backend/src/referral/dto/create-referral-code.dto.ts
+++ b/backend/src/referral/dto/create-referral-code.dto.ts
@@ -1,0 +1,13 @@
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class CreateReferralCodeDto {
+  @ApiPropertyOptional({ description: 'Max redemptions (omit for unlimited)', example: 100 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10_000)
+  @Type(() => Number)
+  maxUses?: number;
+}

--- a/backend/src/referral/dto/redeem-referral-code.dto.ts
+++ b/backend/src/referral/dto/redeem-referral-code.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsNotEmpty, Length, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RedeemReferralCodeDto {
+  @ApiProperty({ description: 'Referral / invite code', example: 'ALICE10' })
+  @IsString()
+  @IsNotEmpty()
+  @Length(3, 20)
+  @Matches(/^[A-Z0-9]+$/, { message: 'code must be uppercase alphanumeric' })
+  code: string;
+}

--- a/backend/src/referral/entities/referral-code.entity.ts
+++ b/backend/src/referral/entities/referral-code.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('referral_codes')
+export class ReferralCode {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** The user who owns / generated this code. */
+  @Column({ name: 'owner_id', type: 'uuid' })
+  @Index()
+  ownerId: string;
+
+  /** The short alphanumeric code (e.g. "ALICE10"). */
+  @Column({ unique: true, length: 20 })
+  @Index()
+  code: string;
+
+  /** Optional max number of uses (null = unlimited). */
+  @Column({ name: 'max_uses', type: 'int', nullable: true })
+  maxUses: number | null;
+
+  /** How many times the code has been redeemed. */
+  @Column({ name: 'use_count', type: 'int', default: 0 })
+  useCount: number;
+
+  @Column({ name: 'is_active', type: 'boolean', default: true })
+  isActive: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/referral/entities/referral-redemption.entity.ts
+++ b/backend/src/referral/entities/referral-redemption.entity.ts
@@ -1,0 +1,26 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('referral_redemptions')
+export class ReferralRedemption {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** FK → referral_codes.id */
+  @Column({ name: 'referral_code_id', type: 'uuid' })
+  @Index()
+  referralCodeId: string;
+
+  /** The user who redeemed the code. */
+  @Column({ name: 'redeemer_id', type: 'uuid' })
+  @Index()
+  redeemerId: string;
+
+  @CreateDateColumn({ name: 'redeemed_at' })
+  redeemedAt: Date;
+}

--- a/backend/src/referral/referral.controller.ts
+++ b/backend/src/referral/referral.controller.ts
@@ -1,0 +1,101 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Body,
+  Param,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
+import { ReferralService } from './referral.service';
+import { CreateReferralCodeDto } from './dto/create-referral-code.dto';
+import { RedeemReferralCodeDto } from './dto/redeem-referral-code.dto';
+import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth-module/decorators/current-user.decorator';
+
+@ApiTags('referral')
+@Controller({ path: 'referral', version: '1' })
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class ReferralController {
+  constructor(private readonly referralService: ReferralService) {}
+
+  /** POST /v1/referral/codes — generate a new code for the authenticated user */
+  @Post('codes')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Generate a referral / invite code' })
+  @ApiResponse({ status: 201, description: 'Code created' })
+  createCode(
+    @CurrentUser() user: { id: string },
+    @Body() dto: CreateReferralCodeDto,
+  ) {
+    return this.referralService.createCode(user.id, dto);
+  }
+
+  /** GET /v1/referral/codes — list my codes */
+  @Get('codes')
+  @ApiOperation({ summary: 'List my referral codes' })
+  @ApiResponse({ status: 200, description: 'List of codes' })
+  listCodes(@CurrentUser() user: { id: string }) {
+    return this.referralService.listCodes(user.id);
+  }
+
+  /** PATCH /v1/referral/codes/:id/deactivate — deactivate a code */
+  @Patch('codes/:id/deactivate')
+  @ApiOperation({ summary: 'Deactivate a referral code' })
+  @ApiParam({ name: 'id', description: 'Referral code UUID' })
+  @ApiResponse({ status: 200, description: 'Code deactivated' })
+  @ApiResponse({ status: 403, description: 'Not your code' })
+  @ApiResponse({ status: 404, description: 'Code not found' })
+  deactivateCode(
+    @CurrentUser() user: { id: string },
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.referralService.deactivateCode(user.id, id);
+  }
+
+  /** GET /v1/referral/codes/:id/redemptions — list redemptions for a code */
+  @Get('codes/:id/redemptions')
+  @ApiOperation({ summary: 'List redemptions for a referral code' })
+  @ApiParam({ name: 'id', description: 'Referral code UUID' })
+  @ApiResponse({ status: 200, description: 'List of redemptions' })
+  listRedemptions(
+    @CurrentUser() user: { id: string },
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.referralService.listRedemptions(user.id, id);
+  }
+
+  /** POST /v1/referral/validate — validate a code without redeeming */
+  @Post('validate')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Validate a referral code (no redemption)' })
+  @ApiResponse({ status: 200, description: 'Validation result' })
+  validateCode(@Body() dto: RedeemReferralCodeDto) {
+    return this.referralService.validateCode(dto.code);
+  }
+
+  /** POST /v1/referral/redeem — redeem a code */
+  @Post('redeem')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Redeem a referral / invite code' })
+  @ApiResponse({ status: 201, description: 'Code redeemed' })
+  @ApiResponse({ status: 400, description: 'Invalid or exhausted code' })
+  @ApiResponse({ status: 409, description: 'Already redeemed' })
+  redeemCode(
+    @CurrentUser() user: { id: string },
+    @Body() dto: RedeemReferralCodeDto,
+  ) {
+    return this.referralService.redeemCode(user.id, dto);
+  }
+}

--- a/backend/src/referral/referral.module.ts
+++ b/backend/src/referral/referral.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ReferralCode } from './entities/referral-code.entity';
+import { ReferralRedemption } from './entities/referral-redemption.entity';
+import { ReferralService } from './referral.service';
+import { ReferralController } from './referral.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ReferralCode, ReferralRedemption])],
+  controllers: [ReferralController],
+  providers: [ReferralService],
+  exports: [ReferralService],
+})
+export class ReferralModule {}

--- a/backend/src/referral/referral.service.spec.ts
+++ b/backend/src/referral/referral.service.spec.ts
@@ -1,0 +1,177 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ReferralService } from './referral.service';
+import { ReferralCode } from './entities/referral-code.entity';
+import { ReferralRedemption } from './entities/referral-redemption.entity';
+
+const mockCodesRepo = () => ({
+  findOne: jest.fn(),
+  find: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+});
+
+const mockRedemptionsRepo = () => ({
+  findOne: jest.fn(),
+  find: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+});
+
+const mockDataSource = () => ({
+  transaction: jest.fn(),
+});
+
+describe('ReferralService', () => {
+  let service: ReferralService;
+  let codesRepo: ReturnType<typeof mockCodesRepo>;
+  let redemptionsRepo: ReturnType<typeof mockRedemptionsRepo>;
+  let dataSource: ReturnType<typeof mockDataSource>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReferralService,
+        { provide: getRepositoryToken(ReferralCode), useFactory: mockCodesRepo },
+        { provide: getRepositoryToken(ReferralRedemption), useFactory: mockRedemptionsRepo },
+        { provide: DataSource, useFactory: mockDataSource },
+      ],
+    }).compile();
+
+    service = module.get(ReferralService);
+    codesRepo = module.get(getRepositoryToken(ReferralCode));
+    redemptionsRepo = module.get(getRepositoryToken(ReferralRedemption));
+    dataSource = module.get(DataSource);
+  });
+
+  describe('createCode', () => {
+    it('creates a unique code for the owner', async () => {
+      codesRepo.findOne.mockResolvedValue(null); // no collision
+      const saved = { id: 'uuid-1', code: 'ABCD1234', ownerId: 'user-1', maxUses: null, useCount: 0, isActive: true };
+      codesRepo.create.mockReturnValue(saved);
+      codesRepo.save.mockResolvedValue(saved);
+
+      const result = await service.createCode('user-1', {});
+      expect(result.ownerId).toBe('user-1');
+      expect(codesRepo.save).toHaveBeenCalled();
+    });
+
+    it('respects maxUses when provided', async () => {
+      codesRepo.findOne.mockResolvedValue(null);
+      const saved = { id: 'uuid-2', code: 'XYZ99999', ownerId: 'user-1', maxUses: 50, useCount: 0, isActive: true };
+      codesRepo.create.mockReturnValue(saved);
+      codesRepo.save.mockResolvedValue(saved);
+
+      const result = await service.createCode('user-1', { maxUses: 50 });
+      expect(result.maxUses).toBe(50);
+    });
+  });
+
+  describe('validateCode', () => {
+    it('returns valid:true for an active code with capacity', async () => {
+      codesRepo.findOne.mockResolvedValue({ code: 'GOOD1234', isActive: true, maxUses: 10, useCount: 5 });
+      const result = await service.validateCode('GOOD1234');
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('returns valid:false when code not found', async () => {
+      codesRepo.findOne.mockResolvedValue(null);
+      const result = await service.validateCode('MISSING1');
+      expect(result.valid).toBe(false);
+    });
+
+    it('returns valid:false when code is inactive', async () => {
+      codesRepo.findOne.mockResolvedValue({ isActive: false, maxUses: null, useCount: 0 });
+      const result = await service.validateCode('DEAD1234');
+      expect(result.valid).toBe(false);
+    });
+
+    it('returns valid:false when usage limit reached', async () => {
+      codesRepo.findOne.mockResolvedValue({ isActive: true, maxUses: 5, useCount: 5 });
+      const result = await service.validateCode('FULL1234');
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('redeemCode', () => {
+    const buildManager = (overrides: Record<string, jest.Mock> = {}) => ({
+      findOne: jest.fn(),
+      save: jest.fn(),
+      create: jest.fn(),
+      ...overrides,
+    });
+
+    it('redeems a valid code and increments useCount', async () => {
+      const code = { id: 'code-uuid', code: 'VALID123', ownerId: 'owner-1', isActive: true, maxUses: null, useCount: 0 };
+      const redemption = { id: 'red-uuid', referralCodeId: 'code-uuid', redeemerId: 'user-2' };
+      const manager = buildManager({
+        findOne: jest.fn()
+          .mockResolvedValueOnce(code)       // ReferralCode lookup
+          .mockResolvedValueOnce(null),       // no prior redemption
+        create: jest.fn().mockReturnValue(redemption),
+        save: jest.fn().mockResolvedValue(redemption),
+      });
+      dataSource.transaction.mockImplementation((cb: (m: typeof manager) => Promise<unknown>) => cb(manager));
+
+      const result = await service.redeemCode('user-2', { code: 'VALID123' });
+      expect(result).toEqual(redemption);
+      expect(manager.save).toHaveBeenCalledWith(ReferralCode, expect.objectContaining({ useCount: 1 }));
+    });
+
+    it('throws NotFoundException when code does not exist', async () => {
+      const manager = buildManager({ findOne: jest.fn().mockResolvedValue(null) });
+      dataSource.transaction.mockImplementation((cb: (m: typeof manager) => Promise<unknown>) => cb(manager));
+
+      await expect(service.redeemCode('user-2', { code: 'NOPE1234' })).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when owner tries to redeem own code', async () => {
+      const code = { id: 'code-uuid', code: 'OWN12345', ownerId: 'user-1', isActive: true, maxUses: null, useCount: 0 };
+      const manager = buildManager({ findOne: jest.fn().mockResolvedValue(code) });
+      dataSource.transaction.mockImplementation((cb: (m: typeof manager) => Promise<unknown>) => cb(manager));
+
+      await expect(service.redeemCode('user-1', { code: 'OWN12345' })).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws ConflictException on duplicate redemption', async () => {
+      const code = { id: 'code-uuid', code: 'DUP12345', ownerId: 'owner-1', isActive: true, maxUses: null, useCount: 1 };
+      const existing = { id: 'red-uuid' };
+      const manager = buildManager({
+        findOne: jest.fn()
+          .mockResolvedValueOnce(code)
+          .mockResolvedValueOnce(existing),
+      });
+      dataSource.transaction.mockImplementation((cb: (m: typeof manager) => Promise<unknown>) => cb(manager));
+
+      await expect(service.redeemCode('user-2', { code: 'DUP12345' })).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('deactivateCode', () => {
+    it('deactivates a code owned by the user', async () => {
+      const code = { id: 'code-uuid', ownerId: 'user-1', isActive: true };
+      codesRepo.findOne.mockResolvedValue(code);
+      codesRepo.save.mockResolvedValue({ ...code, isActive: false });
+
+      const result = await service.deactivateCode('user-1', 'code-uuid');
+      expect(result.isActive).toBe(false);
+    });
+
+    it('throws ForbiddenException when user does not own the code', async () => {
+      codesRepo.findOne.mockResolvedValue({ id: 'code-uuid', ownerId: 'other-user' });
+      await expect(service.deactivateCode('user-1', 'code-uuid')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws NotFoundException when code does not exist', async () => {
+      codesRepo.findOne.mockResolvedValue(null);
+      await expect(service.deactivateCode('user-1', 'code-uuid')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/referral/referral.service.ts
+++ b/backend/src/referral/referral.service.ts
@@ -1,0 +1,127 @@
+import {
+  Injectable,
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { ReferralCode } from './entities/referral-code.entity';
+import { ReferralRedemption } from './entities/referral-redemption.entity';
+import { CreateReferralCodeDto } from './dto/create-referral-code.dto';
+import { RedeemReferralCodeDto } from './dto/redeem-referral-code.dto';
+
+const CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no O/0/I/1 ambiguity
+const CODE_LENGTH = 8;
+
+function generateCode(): string {
+  return Array.from({ length: CODE_LENGTH }, () =>
+    CODE_CHARS[Math.floor(Math.random() * CODE_CHARS.length)],
+  ).join('');
+}
+
+@Injectable()
+export class ReferralService {
+  constructor(
+    @InjectRepository(ReferralCode)
+    private readonly codesRepo: Repository<ReferralCode>,
+    @InjectRepository(ReferralRedemption)
+    private readonly redemptionsRepo: Repository<ReferralRedemption>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  /** Generate a unique referral code for a user. */
+  async createCode(ownerId: string, dto: CreateReferralCodeDto): Promise<ReferralCode> {
+    let code: string;
+    let attempts = 0;
+
+    do {
+      code = generateCode();
+      attempts++;
+      if (attempts > 10) throw new ConflictException('Could not generate a unique code, try again');
+    } while (await this.codesRepo.findOne({ where: { code } }));
+
+    const entity = this.codesRepo.create({
+      ownerId,
+      code,
+      maxUses: dto.maxUses ?? null,
+    });
+
+    return this.codesRepo.save(entity);
+  }
+
+  /** List all codes owned by a user. */
+  async listCodes(ownerId: string): Promise<ReferralCode[]> {
+    return this.codesRepo.find({ where: { ownerId }, order: { createdAt: 'DESC' } });
+  }
+
+  /** Deactivate a code (owner only). */
+  async deactivateCode(ownerId: string, codeId: string): Promise<ReferralCode> {
+    const entity = await this.codesRepo.findOne({ where: { id: codeId } });
+    if (!entity) throw new NotFoundException('Referral code not found');
+    if (entity.ownerId !== ownerId) throw new ForbiddenException('Not your code');
+
+    entity.isActive = false;
+    return this.codesRepo.save(entity);
+  }
+
+  /** Validate a code without redeeming it (used during checkout preview). */
+  async validateCode(code: string): Promise<{ valid: boolean; reason?: string }> {
+    const entity = await this.codesRepo.findOne({ where: { code } });
+    if (!entity) return { valid: false, reason: 'Code not found' };
+    if (!entity.isActive) return { valid: false, reason: 'Code is no longer active' };
+    if (entity.maxUses !== null && entity.useCount >= entity.maxUses) {
+      return { valid: false, reason: 'Code has reached its usage limit' };
+    }
+    return { valid: true };
+  }
+
+  /**
+   * Redeem a referral code for a user.
+   * Idempotent: a user can only redeem a given code once.
+   */
+  async redeemCode(redeemerId: string, dto: RedeemReferralCodeDto): Promise<ReferralRedemption> {
+    return this.dataSource.transaction(async (manager) => {
+      const entity = await manager.findOne(ReferralCode, {
+        where: { code: dto.code },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!entity) throw new NotFoundException('Referral code not found');
+      if (!entity.isActive) throw new BadRequestException('Referral code is no longer active');
+      if (entity.ownerId === redeemerId) {
+        throw new BadRequestException('You cannot redeem your own referral code');
+      }
+      if (entity.maxUses !== null && entity.useCount >= entity.maxUses) {
+        throw new BadRequestException('Referral code has reached its usage limit');
+      }
+
+      const alreadyRedeemed = await manager.findOne(ReferralRedemption, {
+        where: { referralCodeId: entity.id, redeemerId },
+      });
+      if (alreadyRedeemed) throw new ConflictException('You have already redeemed this code');
+
+      entity.useCount += 1;
+      await manager.save(ReferralCode, entity);
+
+      const redemption = manager.create(ReferralRedemption, {
+        referralCodeId: entity.id,
+        redeemerId,
+      });
+      return manager.save(ReferralRedemption, redemption);
+    });
+  }
+
+  /** List redemptions for a code (owner only). */
+  async listRedemptions(ownerId: string, codeId: string): Promise<ReferralRedemption[]> {
+    const entity = await this.codesRepo.findOne({ where: { id: codeId } });
+    if (!entity) throw new NotFoundException('Referral code not found');
+    if (entity.ownerId !== ownerId) throw new ForbiddenException('Not your code');
+
+    return this.redemptionsRepo.find({
+      where: { referralCodeId: codeId },
+      order: { redeemedAt: 'DESC' },
+    });
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,6 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -2647,6 +2646,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2725,20 +2725,6 @@
         "@types/react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@testing-library/user-event": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
-      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -7260,6 +7246,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9807,7 +9794,7 @@
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
       "dev": true,
-      "optional": true
+      "requires": {}
     },
     "@humanfs/core": {
       "version": "0.19.1",
@@ -10463,7 +10450,6 @@
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.0.tgz",
       "integrity": "sha512-AZqQzADaj742oqn2xjl5JbIOzZB/DGCYF/7bpvhA8KvjUj9HJkag6bBuwZvH1ps6dfgxNHyuJVlzSr2VpMgdTQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@tailwindcss/oxide-android-arm64": "4.2.0",
         "@tailwindcss/oxide-darwin-arm64": "4.2.0",
@@ -10657,13 +10643,6 @@
         "@babel/runtime": "^7.12.5"
       }
     },
-    "@testing-library/user-event": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
-      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true,
-      "requires": {}
-    },
     "@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -10852,7 +10831,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
       "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@typescript-eslint/types": "8.56.0",
         "@typescript-eslint/visitor-keys": "8.56.0"
@@ -11460,10 +11438,6 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "requires": {
-        "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
       }
@@ -12084,7 +12058,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.1.tgz",
       "integrity": "sha512-qhabwjQZ1Mk53XzXvmogf8KQ0tG0CQXF0CZ56+2/lVhmObgmaqj7x5A1DSrWdZd3kwI7GTPGUjFne+krRxYmFg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@next/eslint-plugin-next": "16.2.1",
         "eslint-import-resolver-node": "^0.3.6",
@@ -12167,7 +12140,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -13015,15 +12987,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
       "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
-      "dev": true,
-      "requires": {
-        "define-data-property": "^1.1.4",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "get-proto": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "set-function-name": "^2.0.2"
-      }
+      "dev": true
     },
     "jiti": {
       "version": "2.6.1",
@@ -13648,6 +13612,7 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
           "optional": true
         }
       }
@@ -14589,7 +14554,13 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
       "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      }
     },
     "undici-types": {
       "version": "6.21.0",
@@ -14681,7 +14652,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/frontend/src/components/checkout/CheckoutFlow.tsx
+++ b/frontend/src/components/checkout/CheckoutFlow.tsx
@@ -18,6 +18,9 @@ import {
 import { useTransaction } from "@/hooks/useTransaction";
 import { useToast } from "@/contexts/ToastContext";
 import { createAppError } from "@/types/errors";
+import { useFeatureFlag } from "@/hooks/useFeatureFlag";
+import { FeatureFlag } from "@/lib/feature-flags";
+import { ReferralCodeInput } from "@/components/referral/ReferralCodeInput";
 
 import PlanSummaryComponent from "./PlanSummary";
 import PriceBreakdownComponent from "./PriceBreakdown";
@@ -75,6 +78,10 @@ export default function CheckoutFlow({
   const [checkoutResult, setCheckoutResult] = useState<CheckoutResult | null>(
     null
   );
+
+  // Referral code state
+  const referralEnabled = useFeatureFlag(FeatureFlag.REFERRAL_CODES);
+  const [appliedReferralCode, setAppliedReferralCode] = useState<string | null>(null);
 
   // Transaction hook
   const tx = useTransaction({
@@ -328,6 +335,14 @@ export default function CheckoutFlow({
               selectedAsset={selectedAsset}
               requiredAmount={priceBreakdown.total}
               validation={balanceValidation || undefined}
+            />
+          )}
+          {referralEnabled && (
+            <ReferralCodeInput
+              onValidated={(code, valid) => {
+                if (valid) setAppliedReferralCode(code);
+                else setAppliedReferralCode(null);
+              }}
             />
           )}
           <div className="flex gap-3">

--- a/frontend/src/components/referral/ReferralCodeInput.test.tsx
+++ b/frontend/src/components/referral/ReferralCodeInput.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ReferralCodeInput } from './ReferralCodeInput';
+
+describe('ReferralCodeInput', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders the input and apply button', () => {
+    render(<ReferralCodeInput />);
+    expect(screen.getByLabelText(/referral/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /apply/i })).toBeInTheDocument();
+  });
+
+  it('uppercases typed input', () => {
+    render(<ReferralCodeInput />);
+    const input = screen.getByLabelText(/referral/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'alice123' } });
+    expect(input.value).toBe('ALICE123');
+  });
+
+  it('shows valid status on successful validation', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ valid: true }),
+    } as Response);
+
+    const onValidated = vi.fn();
+    render(<ReferralCodeInput onValidated={onValidated} />);
+
+    fireEvent.change(screen.getByLabelText(/referral/i), { target: { value: 'GOOD1234' } });
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Code applied!'));
+    expect(onValidated).toHaveBeenCalledWith('GOOD1234', true);
+  });
+
+  it('shows invalid status when code is rejected', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ valid: false, reason: 'Code not found' }),
+    } as Response);
+
+    render(<ReferralCodeInput />);
+    fireEvent.change(screen.getByLabelText(/referral/i), { target: { value: 'NOPE1234' } });
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Code not found'));
+  });
+
+  it('shows error message on network failure', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    render(<ReferralCodeInput />);
+    fireEvent.change(screen.getByLabelText(/referral/i), { target: { value: 'FAIL1234' } });
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent('Could not validate code'),
+    );
+  });
+});

--- a/frontend/src/components/referral/ReferralCodeInput.tsx
+++ b/frontend/src/components/referral/ReferralCodeInput.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+
+interface ReferralCodeInputProps {
+  onValidated?: (code: string, valid: boolean) => void;
+  className?: string;
+}
+
+export function ReferralCodeInput({ onValidated, className = '' }: ReferralCodeInputProps) {
+  const [code, setCode] = useState('');
+  const [status, setStatus] = useState<'idle' | 'checking' | 'valid' | 'invalid'>('idle');
+  const [message, setMessage] = useState('');
+
+  async function handleApply() {
+    const trimmed = code.trim().toUpperCase();
+    if (!trimmed) return;
+
+    setStatus('checking');
+    setMessage('');
+
+    try {
+      const res = await fetch('/api/v1/referral/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: trimmed }),
+      });
+      const data = await res.json() as { valid: boolean; reason?: string };
+
+      if (data.valid) {
+        setStatus('valid');
+        setMessage('Code applied!');
+        onValidated?.(trimmed, true);
+      } else {
+        setStatus('invalid');
+        setMessage(data.reason ?? 'Invalid code');
+        onValidated?.(trimmed, false);
+      }
+    } catch {
+      setStatus('invalid');
+      setMessage('Could not validate code. Try again.');
+    }
+  }
+
+  return (
+    <div className={`flex flex-col gap-1 ${className}`}>
+      <label htmlFor="referral-code" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        Referral / invite code <span className="text-gray-400">(optional)</span>
+      </label>
+      <div className="flex gap-2">
+        <input
+          id="referral-code"
+          type="text"
+          value={code}
+          onChange={(e) => {
+            setCode(e.target.value.toUpperCase());
+            setStatus('idle');
+            setMessage('');
+          }}
+          placeholder="e.g. ALICE1234"
+          maxLength={20}
+          aria-describedby="referral-code-status"
+          className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        />
+        <button
+          type="button"
+          onClick={handleApply}
+          disabled={!code.trim() || status === 'checking'}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        >
+          {status === 'checking' ? 'Checking…' : 'Apply'}
+        </button>
+      </div>
+      {message && (
+        <p
+          id="referral-code-status"
+          role="status"
+          className={`text-xs ${status === 'valid' ? 'text-green-600' : 'text-red-500'}`}
+        >
+          {status === 'valid' ? '✓ ' : '✗ '}{message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/referral/ReferralSharePanel.tsx
+++ b/frontend/src/components/referral/ReferralSharePanel.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState } from 'react';
+
+interface ReferralSharePanelProps {
+  code: string;
+  useCount: number;
+  maxUses: number | null;
+}
+
+export function ReferralSharePanel({ code, useCount, maxUses }: ReferralSharePanelProps) {
+  const [copied, setCopied] = useState(false);
+
+  const shareUrl =
+    typeof window !== 'undefined'
+      ? `${window.location.origin}/onboarding?ref=${code}`
+      : `/onboarding?ref=${code}`;
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(shareUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+      <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500">Your referral code</p>
+      <p className="mb-3 text-2xl font-bold tracking-widest text-indigo-600">{code}</p>
+
+      <div className="mb-3 flex items-center gap-2 rounded-md bg-gray-50 px-3 py-2 dark:bg-gray-800">
+        <span className="flex-1 truncate text-sm text-gray-600 dark:text-gray-300">{shareUrl}</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy referral link"
+          className="text-xs font-medium text-indigo-600 hover:underline"
+        >
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+
+      <p className="text-xs text-gray-500">
+        {useCount} use{useCount !== 1 ? 's' : ''}
+        {maxUses !== null ? ` / ${maxUses} max` : ' (unlimited)'}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/referral/index.ts
+++ b/frontend/src/components/referral/index.ts
@@ -1,0 +1,2 @@
+export { ReferralCodeInput } from './ReferralCodeInput';
+export { ReferralSharePanel } from './ReferralSharePanel';

--- a/frontend/src/lib/feature-flags.ts
+++ b/frontend/src/lib/feature-flags.ts
@@ -2,6 +2,7 @@ export const FeatureFlag = {
   BOOKMARKS: 'bookmarks',
   EARNINGS_WITHDRAWALS: 'earnings_withdrawals',
   EARNINGS_FEE_TRANSPARENCY: 'earnings_fee_transparency',
+  REFERRAL_CODES: 'referral_codes',
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -33,12 +34,17 @@ export const featureFlagDefinitions: Record<FeatureFlag, FeatureFlagDefinition> 
     description: 'Shows the fee transparency card on the creator earnings page.',
     envKey: 'NEXT_PUBLIC_FLAG_EARNINGS_FEE_TRANSPARENCY',
   },
+  [FeatureFlag.REFERRAL_CODES]: {
+    description: 'Enables referral / invite code input during checkout and share panel in settings.',
+    envKey: 'NEXT_PUBLIC_FLAG_REFERRAL_CODES',
+  },
 };
 
 export const defaultFeatureFlags: FeatureFlagSnapshot = Object.freeze({
   [FeatureFlag.BOOKMARKS]: false,
   [FeatureFlag.EARNINGS_WITHDRAWALS]: false,
   [FeatureFlag.EARNINGS_FEE_TRANSPARENCY]: false,
+  [FeatureFlag.REFERRAL_CODES]: false,
 });
 
 let cachedRemoteFlags: FeatureFlagOverrides = {};


### PR DESCRIPTION
## Summary

Implements referral / invite codes as described in issue #743. The feature is **off by default** behind a feature flag and can be enabled per environment without redeployment.

---

## What's in this PR

### Backend (`backend/src/referral/`)
| File | Purpose |
|---|---|
| `entities/referral-code.entity.ts` | `referral_codes` table — owner, code, max_uses, use_count, is_active |
| `entities/referral-redemption.entity.ts` | `referral_redemptions` table — unique (code × redeemer) constraint |
| `dto/create-referral-code.dto.ts` | Optional `maxUses` param |
| `dto/redeem-referral-code.dto.ts` | Uppercase alphanumeric code validation |
| `referral.service.ts` | generate, validate, redeem (pessimistic lock, idempotent), deactivate, list |
| `referral.controller.ts` | REST: `POST /v1/referral/codes`, `POST /v1/referral/validate`, `POST /v1/referral/redeem`, `GET /v1/referral/codes`, `PATCH /v1/referral/codes/:id/deactivate`, `GET /v1/referral/codes/:id/redemptions` |
| `referral.module.ts` | NestJS module wired into `AppModule` |
| `1745000000000-CreateReferralTables.ts` | TypeORM migration (up + down) |
| `referral.service.spec.ts` | **13 unit tests** — all passing ✅ |

### Frontend (`frontend/src/components/referral/`)
| File | Purpose |
|---|---|
| `ReferralCodeInput.tsx` | Validate-on-apply input, accessible (`aria-describedby`, `role=status`) |
| `ReferralSharePanel.tsx` | Copy-to-clipboard share link panel for code owners |
| `index.ts` | Barrel export |
| `ReferralCodeInput.test.tsx` | **5 component tests** — all passing ✅ |

`ReferralCodeInput` is injected into `CheckoutFlow` (select step) behind the `FEATURE_REFERRAL_CODES` flag.

### Feature flag
| Layer | Env var | Default |
|---|---|---|
| Backend | `FEATURE_REFERRAL_CODES=true` | `false` |
| Frontend | `NEXT_PUBLIC_FLAG_REFERRAL_CODES=true` | `false` |

---

## Manual checklist
- [ ] Set `FEATURE_REFERRAL_CODES=true` in backend `.env`
- [ ] Set `NEXT_PUBLIC_FLAG_REFERRAL_CODES=true` in frontend `.env.local`
- [ ] Run migration: `npm run migration:run`
- [ ] `POST /v1/referral/codes` → generates a code
- [ ] `POST /v1/referral/validate` → returns `{ valid: true }`
- [ ] `POST /v1/referral/redeem` → increments `use_count`, returns redemption
- [ ] Redeeming own code → `400 Bad Request`
- [ ] Redeeming twice → `409 Conflict`
- [ ] Referral input visible in checkout flow when flag is on
- [ ] Referral input hidden when flag is off

Closes #743