### PR TITLE
feat(backend): add getLatestLedgerSequence & getNetworkEvents to Soro…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -104,3 +104,5 @@ CORS_ALLOWED_HOSTS=myfans.example.com,www.myfans.example.com
 FEATURE_NEW_SUBSCRIPTION_FLOW=false
 FEATURE_CRYPTO_PAYMENTS=false
 FEATURE_REFERRAL_CODES=false
+# Set to "false" to disable the Soroban event poller (enabled by default).
+FEATURE_SOROBAN_POLLER=true

--- a/backend/src/common/services/soroban-rpc-ledger-events.spec.ts
+++ b/backend/src/common/services/soroban-rpc-ledger-events.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for SorobanRpcService.getLatestLedgerSequence
+ * and SorobanRpcService.getNetworkEvents
+ */
+import { SorobanRpcService } from './soroban-rpc.service';
+
+function makeService(serverOverrides: Record<string, jest.Mock> = {}): SorobanRpcService {
+  const svc = new SorobanRpcService();
+  (svc as any).server = {
+    getHealth: jest.fn().mockResolvedValue({ status: 'healthy', ledger: 1000 }),
+    getEvents: jest.fn().mockResolvedValue({ events: [], latestLedger: 1000 }),
+    ...serverOverrides,
+  };
+  return svc;
+}
+
+describe('SorobanRpcService – getLatestLedgerSequence', () => {
+  it('returns the ledger number from getHealth', async () => {
+    const svc = makeService({ getHealth: jest.fn().mockResolvedValue({ status: 'healthy', ledger: 42 }) });
+    await expect(svc.getLatestLedgerSequence()).resolves.toBe(42);
+  });
+
+  it('throws when server is null', async () => {
+    const svc = makeService();
+    (svc as any).server = null;
+    await expect(svc.getLatestLedgerSequence()).rejects.toThrow('server not initialized');
+  });
+
+  it('throws when getHealth rejects', async () => {
+    const svc = makeService({ getHealth: jest.fn().mockRejectedValue(new Error('network error')) });
+    await expect(svc.getLatestLedgerSequence()).rejects.toThrow('network error');
+  });
+
+  it('throws when ledger field is missing or zero', async () => {
+    const svc = makeService({ getHealth: jest.fn().mockResolvedValue({ status: 'healthy' }) });
+    await expect(svc.getLatestLedgerSequence()).rejects.toThrow('invalid ledger sequence');
+  });
+});
+
+describe('SorobanRpcService – getNetworkEvents', () => {
+  it('returns events and latestLedger from getEvents', async () => {
+    const fakeEvents = [{ id: '100:0', topic: [], value: {} }];
+    const svc = makeService({
+      getEvents: jest.fn().mockResolvedValue({ events: fakeEvents, latestLedger: 200 }),
+    });
+    const result = await svc.getNetworkEvents({ startLedger: 100 });
+    expect(result.events).toEqual(fakeEvents);
+    expect(result.latestLedger).toBe(200);
+    expect(result.nextToken).toBeUndefined();
+  });
+
+  it('passes limit and cursor to getEvents', async () => {
+    const getEvents = jest.fn().mockResolvedValue({ events: [], latestLedger: 300 });
+    const svc = makeService({ getEvents });
+    await svc.getNetworkEvents({ startLedger: 50, limit: 10, paginationToken: 'tok' });
+    expect(getEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ startLedger: 50, limit: 10, cursor: 'tok' }),
+    );
+  });
+
+  it('returns empty events array when getEvents returns undefined events', async () => {
+    const svc = makeService({ getEvents: jest.fn().mockResolvedValue({ latestLedger: 100 }) });
+    const result = await svc.getNetworkEvents({ startLedger: 1 });
+    expect(result.events).toEqual([]);
+  });
+
+  it('throws when server is null', async () => {
+    const svc = makeService();
+    (svc as any).server = null;
+    await expect(svc.getNetworkEvents({ startLedger: 1 })).rejects.toThrow('server not initialized');
+  });
+
+  it('throws when getEvents rejects', async () => {
+    const svc = makeService({ getEvents: jest.fn().mockRejectedValue(new Error('rpc down')) });
+    await expect(svc.getNetworkEvents({ startLedger: 1 })).rejects.toThrow('rpc down');
+  });
+});

