### PR TITLE
ci: re-enable optional ABI snapshot check

### DIFF
--- a/.github/workflows/abi-snapshot.yml
+++ b/.github/workflows/abi-snapshot.yml
@@ -1,0 +1,39 @@
+name: ABI Snapshot
+
+on:
+  pull_request:
+    paths:
+      - "contract/**"
+      - ".github/workflows/abi-snapshot.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contracts-abi:
+    name: ABI Snapshot Check (optional)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: contract
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: contract
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli
+
+      - name: Check ABI snapshots
+        run: ./scripts/snapshot-abi.sh --check

--- a/contract/abi-snapshots/README.md
+++ b/contract/abi-snapshots/README.md
@@ -6,14 +6,23 @@ can detect accidental breaking changes.
 
 ## How CI uses these
 
-The `contracts-abi` job in CI runs:
+The optional `ABI Snapshot Check` GitHub Actions job runs:
 
 ```bash
 ./scripts/snapshot-abi.sh --check
 ```
 
 It rebuilds every contract WASM, re-generates the ABI, and diffs it against the
-committed snapshot. If anything changed the job fails and the PR is blocked.
+committed snapshot. If anything changed, the job reports the diff, but it is
+configured as non-blocking so maintainers can decide whether to refresh the
+snapshots in a follow-up commit or PR.
+
+You can also run the same verification manually before opening a PR:
+
+```bash
+cd contract
+./scripts/snapshot-abi.sh --check
+```
 
 ## Intentionally updating a snapshot
 
@@ -29,3 +38,13 @@ committed snapshot. If anything changed the job fails and the PR is blocked.
    abi-update: add pagination params to content-likes list function
    ```
 4. Open a PR — reviewers will see the exact ABI diff in the changed files.
+
+## Regenerating snapshots manually
+
+If you intentionally changed a contract interface and want to refresh the
+committed snapshots:
+
+```bash
+cd contract
+./scripts/snapshot-abi.sh
+```


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow to run `contract/scripts/snapshot-abi.sh --check` on contract PRs
- keep the ABI snapshot job non-blocking with an optional workflow job
- update the ABI snapshot README to document manual check and regeneration flows

## Testing
- bash -n contract/scripts/snapshot-abi.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/abi-snapshot.yml")'

Closes #600