### PR TITLE
feat(idempotency): document TTL & harden collision behavior

### DIFF
--- a/backend/docs/IDEMPOTENCY.md
+++ b/backend/docs/IDEMPOTENCY.md
@@ -1,0 +1,83 @@
+# Idempotency Middleware — TTL & Collision Behavior
+
+## Overview
+
+The `IdempotencyMiddleware` protects mutating routes (POST, PUT, PATCH) from
+duplicate execution. Clients supply an `Idempotency-Key` header; the platform
+stores the first response and replays it for any subsequent request carrying the
+same key.
+
+---
+
+## Key TTL
+
+| Setting | Value | Source |
+|---------|-------|--------|
+| Default TTL | **24 hours** | Hard-coded constant `DEFAULT_TTL_MS` |
+| Override | Set `IDEMPOTENCY_TTL_HOURS` env var | Read at service startup |
+
+**Rationale:** 24 hours matches the JWT access-token lifetime so a key cannot
+outlive the session that created it. After expiry the record is deleted by the
+hourly cleanup cron (`IdempotencyCleanupService`) and the key may be reused.
+
+**Cleanup:** `IdempotencyCleanupService` runs `@Cron(EVERY_HOUR)` and calls
+`IdempotencyService.purgeExpired()`, which issues a single `DELETE WHERE
+expires_at < NOW()`.
+
+---
+
+## Collision / Replay Behavior
+
+A "collision" occurs when a client sends a second request with the same
+`Idempotency-Key`. The middleware distinguishes four cases:
+
+| State of existing record | Action |
+|--------------------------|--------|
+| **No record** | Insert in-flight record; proceed to handler. |
+| **In-flight** (`is_complete = false`, not expired) | Return **409 Conflict** — first request still processing. |
+| **Complete** (`is_complete = true`, not expired) — same method + path | Return **200/201** replay of cached response body. |
+| **Complete** — **different** method or path | Return **422 Unprocessable Entity** — key reuse across endpoints is forbidden. |
+| **Expired** (any state) | Delete stale record; treat as new key. |
+
+### Key scoping
+
+Keys are scoped to a `(key, fingerprint)` pair where `fingerprint` is:
+
+- `user:<userId>` — when the request is authenticated.
+- `ip:<clientIp>` — for unauthenticated requests.
+
+This prevents one user from replaying another user's key.
+
+### Race condition
+
+Two concurrent requests with the same key arrive simultaneously. The first
+writer wins via a PostgreSQL unique constraint on `(key, fingerprint)`. The
+loser receives a `23505` unique-violation error which is mapped to **409
+Conflict**.
+
+### Error responses
+
+On non-2xx handler responses the in-flight record is **deleted** (via
+`release()`), allowing the client to retry with the same key after fixing the
+underlying issue.
+
+---
+
+## Configuration
+
+```
+IDEMPOTENCY_TTL_HOURS=24   # optional; defaults to 24
+```
+
+---
+
+## Manual Checklist (Replay Hardening)
+
+1. Send `POST /v1/posts` with `Idempotency-Key: test-1` → expect `201`.
+2. Repeat identical request → expect `201` with same body (replay).
+3. Send `PUT /v1/posts/1` with `Idempotency-Key: test-1` → expect `422`
+   (method/path mismatch).
+4. Send two concurrent requests with `Idempotency-Key: test-2` → one gets
+   `201`, the other gets `409`.
+5. Wait for TTL expiry (or manually delete the record) → same key accepted
+   again as new.

--- a/backend/src/idempotency/idempotency.middleware.spec.ts
+++ b/backend/src/idempotency/idempotency.middleware.spec.ts
@@ -182,4 +182,21 @@ describe('IdempotencyMiddleware', () => {
       '/v1/posts',
     );
   });
+
+  it('re-throws UnprocessableEntityException on method/path mismatch', async () => {
+    svc.acquire.mockRejectedValue(
+      new UnprocessableEntityException('key reused on different endpoint'),
+    );
+
+    const req = buildReq({
+      headers: { [IDEMPOTENCY_KEY_HEADER]: 'key-mismatch' },
+    });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await expect(
+      middleware.use(req as Request, res as Response, next),
+    ).rejects.toThrow(UnprocessableEntityException);
+    expect(next).not.toHaveBeenCalled();
+  });
 });