--- a/backend/src/common/services/soroban-rpc.service.ts
+++ b/backend/src/common/services/soroban-rpc.service.ts
@@ -418,4 +418,65 @@ export class SorobanRpcService {
     getRetryConfig(): RetryConfig {
         return { ...this.retryConfig };
     }
+
+    /**
+     * Returns the latest ledger sequence number from the Soroban RPC node.
+     * Throws on network failure so callers can decide how to handle stale state.
+     */
+    async getLatestLedgerSequence(): Promise<number> {
+        if (!this.server) {
+            throw new Error('SorobanRpcService: server not initialized');
+        }
+        try {
+            const health = await (this.server as rpc.Server).getHealth();
+            const seq = (health as rpc.Api.GetHealthResponse & { ledger?: number }).ledger;
+            if (typeof seq !== 'number' || seq <= 0) {
+                throw new Error('SorobanRpcService: invalid ledger sequence in health response');
+            }
+            return seq;
+        } catch (err) {
+            this.logger.error(`getLatestLedgerSequence failed: ${err}`);
+            throw err;
+        }
+    }
+
+    /**
+     * Fetches contract events from the Soroban RPC node.
+     *
+     * @param startLedger  First ledger to include (inclusive).
+     * @param limit        Max events per page (default 200, max 10 000).
+     * @param paginationToken  Opaque cursor returned by a previous call.
+     */
+    async getNetworkEvents(opts: {
+        startLedger: number;
+        limit?: number;
+        paginationToken?: string;
+    }): Promise<{
+        events: rpc.Api.EventResponse[];
+        startLedger: number;
+        latestLedger: number;
+        nextToken?: string;
+    }> {
+        if (!this.server) {
+            throw new Error('SorobanRpcService: server not initialized');
+        }
+        const { startLedger, limit = 200, paginationToken } = opts;
+        try {
+            const response = await (this.server as rpc.Server).getEvents({
+                startLedger,
+                filters: [],
+                limit,
+                ...(paginationToken ? { cursor: paginationToken } : {}),
+            });
+            return {
+                events: response.events ?? [],
+                startLedger: response.latestLedger,   // Soroban SDK field
+                latestLedger: response.latestLedger,
+                nextToken: (response as any).cursor ?? undefined,
+            };
+        } catch (err) {
+            this.logger.error(`getNetworkEvents failed (startLedger=${startLedger}): ${err}`);
+            throw err;
+        }
+    }
 }

--- a/backend/src/feature-flags/feature-flags.service.ts
+++ b/backend/src/feature-flags/feature-flags.service.ts
@@ -14,11 +14,16 @@ export class FeatureFlagsService {
     return process.env.FEATURE_REFERRAL_CODES === 'true';
   }
 
+  isSorobanPollerEnabled(): boolean {
+    return process.env.FEATURE_SOROBAN_POLLER !== 'false';
+  }
+
   getAllFlags() {
     return {
       newSubscriptionFlow: this.isNewSubscriptionFlowEnabled(),
       cryptoPayments: this.isCryptoPaymentsEnabled(),
       referralCodes: this.isReferralCodesEnabled(),
+      sorobanPoller: this.isSorobanPollerEnabled(),
     };
   }
 }

