### PR TITLE
fix(backend): DB migration CI with ephemeral Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,32 @@ jobs:
       matrix:
         node: ['20', '22']
 
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: myfans_ci
+          POSTGRES_PASSWORD: myfans_ci
+          POSTGRES_DB: myfans_test
+        ports:
+          - 5432:5432
+        options: >
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USER: myfans_ci
+      DB_PASSWORD: myfans_ci
+      DB_NAME: myfans_test
+      JWT_SECRET: ci-test-secret-not-for-production
+      NODE_ENV: test
+      STELLAR_NETWORK: testnet
+      SOROBAN_RPC_URL: https://soroban-testnet.stellar.org
+
     steps:
       - uses: actions/checkout@v4
 
@@ -44,6 +70,66 @@ jobs:
 
       - name: Build
         run: npm run build
+        working-directory: backend
+
+  backend-migrations:
+    name: Backend DB Migrations (Postgres)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: myfans_ci
+          POSTGRES_PASSWORD: myfans_ci
+          POSTGRES_DB: myfans_test
+        ports:
+          - 5432:5432
+        options: >
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USER: myfans_ci
+      DB_PASSWORD: myfans_ci
+      DB_NAME: myfans_test
+      JWT_SECRET: ci-test-secret-not-for-production
+      NODE_ENV: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: backend
+
+      - name: Wait for Postgres
+        run: |
+          until pg_isready -h localhost -p 5432 -U myfans_ci; do
+            echo "waiting for postgres…"; sleep 1;
+          done
+
+      - name: Run migration integration tests
+        run: npm run test:migrations
+        working-directory: backend
+
+      - name: Verify migration runner script (up)
+        run: npm run migration:run
+        working-directory: backend
+
+      - name: Verify migration runner script (revert)
+        run: npm run migration:revert
         working-directory: backend
 
   frontend:

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,10 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:migrations": "jest --config ./test/jest-migrations.json --runInBand",
+    "migration:run": "ts-node -r tsconfig-paths/register scripts/run-migrations.ts",
+    "migration:revert": "ts-node -r tsconfig-paths/register scripts/run-migrations.ts --revert"
   },
   "dependencies": {
     "@nestjs/common": "^11.1.17",

--- a/backend/scripts/run-migrations.ts
+++ b/backend/scripts/run-migrations.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env ts-node
+/**
+ * scripts/run-migrations.ts
+ *
+ * Runs all TypeORM migrations against the configured Postgres database.
+ *
+ * Usage:
+ *   npx ts-node -r tsconfig-paths/register scripts/run-migrations.ts
+ *   npx ts-node -r tsconfig-paths/register scripts/run-migrations.ts --revert
+ *
+ * Environment variables: DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME
+ * (same as .env.example)
+ */
+import 'reflect-metadata';
+import { migrationDataSource } from '../src/migration.datasource';
+
+const revert = process.argv.includes('--revert');
+
+async function main() {
+  await migrationDataSource.initialize();
+  try {
+    if (revert) {
+      console.log('[migrations] reverting last migration…');
+      await migrationDataSource.undoLastMigration();
+      console.log('[migrations] revert complete');
+    } else {
+      console.log('[migrations] running pending migrations…');
+      const ran = await migrationDataSource.runMigrations({ transaction: 'each' });
+      if (ran.length === 0) {
+        console.log('[migrations] no pending migrations');
+      } else {
+        ran.forEach((m) => console.log(`[migrations] ran: ${m.name}`));
+      }
+    }
+  } finally {
+    await migrationDataSource.destroy();
+  }
+}
+
+main().catch((err) => {
+  console.error('[migrations] FAILED:', err);
+  process.exit(1);
+});

--- a/backend/src/migration.datasource.ts
+++ b/backend/src/migration.datasource.ts
@@ -1,0 +1,29 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+
+// ── Migration files (ordered by timestamp) ───────────────────────────────────
+import { CreateRefreshTokens1700000000000 } from './refresh-module/1700000000000-CreateRefreshTokens';
+import { AddSocialLinksToUser1700000000000 } from './social-link/1700000000000-AddSocialLinksToUser';
+import { CreateWalletChallenges1711554834000 } from './auth/1711554834000-CreateWalletChallenges';
+import { CreateIdempotencyKeys1711554835000 } from './idempotency/1711554835000-CreateIdempotencyKeys';
+import { AddQueuedAtToModerationFlags1745000000000 } from './moderation/1745000000000-AddQueuedAtToModerationFlags';
+import { CreateReferralTables1745000000000 } from './referral/1745000000000-CreateReferralTables';
+
+export const migrationDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST ?? 'localhost',
+  port: Number(process.env.DB_PORT ?? 5432),
+  username: process.env.DB_USER ?? 'myfans',
+  password: process.env.DB_PASSWORD ?? '',
+  database: process.env.DB_NAME ?? 'myfans',
+  synchronize: false,
+  logging: process.env.MIGRATION_LOG === 'true',
+  migrations: [
+    CreateRefreshTokens1700000000000,
+    AddSocialLinksToUser1700000000000,
+    CreateWalletChallenges1711554834000,
+    CreateIdempotencyKeys1711554835000,
+    AddQueuedAtToModerationFlags1745000000000,
+    CreateReferralTables1745000000000,
+  ],
+});