--- a/backend/src/idempotency/idempotency.middleware.ts
+++ b/backend/src/idempotency/idempotency.middleware.ts
@@ -57,8 +57,11 @@ export class IdempotencyMiddleware implements NestMiddleware {
         return;
       }
     } catch (err) {
-      if (err instanceof ConflictException) {
-        // Re-throw so NestJS exception filters handle it correctly.
+      // Re-throw known client errors so NestJS exception filters handle them.
+      if (
+        err instanceof ConflictException ||
+        err instanceof UnprocessableEntityException
+      ) {
         throw err;
       }
       throw err;

--- a/backend/src/idempotency/idempotency.service.spec.ts
+++ b/backend/src/idempotency/idempotency.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, UnprocessableEntityException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { IdempotencyService } from './idempotency.service';
 import { IdempotencyKey } from './idempotency-key.entity';
@@ -54,6 +54,8 @@ describe('IdempotencyService', () => {
         fingerprint: FP,
         is_complete: true,
         expires_at: future,
+        method: METHOD,
+        path: PATH,
         response_status: 201,
         response_body: JSON.stringify({ id: '42' }),
       });
@@ -115,6 +117,59 @@ describe('IdempotencyService', () => {
       await expect(service.acquire(KEY, FP, METHOD, PATH)).rejects.toThrow(
         'DB connection lost',
       );
+    });
+
+    it('throws UnprocessableEntityException when key is reused on a different method', async () => {
+      const future = new Date(Date.now() + 60_000);
+      repo.findOne.mockResolvedValue({
+        key: KEY,
+        fingerprint: FP,
+        is_complete: true,
+        expires_at: future,
+        method: 'POST',
+        path: PATH,
+        response_status: 201,
+        response_body: JSON.stringify({ id: '1' }),
+      });
+
+      await expect(
+        service.acquire(KEY, FP, 'PUT', PATH),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('throws UnprocessableEntityException when key is reused on a different path', async () => {
+      const future = new Date(Date.now() + 60_000);
+      repo.findOne.mockResolvedValue({
+        key: KEY,
+        fingerprint: FP,
+        is_complete: true,
+        expires_at: future,
+        method: METHOD,
+        path: '/v1/other',
+        response_status: 201,
+        response_body: JSON.stringify({ id: '1' }),
+      });
+
+      await expect(
+        service.acquire(KEY, FP, METHOD, PATH),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('replays response when method and path match the original', async () => {
+      const future = new Date(Date.now() + 60_000);
+      repo.findOne.mockResolvedValue({
+        key: KEY,
+        fingerprint: FP,
+        is_complete: true,
+        expires_at: future,
+        method: METHOD,
+        path: PATH,
+        response_status: 201,
+        response_body: JSON.stringify({ id: '99' }),
+      });
+
+      const result = await service.acquire(KEY, FP, METHOD, PATH);
+      expect(result).toEqual({ status: 201, body: { id: '99' } });
     });
   });
 

--- a/backend/src/idempotency/idempotency.service.ts
+++ b/backend/src/idempotency/idempotency.service.ts
@@ -2,6 +2,7 @@ import {
   ConflictException,
   Injectable,
   Logger,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { LessThan, Repository } from 'typeorm';
@@ -12,8 +13,12 @@ export interface CachedResponse {
   body: unknown;
 }
 
-/** Default TTL: 24 hours (matches JWT expiry). */
-const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+/**
+ * Default TTL: 24 hours (matches JWT expiry).
+ * Override via IDEMPOTENCY_TTL_HOURS environment variable.
+ */
+const DEFAULT_TTL_MS =
+  parseInt(process.env.IDEMPOTENCY_TTL_HOURS ?? '24', 10) * 60 * 60 * 1000;
 
 @Injectable()
 export class IdempotencyService {
@@ -53,7 +58,14 @@ export class IdempotencyService {
           'A request with this Idempotency-Key is already being processed. Please wait and retry.',
         );
       } else {
-        // Completed — replay cached response.
+        // Completed — guard against key reuse across different endpoints.
+        if (existing.method !== method || existing.path !== path) {
+          throw new UnprocessableEntityException(
+            `Idempotency-Key "${key}" was already used for ${existing.method} ${existing.path}. ` +
+              `It cannot be reused for ${method} ${path}.`,
+          );
+        }
+        // Replay cached response.
         return {
           status: existing.response_status!,
           body: existing.response_body ? JSON.parse(existing.response_body) : null,


### PR DESCRIPTION
- Add docs/IDEMPOTENCY.md: TTL config, collision table, manual checklist
- Env-driven TTL via IDEMPOTENCY_TTL_HOURS (default 24h)
- Guard against key reuse across different method/path (422)
- Middleware re-throws UnprocessableEntityException alongside ConflictException
- Tests: 4 new cases (method mismatch, path mismatch, same-endpoint replay, middleware mismatch re-throw)
- Fix existing replay fixture to include method+path fields
closes #591 