--- a/backend/src/subscriptions/services/subscription-event-poller-ledger.spec.ts
+++ b/backend/src/subscriptions/services/subscription-event-poller-ledger.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for SubscriptionEventPollerService:
+ *  - feature flag disables polling
+ *  - stale / disconnected RPC is handled gracefully (no throw)
+ *  - typed methods are called (no any-cast)
+ */
+import { SubscriptionEventPollerService } from './subscription-event-poller.service';
+import { RequestContextService } from '../../common/services/request-context.service';
+
+function makePoller(overrides: {
+  pollerEnabled?: boolean;
+  getLatestLedgerSequence?: () => Promise<number>;
+  getNetworkEvents?: () => Promise<any>;
+  checkpoint?: number;
+}) {
+  const requestContext = new RequestContextService();
+
+  const featureFlags = {
+    isSorobanPollerEnabled: jest.fn().mockReturnValue(overrides.pollerEnabled ?? true),
+  };
+
+  const indexRepo = {
+    getLatestCheckpoint: jest.fn().mockResolvedValue(overrides.checkpoint ?? 0),
+    findByEventId: jest.fn().mockResolvedValue(null),
+    upsertEvent: jest.fn().mockResolvedValue({ id: '1', eventType: 'subscribed', fan: 'A', creator: 'B', planId: 0, expiryUnix: 9999999999 }),
+  };
+
+  const sorobanRpc = {
+    getLatestLedgerSequence: jest.fn().mockImplementation(
+      overrides.getLatestLedgerSequence ?? (() => Promise.resolve(0)),
+    ),
+    getNetworkEvents: jest.fn().mockImplementation(
+      overrides.getNetworkEvents ?? (() => Promise.resolve({ events: [], startLedger: 0, latestLedger: 0 })),
+    ),
+  };
+
+  const eventBus = { publish: jest.fn() };
+
+  const svc = new (SubscriptionEventPollerService as any)(
+    { get: () => 'CONTRACT_ID' },
+    indexRepo,
+    eventBus,
+    sorobanRpc,
+    requestContext,
+    featureFlags,
+  ) as SubscriptionEventPollerService;
+
+  (svc as any).contractId = 'CONTRACT_ID';
+
+  return { svc, sorobanRpc, indexRepo, featureFlags, eventBus };
+}
+
+describe('SubscriptionEventPollerService – feature flag', () => {
+  it('skips poll when isSorobanPollerEnabled returns false', async () => {
+    const { svc, sorobanRpc } = makePoller({ pollerEnabled: false });
+    await svc.poll();
+    expect(sorobanRpc.getLatestLedgerSequence).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when isSorobanPollerEnabled returns true', async () => {
+    const { svc, sorobanRpc } = makePoller({ pollerEnabled: true, checkpoint: 5 });
+    // latest == checkpoint → early return, but RPC was still called
+    sorobanRpc.getLatestLedgerSequence.mockResolvedValue(5);
+    await svc.poll();
+    expect(sorobanRpc.getLatestLedgerSequence).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SubscriptionEventPollerService – stale / disconnected RPC', () => {
+  it('does not throw when getLatestLedgerSequence rejects', async () => {
+    const { svc, sorobanRpc } = makePoller({
+      getLatestLedgerSequence: () => Promise.reject(new Error('connection refused')),
+    });
+    await expect(svc.poll()).resolves.toBeUndefined();
+    expect(sorobanRpc.getNetworkEvents).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when getNetworkEvents rejects mid-page', async () => {
+    const { svc, sorobanRpc } = makePoller({
+      getLatestLedgerSequence: () => Promise.resolve(100),
+      getNetworkEvents: () => Promise.reject(new Error('rpc timeout')),
+      checkpoint: 50,
+    });
+    await expect(svc.poll()).resolves.toBeUndefined();
+  });
+
+  it('uses typed getLatestLedgerSequence (not any-cast)', async () => {
+    const { svc, sorobanRpc } = makePoller({ checkpoint: 10 });
+    sorobanRpc.getLatestLedgerSequence.mockResolvedValue(10); // no new ledgers
+    await svc.poll();
+    // Verify the real method was called, not a dynamic property
+    expect(sorobanRpc.getLatestLedgerSequence).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/subscriptions/services/subscription-event-poller.service.ts
+++ b/backend/src/subscriptions/services/subscription-event-poller.service.ts
@@ -14,8 +14,9 @@ import { v4 as uuidv4 } from 'uuid';
 import { resolveSubscriptionContractId } from '../../common/contract-deployed-env';
 import { SubscriptionIndexEntity, SubscriptionStatus } from '../entities/subscription-index.entity';
 import { SubscriptionIndexRepository, UpsertEventData } from '../repositories/subscription-index.repository';
-import { SorobanRpcService } from '../../common/services/soroban-rpc.service'; // Assumed to exist
+import { SorobanRpcService } from '../../common/services/soroban-rpc.service';
 import { RequestContextService } from '../../common/services/request-context.service';
+import { FeatureFlagsService } from '../../feature-flags/feature-flags.service';
 
 const TARGET_EVENTS = ['subscribed', 'extended', 'cancelled'] as const;
 type TargetEventType = typeof TARGET_EVENTS[number];
@@ -31,6 +32,7 @@ export class SubscriptionEventPollerService implements OnModuleInit {
     private readonly eventBus: EventBus,
     private readonly sorobanRpc: SorobanRpcService,
     private readonly requestContext: RequestContextService,
+    private readonly featureFlags: FeatureFlagsService,
   ) {}
 
   async onModuleInit() {
@@ -68,14 +70,25 @@ export class SubscriptionEventPollerService implements OnModuleInit {
   }
 
   private async _poll(): Promise<void> {
+    if (!this.featureFlags.isSorobanPollerEnabled()) {
+      this.logger.debug('Soroban poller disabled via feature flag; skipping.');
+      return;
+    }
+
     const startTime = Date.now();
     let processed = 0;
     let errors = 0;
 
     try {
       const checkpoint = await this.indexRepo.getLatestCheckpoint();
-      const latestLedger = await (this.sorobanRpc as any).getLatestLedgerSequence();
-      
+      let latestLedger: number;
+      try {
+        latestLedger = await this.sorobanRpc.getLatestLedgerSequence();
+      } catch (rpcErr) {
+        this.logger.warn(`getLatestLedgerSequence failed – skipping poll cycle: ${rpcErr}`);
+        return;
+      }
+
       if (latestLedger <= checkpoint) {
         this.logger.debug(`No new ledgers (checkpoint: ${checkpoint}, latest: ${latestLedger})`);
         return;
@@ -84,11 +97,17 @@ export class SubscriptionEventPollerService implements OnModuleInit {
       // Paginated fetch from checkpoint+1
       let cursor: string | undefined;
       do {
-          const eventsResponse = await (this.sorobanRpc as any).getNetworkEvents({
-          startLedger: checkpoint + 1,
-          limit: 200,
-          paginationToken: cursor,
-        });
+        let eventsResponse: Awaited<ReturnType<SorobanRpcService['getNetworkEvents']>>;
+        try {
+          eventsResponse = await this.sorobanRpc.getNetworkEvents({
+            startLedger: checkpoint + 1,
+            limit: 200,
+            paginationToken: cursor,
+          });
+        } catch (rpcErr) {
+          this.logger.warn(`getNetworkEvents failed – aborting page fetch: ${rpcErr}`);
+          break;
+        }
 
         const events = eventsResponse.events ?? [];
         this.logger.debug(`Fetched ${events.length} events from ${eventsResponse.startLedger}-${eventsResponse.latestLedger}`);

--- a/backend/src/subscriptions/subscriptions.module.ts
+++ b/backend/src/subscriptions/subscriptions.module.ts
@@ -4,6 +4,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { ConfigModule } from '@nestjs/config';
 import { LoggingModule } from '../common/logging.module';
 import { EventsModule } from '../events/events.module';
+import { FeatureFlagsModule } from '../feature-flags/feature-flags.module';
 import { SubscriptionLifecycleIndexerController } from './subscription-lifecycle-indexer.controller';
 import { SubscriptionLifecycleIndexerService } from './subscription-lifecycle-indexer.service';
 import { SubscriptionIndexEntity } from './entities/subscription-index.entity';
@@ -28,8 +29,9 @@ import { LedgerClockService } from './ledger-clock.service';
     ConfigModule,
     ScheduleModule,
     TypeOrmModule.forFeature([SubscriptionIndexEntity, FanSpendingCapEntity]),
-    EventsModule, 
+    EventsModule,
     LoggingModule,
+    FeatureFlagsModule,
   ],
   controllers: [SubscriptionsController, SpendingCapController, SubscriptionLifecycleIndexerController],
   providers: [


### PR DESCRIPTION
## Summary

### Changes
- SorobanRpcService – adds getLatestLedgerSequence() and getNetworkEvents() with typed return shapes. Both throw on RPC failure so callers control recovery.
- FeatureFlagsService – adds isSorobanPollerEnabled() (opt-out: enabled by default, set FEATURE_SOROBAN_POLLER=false to disable).
- SubscriptionEventPollerService – replaces (this.sorobanRpc as any) casts with typed calls; skips poll when flag is off; handles stale/disconnected RPC gracefully (warn + return, no throw).
- SubscriptionsModule – imports FeatureFlagsModule.
- backend/.env.example – documents FEATURE_SOROBAN_POLLER=true.

### Tests added
- soroban-rpc-ledger-events.spec.ts (9 cases)
- subscription-event-poller-ledger.spec.ts (5 cases)

### Acceptance criteria
- [x] getLatestLedgerSequence and getNetworkEvents implemented and typed
- [x] Poller uses typed methods (no any cast)
- [x] Poller skippable via FEATURE_SOROBAN_POLLER=false
- [x] Stale / disconnected RPC handled gracefully
- [x] Unit tests cover all new paths
closes #579 