### PR TITLE
chore: add CODEOWNERS for contract/ and backend/ (#721)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS – route reviews to the right team automatically.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Soroban smart contract (Rust) – contract team reviews all changes under contract/
+/contract/ @MyFanss/contract
+
+# Nest.js backend – backend team reviews all changes under backend/
+/backend/ @MyFanss/backend


### PR DESCRIPTION
Changes made:                                                                  
                                                                                 
  - Created .github/CODEOWNERS with two rules:                                   
    - /contract/ → @MyFanss/contract (Soroban/Rust team)                         
    - /backend/ → @MyFanss/backend (Nest.js team)                                
                                                                                 
  Git:                                                                           
                                                                                 
  - Synced with origin/main (was already up to date)                             
  - Branch feature/721-codeowners created and pushed                             
  - PR link: https://github.com/abrak01/MyFans/pull/new/feature/721-codeowners   
   (https://github.com/abrak01/MyFans/pull/new/feature/721-codeowners)           
                                                                                 
  Next steps before merging:                                                     
                                                                                 
  1. Make sure the GitHub teams MyFanss/contract and MyFanss/backend exist in    
  your org — if you use individual usernames instead, swap them in (e.g.         
  2. In repo settings → Branches, enable "Require review from Code Owners" on the
  main branch protection rule to enforce the reviews in CI.                      
  3. Open the PR and close issue #721.                                           
─────────────────────────────────────────────────────────────────────────────────
  write a clean PR description                                                   
                                                                                 
  Here's a clean PR description you can paste into GitHub:                       
                                                                                 
  ───────────────────────────────────────────────────────────────────────────────
                                                                                 
  chore: add CODEOWNERS for `contract/` and `backend/` (#721)                    
                                                                                 
  Routes PR reviews automatically to the right team.                             
                                                                                 
  What changed                                                                   
                                                                                 
  - Added .github/CODEOWNERS                                                     
  - /contract/ → @MyFanss/contract (Soroban/Rust)                                
  - /backend/ → @MyFanss/backend (Nest.js)                                       
                                                                                 
  How to verify                                                                  
                                                                                 
  1. Open any PR that touches contract/ or backend/ — the respective team should 
  be auto-requested as reviewer.                                                 
  2. Confirm "Require review from Code Owners" is enabled under Settings →       
  Branches → main protection rule.                                               
                                                                                 
  Notes                                                                          
                                                                                 
  - frontend/ is intentionally unowned for now; add a rule when a frontend team  
  is defined.                                                                    
  - No runtime behavior changed; no tests required.                              
                                                                                 
  Closes #721