--- a/backend/test/jest-migrations.json
+++ b/backend/test/jest-migrations.json
@@ -1,0 +1,17 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": "test/migrations\\.integration-spec\\.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/src/$1"
+  },
+  "transformIgnorePatterns": [
+    "node_modules/(?!(uuid|@stellar)/)"
+  ],
+  "testTimeout": 60000,
+  "verbose": true
+}

--- a/backend/test/migrations.integration-spec.ts
+++ b/backend/test/migrations.integration-spec.ts
@@ -1,0 +1,206 @@
+/**
+ * Migration integration test.
+ *
+ * Requires a running Postgres instance. In CI this is provided by the
+ * `postgres` service container defined in .github/workflows/ci.yml.
+ * Locally: `docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=test -e POSTGRES_DB=myfans_test postgres:16-alpine`
+ *
+ * Environment variables (all have defaults matching the CI service):
+ *   DB_HOST     (default: localhost)
+ *   DB_PORT     (default: 5432)
+ *   DB_USER     (default: myfans_ci)
+ *   DB_PASSWORD (default: myfans_ci)
+ *   DB_NAME     (default: myfans_test)
+ */
+import 'reflect-metadata';
+import { DataSource, QueryRunner } from 'typeorm';
+
+// ── Migration classes (same order as migration.datasource.ts) ────────────────
+import { CreateRefreshTokens1700000000000 } from '../src/refresh-module/1700000000000-CreateRefreshTokens';
+import { AddSocialLinksToUser1700000000000 } from '../src/social-link/1700000000000-AddSocialLinksToUser';
+import { CreateWalletChallenges1711554834000 } from '../src/auth/1711554834000-CreateWalletChallenges';
+import { CreateIdempotencyKeys1711554835000 } from '../src/idempotency/1711554835000-CreateIdempotencyKeys';
+import { AddQueuedAtToModerationFlags1745000000000 } from '../src/moderation/1745000000000-AddQueuedAtToModerationFlags';
+import { CreateReferralTables1745000000000 } from '../src/referral/1745000000000-CreateReferralTables';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildDataSource(): DataSource {
+  return new DataSource({
+    type: 'postgres',
+    host: process.env.DB_HOST ?? 'localhost',
+    port: Number(process.env.DB_PORT ?? 5432),
+    username: process.env.DB_USER ?? 'myfans_ci',
+    password: process.env.DB_PASSWORD ?? 'myfans_ci',
+    database: process.env.DB_NAME ?? 'myfans_test',
+    synchronize: false,
+    logging: false,
+    migrations: [
+      CreateRefreshTokens1700000000000,
+      AddSocialLinksToUser1700000000000,
+      CreateWalletChallenges1711554834000,
+      CreateIdempotencyKeys1711554835000,
+      AddQueuedAtToModerationFlags1745000000000,
+      CreateReferralTables1745000000000,
+    ],
+  });
+}
+
+async function tableExists(qr: QueryRunner, table: string): Promise<boolean> {
+  const result = await qr.query(
+    `SELECT 1 FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name = $1`,
+    [table],
+  );
+  return result.length > 0;
+}
+
+async function columnExists(
+  qr: QueryRunner,
+  table: string,
+  column: string,
+): Promise<boolean> {
+  const result = await qr.query(
+    `SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2`,
+    [table, column],
+  );
+  return result.length > 0;
+}
+
+// ── Test suite ────────────────────────────────────────────────────────────────
+
+describe('Database migrations (integration)', () => {
+  let ds: DataSource;
+  let qr: QueryRunner;
+
+  // Increase timeout — real DB operations can be slow in CI
+  jest.setTimeout(60_000);
+
+  beforeAll(async () => {
+    ds = buildDataSource();
+    await ds.initialize();
+    qr = ds.createQueryRunner();
+
+    // Enable uuid-ossp so uuid_generate_v4() works (needed by refresh_tokens)
+    await qr.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
+
+    // Create a minimal `users` table that migrations depend on (FK target).
+    // This mirrors what the ORM would create via synchronize in production.
+    await qr.query(`
+      CREATE TABLE IF NOT EXISTS "users" (
+        "id"            uuid          NOT NULL DEFAULT gen_random_uuid(),
+        "email"         varchar(255)  NOT NULL,
+        "username"      varchar(50)   NOT NULL,
+        "password_hash" varchar(255)  NOT NULL,
+        "first_name"    varchar(100),
+        "last_name"     varchar(100),
+        "created_at"    timestamptz   NOT NULL DEFAULT now(),
+        "updated_at"    timestamptz   NOT NULL DEFAULT now(),
+        "deleted_at"    timestamptz,
+        CONSTRAINT "PK_users" PRIMARY KEY ("id")
+      )
+    `);
+
+    // Create a minimal `moderation_flags` table for the queued_at migration
+    await qr.query(`
+      CREATE TABLE IF NOT EXISTS "moderation_flags" (
+        "id"         uuid        NOT NULL DEFAULT gen_random_uuid(),
+        "created_at" TIMESTAMP   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_moderation_flags" PRIMARY KEY ("id")
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    await qr.release();
+    await ds.destroy();
+  });
+
+  // ── Up migrations ──────────────────────────────────────────────────────────
+
+  it('runs all migrations up without error', async () => {
+    const ran = await ds.runMigrations({ transaction: 'each' });
+    expect(ran.length).toBeGreaterThan(0);
+  });
+
+  it('CreateRefreshTokens: refresh_tokens table exists with expected columns', async () => {
+    expect(await tableExists(qr, 'refresh_tokens')).toBe(true);
+    expect(await columnExists(qr, 'refresh_tokens', 'token_hash')).toBe(true);
+    expect(await columnExists(qr, 'refresh_tokens', 'user_id')).toBe(true);
+    expect(await columnExists(qr, 'refresh_tokens', 'expires_at')).toBe(true);
+  });
+
+  it('AddSocialLinksToUser: social link columns exist on users', async () => {
+    expect(await columnExists(qr, 'users', 'website_url')).toBe(true);
+    expect(await columnExists(qr, 'users', 'twitter_handle')).toBe(true);
+    expect(await columnExists(qr, 'users', 'instagram_handle')).toBe(true);
+    expect(await columnExists(qr, 'users', 'other_link')).toBe(true);
+  });
+
+  it('CreateWalletChallenges: wallet_challenges table exists with expected columns', async () => {
+    expect(await tableExists(qr, 'wallet_challenges')).toBe(true);
+    expect(await columnExists(qr, 'wallet_challenges', 'stellar_address'  )).toBe(false); // camelCase stored as "stellarAddress"
+    expect(await columnExists(qr, 'wallet_challenges', 'stellarAddress')).toBe(true);
+    expect(await columnExists(qr, 'wallet_challenges', 'nonce')).toBe(true);
+    expect(await columnExists(qr, 'wallet_challenges', 'expiresAt')).toBe(true);
+  });
+
+  it('CreateIdempotencyKeys: idempotency_keys table exists with expected columns', async () => {
+    expect(await tableExists(qr, 'idempotency_keys')).toBe(true);
+    expect(await columnExists(qr, 'idempotency_keys', 'key')).toBe(true);
+    expect(await columnExists(qr, 'idempotency_keys', 'fingerprint')).toBe(true);
+    expect(await columnExists(qr, 'idempotency_keys', 'expires_at')).toBe(true);
+  });
+
+  it('AddQueuedAtToModerationFlags: queued_at column exists on moderation_flags', async () => {
+    expect(await columnExists(qr, 'moderation_flags', 'queued_at')).toBe(true);
+  });
+
+  it('CreateReferralTables: referral_codes and referral_redemptions tables exist', async () => {
+    expect(await tableExists(qr, 'referral_codes')).toBe(true);
+    expect(await tableExists(qr, 'referral_redemptions')).toBe(true);
+    expect(await columnExists(qr, 'referral_codes', 'code')).toBe(true);
+    expect(await columnExists(qr, 'referral_redemptions', 'redeemer_id')).toBe(true);
+  });
+
+  it('migrations table records all 6 migrations', async () => {
+    const rows: { name: string }[] = await qr.query(
+      `SELECT name FROM migrations ORDER BY timestamp ASC`,
+    );
+    expect(rows.length).toBe(6);
+  });
+
+  it('running migrations again is idempotent (no-op)', async () => {
+    const ran = await ds.runMigrations({ transaction: 'each' });
+    expect(ran.length).toBe(0);
+  });
+
+  // ── Down migrations (revert all in reverse order) ─────────────────────────
+
+  it('reverts all migrations down without error', async () => {
+    // Revert one at a time in reverse order
+    for (let i = 0; i < 6; i++) {
+      await ds.undoLastMigration({ transaction: true });
+    }
+
+    // All tracked migrations should be gone
+    const rows: { name: string }[] = await qr.query(
+      `SELECT name FROM migrations`,
+    );
+    expect(rows.length).toBe(0);
+  });
+
+  it('referral tables are dropped after revert', async () => {
+    expect(await tableExists(qr, 'referral_codes')).toBe(false);
+    expect(await tableExists(qr, 'referral_redemptions')).toBe(false);
+  });
+
+  it('wallet_challenges table is dropped after revert', async () => {
+    expect(await tableExists(qr, 'wallet_challenges')).toBe(false);
+  });
+
+  it('refresh_tokens table is dropped after revert', async () => {
+    expect(await tableExists(qr, 'refresh_tokens')).toBe(false);
+  });
+});


### PR DESCRIPTION
Problem: the backend CI job had no Postgres service, so TypeORM migrations could never be exercised against a real database.

Changes:
- .github/workflows/ci.yml
  - Add postgres:16-alpine service + DB_* env vars to the existing backend job (unit tests now have a real DB available)
  - Add new backend-migrations job with its own ephemeral Postgres, pg_isready wait, migration integration test run, and explicit migration:run / migration:revert smoke steps

- backend/src/migration.datasource.ts
  - Standalone TypeORM DataSource listing all 6 migrations in timestamp order; reads DB_* env vars; used by runner + tests

- backend/scripts/run-migrations.ts
  - CLI runner: npx ts-node run-migrations.ts [--revert]
  - npm scripts: migration:run, migration:revert

- backend/test/migrations.integration-spec.ts
  - Integration test suite (requires real Postgres)
  - Verifies every migration runs up (table/column existence checks)
  - Verifies idempotency (second runMigrations is a no-op)
  - Verifies every migration rolls back down cleanly
  - 60 s timeout; runs with --runInBand

- backend/test/jest-migrations.json
  - Dedicated Jest config for migration tests (separate from e2e)
  - npm run test:migrations
closes #715 