### PR TITLE
feature:Moderation queue SLA metrics

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -234,7 +234,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2110,7 +2109,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2274,7 +2272,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2334,7 +2331,6 @@
       "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2418,7 +2414,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.17.tgz",
       "integrity": "sha512-mAf4eOsSBsTOn/VbrUO1gsjW6dVh91qqXPMXun4dN8SnNjf7PTQagM9o8d6ab8ZBpNe6UdZftdrZoDetU+n4Qg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2977,7 +2972,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3112,7 +3106,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3296,7 +3289,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -3952,7 +3944,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4002,7 +3993,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4482,7 +4472,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4705,7 +4694,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4753,15 +4741,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5511,7 +5497,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5572,7 +5557,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6934,7 +6918,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8599,7 +8582,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -8717,7 +8699,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -8975,7 +8956,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9160,8 +9140,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9257,7 +9236,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9926,7 +9904,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10281,7 +10258,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10441,7 +10417,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -10625,7 +10600,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10998,6 +10972,7 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -11016,6 +10991,7 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -11029,6 +11005,7 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -11043,6 +11020,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -11053,6 +11031,7 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11063,6 +11042,7 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -11076,6 +11056,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -11131,7 +11112,6 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",

--- a/backend/src/metrics/metrics.controller.ts
+++ b/backend/src/metrics/metrics.controller.ts
@@ -2,30 +2,41 @@ import { Controller, Get, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import type { MetricsSnapshot } from '../common/services/http-metrics.service';
 import { HttpMetricsService } from '../common/services/http-metrics.service';
+import { ModerationSlaService, ModerationSlaSnapshot } from '../moderation/moderation-sla.service';
+
+export interface FullMetricsSnapshot extends MetricsSnapshot {
+  moderationSla: ModerationSlaSnapshot;
+}
 
 @ApiTags('metrics')
 @Controller({ path: 'metrics', version: '1' })
 export class MetricsController {
-  constructor(private readonly httpMetrics: HttpMetricsService) {}
+  constructor(
+    private readonly httpMetrics: HttpMetricsService,
+    private readonly moderationSla: ModerationSlaService,
+  ) {}
 
   /**
    * GET /v1/metrics
-   * Returns a point-in-time snapshot of per-endpoint SLA metrics.
-   * Optionally filter to a single route prefix.
+   * Returns a point-in-time snapshot of per-endpoint SLA metrics
+   * plus moderation queue SLA stats.
    */
   @Get()
-  @ApiOperation({ summary: 'Per-endpoint HTTP latency and error rate metrics' })
-  @ApiQuery({ name: 'route', required: false, description: 'Filter by route prefix, e.g. /v1/auth' })
+  @ApiOperation({ summary: 'Per-endpoint HTTP latency, error rate metrics, and moderation queue SLA' })
+  @ApiQuery({ name: 'route', required: false, description: 'Filter HTTP endpoints by route prefix, e.g. /v1/auth' })
   @ApiResponse({ status: 200, description: 'Metrics snapshot' })
-  getMetrics(@Query('route') routeFilter?: string): MetricsSnapshot {
-    const snapshot = this.httpMetrics.snapshot();
+  async getMetrics(@Query('route') routeFilter?: string): Promise<FullMetricsSnapshot> {
+    const [httpSnap, slaSnap] = await Promise.all([
+      Promise.resolve(this.httpMetrics.snapshot()),
+      this.moderationSla.snapshot(),
+    ]);
 
     if (routeFilter) {
-      snapshot.endpoints = snapshot.endpoints.filter((e) =>
+      httpSnap.endpoints = httpSnap.endpoints.filter((e) =>
         e.route.startsWith(routeFilter),
       );
     }
 
-    return snapshot;
+    return { ...httpSnap, moderationSla: slaSnap };
   }
 }

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { MetricsController } from './metrics.controller';
 import { HttpMetricsService } from '../common/services/http-metrics.service';
+import { ModerationModule } from '../moderation/moderation.module';
 
 @Module({
+  imports: [ModerationModule],
   controllers: [MetricsController],
   providers: [HttpMetricsService],
   exports: [HttpMetricsService],

--- a/backend/src/moderation/1745000000000-AddQueuedAtToModerationFlags.ts
+++ b/backend/src/moderation/1745000000000-AddQueuedAtToModerationFlags.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds `queued_at` to `moderation_flags`.
+ * Backfills existing rows with their `created_at` value so SLA age
+ * calculations are meaningful for pre-existing flags.
+ */
+export class AddQueuedAtToModerationFlags1745000000000 implements MigrationInterface {
+  name = 'AddQueuedAtToModerationFlags1745000000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "moderation_flags"
+      ADD COLUMN IF NOT EXISTS "queued_at" TIMESTAMP NULL
+    `);
+
+    // Backfill: use created_at as the baseline queue entry time
+    await queryRunner.query(`
+      UPDATE "moderation_flags"
+      SET "queued_at" = "created_at"
+      WHERE "queued_at" IS NULL
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_moderation_flags_queued_at"
+      ON "moderation_flags" ("queued_at")
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "IDX_moderation_flags_queued_at"
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "moderation_flags"
+      DROP COLUMN IF EXISTS "queued_at"
+    `);
+  }
+}

--- a/backend/src/moderation/entities/moderation-flag.entity.ts
+++ b/backend/src/moderation/entities/moderation-flag.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Index,
+  BeforeInsert,
 } from 'typeorm';
 
 export enum ModerationStatus {
@@ -69,9 +70,25 @@ export class ModerationFlag {
   @Column({ type: 'text', nullable: true })
   admin_notes: string | null;
 
+  /**
+   * Timestamp when the flag entered its current status.
+   * Used to compute queue-age SLA metrics (how long a flag has been waiting).
+   * Defaults to created_at on insert; updated whenever status changes.
+   */
+  @Column({ type: 'timestamp', nullable: true })
+  @Index()
+  queued_at: Date | null;
+
   @CreateDateColumn()
   created_at: Date;
 
   @UpdateDateColumn()
   updated_at: Date;
+
+  @BeforeInsert()
+  setQueuedAt() {
+    if (!this.queued_at) {
+      this.queued_at = new Date();
+    }
+  }
 }

--- a/backend/src/moderation/moderation-sla.service.spec.ts
+++ b/backend/src/moderation/moderation-sla.service.spec.ts
@@ -1,0 +1,193 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  ModerationSlaService,
+  SLA_THRESHOLDS_MS,
+} from './moderation-sla.service';
+import {
+  ModerationFlag,
+  ModerationStatus,
+  ContentType,
+  FlagReason,
+} from './entities/moderation-flag.entity';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeFlag(
+  status: ModerationStatus,
+  ageMs: number,
+  overrides: Partial<ModerationFlag> = {},
+): Partial<ModerationFlag> {
+  const queued_at = new Date(Date.now() - ageMs);
+  return {
+    id: Math.random().toString(36).slice(2),
+    status,
+    queued_at,
+    created_at: queued_at,
+    content_type: ContentType.POST,
+    content_id: 'content-uuid',
+    reason: FlagReason.SPAM,
+    notes: null,
+    reported_by: 'user-uuid',
+    reviewed_by: null,
+    reviewed_at: null,
+    admin_notes: null,
+    ...overrides,
+  };
+}
+
+const mockFlagRepo = () => ({
+  createQueryBuilder: jest.fn(),
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('ModerationSlaService', () => {
+  let service: ModerationSlaService;
+  let flagRepo: ReturnType<typeof mockFlagRepo>;
+
+  /** Helper: configure the query builder mock to return `flags` */
+  function mockQuery(flags: Partial<ModerationFlag>[]) {
+    const qb = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(flags),
+    };
+    flagRepo.createQueryBuilder.mockReturnValue(qb);
+    return qb;
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ModerationSlaService,
+        { provide: getRepositoryToken(ModerationFlag), useFactory: mockFlagRepo },
+      ],
+    }).compile();
+
+    service = module.get(ModerationSlaService);
+    flagRepo = module.get(getRepositoryToken(ModerationFlag));
+  });
+
+  // ── empty queue ─────────────────────────────────────────────────────────
+
+  it('returns zero counts when queue is empty', async () => {
+    mockQuery([]);
+    const snap = await service.snapshot();
+
+    expect(snap.openCount).toBe(0);
+    expect(snap.byStatus).toHaveLength(2); // PENDING + UNDER_REVIEW
+    for (const s of snap.byStatus) {
+      expect(s.count).toBe(0);
+      expect(s.avgAgeMs).toBe(0);
+      expect(s.p95AgeMs).toBe(0);
+      expect(s.overdueCount).toBe(0);
+    }
+  });
+
+  // ── basic counts ────────────────────────────────────────────────────────
+
+  it('counts flags per status correctly', async () => {
+    const ONE_HOUR = 60 * 60 * 1000;
+    mockQuery([
+      makeFlag(ModerationStatus.PENDING, ONE_HOUR),
+      makeFlag(ModerationStatus.PENDING, ONE_HOUR * 2),
+      makeFlag(ModerationStatus.UNDER_REVIEW, ONE_HOUR * 5),
+    ]);
+
+    const snap = await service.snapshot();
+    expect(snap.openCount).toBe(3);
+
+    const pending = snap.byStatus.find((s) => s.status === ModerationStatus.PENDING)!;
+    expect(pending.count).toBe(2);
+
+    const underReview = snap.byStatus.find((s) => s.status === ModerationStatus.UNDER_REVIEW)!;
+    expect(underReview.count).toBe(1);
+  });
+
+  // ── overdue detection ───────────────────────────────────────────────────
+
+  it('marks PENDING flags overdue after 4 h', async () => {
+    const FOUR_H = SLA_THRESHOLDS_MS.PENDING_OVERDUE_MS;
+    mockQuery([
+      makeFlag(ModerationStatus.PENDING, FOUR_H - 1000),  // within SLO
+      makeFlag(ModerationStatus.PENDING, FOUR_H + 1000),  // overdue
+      makeFlag(ModerationStatus.PENDING, FOUR_H + 5000),  // overdue
+    ]);
+
+    const snap = await service.snapshot();
+    const pending = snap.byStatus.find((s) => s.status === ModerationStatus.PENDING)!;
+    expect(pending.overdueCount).toBe(2);
+    expect(pending.sloThresholdMs).toBe(FOUR_H);
+  });
+
+  it('marks UNDER_REVIEW flags overdue after 24 h', async () => {
+    const TWENTY_FOUR_H = SLA_THRESHOLDS_MS.UNDER_REVIEW_OVERDUE_MS;
+    mockQuery([
+      makeFlag(ModerationStatus.UNDER_REVIEW, TWENTY_FOUR_H - 1000),
+      makeFlag(ModerationStatus.UNDER_REVIEW, TWENTY_FOUR_H + 1000),
+    ]);
+
+    const snap = await service.snapshot();
+    const ur = snap.byStatus.find((s) => s.status === ModerationStatus.UNDER_REVIEW)!;
+    expect(ur.overdueCount).toBe(1);
+    expect(ur.sloThresholdMs).toBe(TWENTY_FOUR_H);
+  });
+
+  // ── percentile accuracy ─────────────────────────────────────────────────
+
+  it('computes correct p95 and p99 ages', async () => {
+    // 100 PENDING flags with ages 1 min … 100 min
+    const ONE_MIN = 60 * 1000;
+    const flags = Array.from({ length: 100 }, (_, i) =>
+      makeFlag(ModerationStatus.PENDING, (i + 1) * ONE_MIN),
+    );
+    mockQuery(flags);
+
+    const snap = await service.snapshot();
+    const pending = snap.byStatus.find((s) => s.status === ModerationStatus.PENDING)!;
+
+    // p95 of [1..100] min → 95 min
+    expect(pending.p95AgeMs).toBeCloseTo(95 * ONE_MIN, -3);
+    // p99 → 99 min
+    expect(pending.p99AgeMs).toBeCloseTo(99 * ONE_MIN, -3);
+  });
+
+  // ── null queued_at fallback ─────────────────────────────────────────────
+
+  it('falls back to created_at when queued_at is null', async () => {
+    const TWO_HOURS = 2 * 60 * 60 * 1000;
+    const flag = makeFlag(ModerationStatus.PENDING, TWO_HOURS);
+    (flag as any).queued_at = null; // simulate legacy row
+    (flag as any).created_at = new Date(Date.now() - TWO_HOURS);
+    mockQuery([flag]);
+
+    const snap = await service.snapshot();
+    const pending = snap.byStatus.find((s) => s.status === ModerationStatus.PENDING)!;
+    // avgAgeMs should be approximately 2 h (allow 1 s tolerance)
+    expect(pending.avgAgeMs).toBeGreaterThanOrEqual(TWO_HOURS - 1000);
+    expect(pending.avgAgeMs).toBeLessThanOrEqual(TWO_HOURS + 1000);
+  });
+
+  // ── collectedAt is a valid ISO timestamp ────────────────────────────────
+
+  it('sets collectedAt to a valid ISO string', async () => {
+    mockQuery([]);
+    const snap = await service.snapshot();
+    expect(() => new Date(snap.collectedAt)).not.toThrow();
+    expect(new Date(snap.collectedAt).toISOString()).toBe(snap.collectedAt);
+  });
+
+  // ── stale / disconnected state: clock skew guard ────────────────────────
+
+  it('clamps negative ages to 0 (clock skew guard)', async () => {
+    // queued_at slightly in the future (clock skew)
+    const flag = makeFlag(ModerationStatus.PENDING, -500); // negative age
+    mockQuery([flag]);
+
+    const snap = await service.snapshot();
+    const pending = snap.byStatus.find((s) => s.status === ModerationStatus.PENDING)!;
+    expect(pending.avgAgeMs).toBeGreaterThanOrEqual(0);
+    expect(pending.overdueCount).toBe(0);
+  });
+});

--- a/backend/src/moderation/moderation-sla.service.ts
+++ b/backend/src/moderation/moderation-sla.service.ts
@@ -1,0 +1,130 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ModerationFlag, ModerationStatus } from './entities/moderation-flag.entity';
+
+/** SLO thresholds in milliseconds */
+export const SLA_THRESHOLDS_MS = {
+  /** Flags pending > 4 h are considered overdue */
+  PENDING_OVERDUE_MS: 4 * 60 * 60 * 1000,
+  /** Flags under_review > 24 h are considered overdue */
+  UNDER_REVIEW_OVERDUE_MS: 24 * 60 * 60 * 1000,
+} as const;
+
+export interface StatusSlaStats {
+  status: ModerationStatus;
+  count: number;
+  /** Average age in the current status (ms) */
+  avgAgeMs: number;
+  /** 95th-percentile age (ms) */
+  p95AgeMs: number;
+  /** 99th-percentile age (ms) */
+  p99AgeMs: number;
+  /** Oldest flag age (ms) */
+  maxAgeMs: number;
+  /** Flags exceeding the SLO threshold for this status */
+  overdueCount: number;
+  /** SLO threshold applied (ms) */
+  sloThresholdMs: number;
+}
+
+export interface ModerationSlaSnapshot {
+  collectedAt: string;
+  /** Total flags currently in an open (non-terminal) status */
+  openCount: number;
+  byStatus: StatusSlaStats[];
+}
+
+/** Statuses that are still "in queue" and need SLA tracking */
+const OPEN_STATUSES = [ModerationStatus.PENDING, ModerationStatus.UNDER_REVIEW];
+
+const THRESHOLD_BY_STATUS: Record<string, number> = {
+  [ModerationStatus.PENDING]: SLA_THRESHOLDS_MS.PENDING_OVERDUE_MS,
+  [ModerationStatus.UNDER_REVIEW]: SLA_THRESHOLDS_MS.UNDER_REVIEW_OVERDUE_MS,
+};
+
+@Injectable()
+export class ModerationSlaService {
+  constructor(
+    @InjectRepository(ModerationFlag)
+    private readonly flagRepo: Repository<ModerationFlag>,
+  ) {}
+
+  /**
+   * Compute a point-in-time SLA snapshot for the moderation queue.
+   * Only open (non-terminal) statuses are included.
+   * Flags with a null queued_at fall back to created_at for age calculation.
+   */
+  async snapshot(): Promise<ModerationSlaSnapshot> {
+    const now = Date.now();
+
+    // Fetch all open flags in a single query — only the columns we need
+    const flags = await this.flagRepo
+      .createQueryBuilder('flag')
+      .select(['flag.status', 'flag.queued_at', 'flag.created_at'])
+      .where('flag.status IN (:...statuses)', { statuses: OPEN_STATUSES })
+      .getMany();
+
+    // Group by status
+    const grouped = new Map<ModerationStatus, ModerationFlag[]>();
+    for (const status of OPEN_STATUSES) grouped.set(status, []);
+    for (const flag of flags) {
+      grouped.get(flag.status)?.push(flag);
+    }
+
+    const byStatus: StatusSlaStats[] = [];
+
+    for (const status of OPEN_STATUSES) {
+      const bucket = grouped.get(status) ?? [];
+      const sloThresholdMs = THRESHOLD_BY_STATUS[status];
+
+      if (bucket.length === 0) {
+        byStatus.push({
+          status,
+          count: 0,
+          avgAgeMs: 0,
+          p95AgeMs: 0,
+          p99AgeMs: 0,
+          maxAgeMs: 0,
+          overdueCount: 0,
+          sloThresholdMs,
+        });
+        continue;
+      }
+
+      const ages = bucket
+        .map((f) => now - (f.queued_at ?? f.created_at).getTime())
+        .map((ms) => Math.max(0, ms)) // guard against clock skew
+        .sort((a, b) => a - b);
+
+      const avgAgeMs = Math.round(ages.reduce((s, v) => s + v, 0) / ages.length);
+      const p95AgeMs = percentile(ages, 95);
+      const p99AgeMs = percentile(ages, 99);
+      const maxAgeMs = ages[ages.length - 1];
+      const overdueCount = ages.filter((ms) => ms > sloThresholdMs).length;
+
+      byStatus.push({
+        status,
+        count: bucket.length,
+        avgAgeMs,
+        p95AgeMs,
+        p99AgeMs,
+        maxAgeMs,
+        overdueCount,
+        sloThresholdMs,
+      });
+    }
+
+    return {
+      collectedAt: new Date().toISOString(),
+      openCount: flags.length,
+      byStatus,
+    };
+  }
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}

--- a/backend/src/moderation/moderation.controller.ts
+++ b/backend/src/moderation/moderation.controller.ts
@@ -19,6 +19,7 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { ModerationService } from './moderation.service';
+import { ModerationSlaService } from './moderation-sla.service';
 import { CreateFlagDto } from './dto/create-flag.dto';
 import { ReviewFlagDto } from './dto/review-flag.dto';
 import { QueryFlagsDto } from './dto/query-flags.dto';
@@ -33,7 +34,10 @@ import { UserRole } from '../../common/enums/user-role.enum';
 @Roles(UserRole.ADMIN)
 @Controller({ path: 'moderation', version: '1' })
 export class ModerationController {
-  constructor(private readonly moderationService: ModerationService) {}
+  constructor(
+    private readonly moderationService: ModerationService,
+    private readonly moderationSlaService: ModerationSlaService,
+  ) {}
 
   // ── User endpoints ────────────────────────────────────────────────────
 
@@ -87,5 +91,21 @@ export class ModerationController {
   @ApiResponse({ status: 200, description: 'Audit log entries' })
   getAuditLog(@Param('id', ParseUUIDPipe) id: string) {
     return this.moderationService.getAuditLog(id);
+  }
+
+  // ── SLA metrics ───────────────────────────────────────────────────────
+
+  @Get('sla')
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({
+    summary: '[Admin] Moderation queue SLA metrics',
+    description:
+      'Returns queue-age statistics (avg, p95, p99, overdue count) for each open moderation status. ' +
+      'SLO: PENDING ≤ 4 h, UNDER_REVIEW ≤ 24 h.',
+  })
+  @ApiResponse({ status: 200, description: 'SLA snapshot' })
+  getSla() {
+    return this.moderationSlaService.snapshot();
   }
 }

--- a/backend/src/moderation/moderation.module.ts
+++ b/backend/src/moderation/moderation.module.ts
@@ -3,12 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ModerationFlag } from './entities/moderation-flag.entity';
 import { ModerationAuditLog } from './entities/moderation-audit-log.entity';
 import { ModerationService } from './moderation.service';
+import { ModerationSlaService } from './moderation-sla.service';
 import { ModerationController } from './moderation.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([ModerationFlag, ModerationAuditLog])],
   controllers: [ModerationController],
-  providers: [ModerationService],
-  exports: [ModerationService],
+  providers: [ModerationService, ModerationSlaService],
+  exports: [ModerationService, ModerationSlaService],
 })
 export class ModerationModule {}

--- a/backend/src/moderation/moderation.service.spec.ts
+++ b/backend/src/moderation/moderation.service.spec.ts
@@ -116,6 +116,25 @@ describe('ModerationService', () => {
         }),
       );
     });
+
+    it('resets queued_at on status change', async () => {
+      const flagCopy = { ...baseFlag };
+      flagRepo.findOne.mockResolvedValue(flagCopy);
+      flagRepo.save.mockImplementation(async (f) => f);
+      auditRepo.create.mockReturnValue({});
+      auditRepo.save.mockResolvedValue({});
+
+      const before = Date.now();
+      await service.reviewFlag(ADMIN_ID, FLAG_ID, {
+        status: ModerationStatus.UNDER_REVIEW,
+      });
+      const after = Date.now();
+
+      const saved = flagRepo.save.mock.calls[0][0];
+      expect(saved.queued_at).toBeInstanceOf(Date);
+      expect(saved.queued_at.getTime()).toBeGreaterThanOrEqual(before);
+      expect(saved.queued_at.getTime()).toBeLessThanOrEqual(after);
+    });
   });
 
   describe('getAuditLog', () => {

--- a/backend/src/moderation/moderation.service.ts
+++ b/backend/src/moderation/moderation.service.ts
@@ -79,6 +79,8 @@ export class ModerationService {
     flag.reviewed_by = adminId;
     flag.reviewed_at = new Date();
     flag.admin_notes = dto.admin_notes ?? null;
+    // Reset queue clock so SLA measures time in the new status
+    flag.queued_at = new Date();
 
     const updated = await this.flagRepo.save(flag);
 


### PR DESCRIPTION
closes #739



# Feature Flags

Toggle new flows on/off without redeployment.

## Backend

Add to `.env`:
```env
FEATURE_NEW_SUBSCRIPTION_FLOW=false
FEATURE_CRYPTO_PAYMENTS=false
```

Usage:
```typescript
@Post('new-flow')
@UseGuards(FeatureFlagGuard)
@RequireFeatureFlag('newSubscriptionFlow')
createWithNewFlow() {
  return { message: 'New flow' };
}
```

## Frontend

Add to `.env.local`:
```env
NEXT_PUBLIC_FEATURE_NEW_SUBSCRIPTION_FLOW=false
NEXT_PUBLIC_FEATURE_CRYPTO_PAYMENTS=false
```

Usage:
```tsx
<FeatureFlag feature="newSubscriptionFlow">
  <NewFlow />
</FeatureFlag>
```

## Toggle

Update env vars and restart - no deploy needed.
