### PR TITLE
test(treasury): granular mock_auths for initialize/deposit/withdraw auth

### DIFF
--- a/contract/contracts/treasury/src/test.rs
+++ b/contract/contracts/treasury/src/test.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{
     testutils::{Address as _, Events, MockAuth, MockAuthInvoke},
     token::{StellarAssetClient, TokenClient},
     xdr::SorobanAuthorizationEntry,
-    Address, Env, IntoVal, Symbol, TryIntoVal,
+    Address, Env, Error as SorobanError, IntoVal, Symbol, TryIntoVal,
 };
 
 fn create_token_contract<'a>(
@@ -320,4 +320,116 @@ fn test_deposit_emits_event() {
     assert_eq!(from, user);
     assert_eq!(amount, 500);
     assert_eq!(token, token_address);
+}
+
+/// Asserts exact auth requirements using only `mock_auths` (no `mock_all_auths`):
+///   - `initialize` requires admin auth
+///   - `deposit` requires from (user) auth
+///   - `withdraw` requires admin auth
+///   - unauthorized `withdraw` (no auth) fails
+#[test]
+fn test_mock_auths_granular_auth_requirements() {
+    let env = Env::default();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let unauthorized = Address::generate(&env);
+
+    let (token_address, token_client, admin_client) = create_token_contract(&env, &admin);
+    let treasury_id = env.register_contract(None, Treasury);
+    let treasury_client = TreasuryClient::new(&env, &treasury_id);
+
+    // --- token mint: admin auth ---
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &token_address,
+            fn_name: "mint",
+            args: soroban_sdk::vec![&env, user.clone().into_val(&env), 1000_i128.into_val(&env)],
+            sub_invokes: &[],
+        },
+    }]);
+    admin_client.mint(&user, &1000);
+
+    // --- initialize: requires admin auth ---
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &treasury_id,
+            fn_name: "initialize",
+            args: soroban_sdk::vec![
+                &env,
+                admin.clone().into_val(&env),
+                token_address.clone().into_val(&env),
+            ],
+            sub_invokes: &[],
+        },
+    }]);
+    treasury_client.initialize(&admin, &token_address);
+
+    // --- deposit: requires from (user) auth; sub-invokes token transfer ---
+    let deposit_amount = 600_i128;
+    env.mock_auths(&[MockAuth {
+        address: &user,
+        invoke: &MockAuthInvoke {
+            contract: &treasury_id,
+            fn_name: "deposit",
+            args: soroban_sdk::vec![
+                &env,
+                user.clone().into_val(&env),
+                deposit_amount.into_val(&env),
+            ],
+            sub_invokes: &[MockAuthInvoke {
+                contract: &token_address,
+                fn_name: "transfer",
+                args: soroban_sdk::vec![
+                    &env,
+                    user.clone().into_val(&env),
+                    treasury_id.clone().into_val(&env),
+                    deposit_amount.into_val(&env),
+                ],
+                sub_invokes: &[],
+            }],
+        },
+    }]);
+    treasury_client.deposit(&user, &deposit_amount);
+
+    assert_eq!(token_client.balance(&treasury_id), 600);
+    assert_eq!(token_client.balance(&user), 400);
+
+    // --- withdraw: requires admin auth ---
+    let withdraw_amount = 100_i128;
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &treasury_id,
+            fn_name: "withdraw",
+            args: soroban_sdk::vec![
+                &env,
+                user.clone().into_val(&env),
+                withdraw_amount.into_val(&env),
+            ],
+            sub_invokes: &[MockAuthInvoke {
+                contract: &token_address,
+                fn_name: "transfer",
+                args: soroban_sdk::vec![
+                    &env,
+                    treasury_id.clone().into_val(&env),
+                    user.clone().into_val(&env),
+                    withdraw_amount.into_val(&env),
+                ],
+                sub_invokes: &[],
+            }],
+        },
+    }]);
+    treasury_client.withdraw(&user, &withdraw_amount);
+
+    assert_eq!(token_client.balance(&treasury_id), 500);
+    assert_eq!(token_client.balance(&user), 500);
+
+    // --- unauthorized withdraw: no auth set → must fail ---
+    let empty: &[soroban_sdk::xdr::SorobanAuthorizationEntry] = &[];
+    env.set_auths(empty);
+    let result = treasury_client.try_withdraw(&unauthorized, &50);
+    assert!(result.is_err(), "unauthorized withdraw must fail");
 }


### PR DESCRIPTION
Per ISSUES.md item 1:
- Fix missing SorobanError import that broke treasury test compilation
- Add test_mock_auths_granular_auth_requirements: uses only mock_auths (no mock_all_auths) to assert exact auth requirements:
    * initialize requires admin auth
    * deposit requires from (user) auth with token transfer sub-invoke
    * withdraw requires admin auth
    * unauthorized withdraw (set_auths(&[])) fails
- All 11 treasury tests pass
closes #601 