### PR TITLE
fix(backend): use SDK discriminated unions for simulate responses in …

### DIFF
--- a/backend/src/subscriptions/subscription-chain-reader.service.spec.ts
+++ b/backend/src/subscriptions/subscription-chain-reader.service.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for SubscriptionChainReaderService simulation typing.
+ *
+ * Covers every branch of the SDK discriminated union:
+ *   SimulateTransactionErrorResponse   → isSimulationError
+ *   SimulateTransactionSuccessResponse → isSimulationSuccess
+ *   SimulateTransactionRestoreResponse → isSimulationRestore
+ *
+ * Also verifies graceful handling of: network errors, missing retval,
+ * and the restore (archived entry) path.
+ */
+import { rpc, xdr, nativeToScVal } from '@stellar/stellar-sdk';
+import { SubscriptionChainReaderService } from './subscription-chain-reader.service';
+import { LedgerClockService } from './ledger-clock.service';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const CONTRACT_ID = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+const FAN     = 'GFAN1111111111111111111111111111111111111111111111111111';
+const CREATOR = 'GCREATOR111111111111111111111111111111111111111111111111';
+
+function makeService(simResult: rpc.Api.SimulateTransactionResponse): SubscriptionChainReaderService {
+  const ledgerClock = {
+    fetchSnapshot: jest.fn().mockResolvedValue({
+      ledgerSeq: 1000,
+      ledgerCloseTimeUnix: 1_700_000_000,
+      capturedAtMs: 1_700_000_000_000,
+      skewMs: -200,
+    }),
+    ledgerSeqToUnix: jest.fn().mockReturnValue(1_700_000_000 + 30 * 24 * 3600),
+  } as unknown as LedgerClockService;
+
+  const svc = new SubscriptionChainReaderService(ledgerClock);
+
+  // Stub the private makeServer() so no real network call is made
+  jest.spyOn(svc as any, 'makeServer').mockReturnValue({
+    simulateTransaction: jest.fn().mockResolvedValue(simResult),
+  });
+
+  return svc;
+}
+
+/** Build a minimal success response */
+function successSim(retval: xdr.ScVal): rpc.Api.SimulateTransactionSuccessResponse {
+  return {
+    _parsed: true,
+    id: '1',
+    latestLedger: 1000,
+    events: [],
+    transactionData: {} as any,
+    minResourceFee: '100',
+    result: { auth: [], retval },
+  } as rpc.Api.SimulateTransactionSuccessResponse;
+}
+
+/** Build a minimal error response */
+function errorSim(error: string): rpc.Api.SimulateTransactionErrorResponse {
+  return {
+    _parsed: true,
+    id: '1',
+    latestLedger: 1000,
+    events: [],
+    error,
+  } as rpc.Api.SimulateTransactionErrorResponse;
+}
+
+/** Build a minimal restore response */
+function restoreSim(): rpc.Api.SimulateTransactionRestoreResponse {
+  return {
+    _parsed: true,
+    id: '1',
+    latestLedger: 1000,
+    events: [],
+    transactionData: {} as any,
+    minResourceFee: '100',
+    result: { auth: [], retval: nativeToScVal(true) },
+    restorePreamble: { minResourceFee: '200', transactionData: {} as any },
+  } as rpc.Api.SimulateTransactionRestoreResponse;
+}
+
+// ── readIsSubscriber ──────────────────────────────────────────────────────────
+
+describe('SubscriptionChainReaderService.readIsSubscriber', () => {
+  it('returns ok=true isSubscriber=true on success sim with true retval', async () => {
+    const svc = makeService(successSim(nativeToScVal(true)));
+    const result = await svc.readIsSubscriber(CONTRACT_ID, FAN, CREATOR);
+    expect(result).toEqual({ ok: true, isSubscriber: true });
+  });
+
+  it('returns ok=true isSubscriber=false on success sim with false retval', async () => {
+    const svc = makeService(successSim(nativeToScVal(false)));
+    const result = await svc.readIsSubscriber(CONTRACT_ID, FAN, CREATOR);
+    expect(result).toEqual({ ok: true, isSubscriber: false });
+  });
+
+  it('returns ok=false with error string on error sim', async () => {
+    const svc = makeService(errorSim('contract not found'));
+    const result = await svc.readIsSubscriber(CONTRACT_ID, FAN, CREATOR);
+    expect(result.ok).toBe(false);
+    expect((result as any).error).toMatch(/contract not found/i);
+  });
+
+  it('returns ok=false with restore message on restore sim', async () => {
+    const svc = makeService(restoreSim());
+    const result = await svc.readIsSubscriber(CONTRACT_ID, FAN, CREATOR);
+    expect(result.ok).toBe(false);
+    expect((result as any).error).toMatch(/restoration/i);
+  });
+
+  it('returns ok=false when simulateTransaction rejects (network error)', async () => {
+    const svc = new SubscriptionChainReaderService({
+      fetchSnapshot: jest.fn(),
+      ledgerSeqToUnix: jest.fn(),
+    } as unknown as LedgerClockService);
+    jest.spyOn(svc as any, 'makeServer').mockReturnValue({
+      simulateTransaction: jest.fn().mockRejectedValue(new Error('connection refused')),
+    });
+    const result = await svc.readIsSubscriber(CONTRACT_ID, FAN, CREATOR);
+    expect(result.ok).toBe(false);
+    expect((result as any).error).toMatch(/connection refused/i);
+  });
+
+  it('returns ok=false when success sim has no retval', async () => {
+    const sim: rpc.Api.SimulateTransactionSuccessResponse = {
+      _parsed: true,
+      id: '1',
+      latestLedger: 1000,
+      events: [],
+      transactionData: {} as any,
+      minResourceFee: '100',
+      // result intentionally absent
+    } as rpc.Api.SimulateTransactionSuccessResponse;
+    const svc = makeService(sim);
+    const result = await svc.readIsSubscriber(CONTRACT_ID, FAN, CREATOR);
+    expect(result.ok).toBe(false);
+    expect((result as any).error).toMatch(/no retval/i);
+  });
+});
+
+// ── readExpiryUnix ────────────────────────────────────────────────────────────
+
+describe('SubscriptionChainReaderService.readExpiryUnix', () => {
+  it('returns ok=true with expiryUnix from contract when non-zero', async () => {
+    const contractExpiry = 1_800_000_000n;
+    const retval = nativeToScVal([1200n, contractExpiry] as any);
+    const svc = makeService(successSim(retval));
+    const result = await svc.readExpiryUnix(CONTRACT_ID, FAN, CREATOR);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.expiryUnix).toBe(Number(contractExpiry));
+      expect(typeof result.skewMs).toBe('number');
+    }
+  });
+
+  it('returns ok=false on error sim', async () => {
+    const svc = makeService(errorSim('host function error'));
+    const result = await svc.readExpiryUnix(CONTRACT_ID, FAN, CREATOR);
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns ok=false on restore sim', async () => {
+    const svc = makeService(restoreSim());
+    const result = await svc.readExpiryUnix(CONTRACT_ID, FAN, CREATOR);
+    expect(result.ok).toBe(false);
+    expect((result as any).error).toMatch(/restoration/i);
+  });
+});
+
+// ── readPlan ──────────────────────────────────────────────────────────────────
+
+describe('SubscriptionChainReaderService.readPlan', () => {
+  it('returns ok=true with plan fields on success sim', async () => {
+    const planNative = { creator: CREATOR, asset: 'XLM', amount: 10_000_000n, interval_days: 30 };
+    const retval = nativeToScVal(planNative as any);
+    const svc = makeService(successSim(retval));
+    const result = await svc.readPlan(CONTRACT_ID, 1);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.plan.creator).toBe(CREATOR);
+      expect(result.plan.amount).toBe('10000000');
+      expect(result.plan.intervalDays).toBe(30);
+    }
+  });
+
+  it('returns ok=false on error sim', async () => {
+    const svc = makeService(errorSim('plan not found'));
+    const result = await svc.readPlan(CONTRACT_ID, 99);
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns ok=false on restore sim', async () => {
+    const svc = makeService(restoreSim());
+    const result = await svc.readPlan(CONTRACT_ID, 1);
+    expect(result.ok).toBe(false);
+    expect((result as any).error).toMatch(/restoration/i);
+  });
+});
+
+// ── readPlanCount ─────────────────────────────────────────────────────────────
+
+describe('SubscriptionChainReaderService.readPlanCount', () => {
+  it('returns ok=true with count on success sim', async () => {
+    const svc = makeService(successSim(nativeToScVal(5, { type: 'u32' })));
+    const result = await svc.readPlanCount(CONTRACT_ID);
+    expect(result).toEqual({ ok: true, count: 5 });
+  });
+
+  it('returns ok=false on error sim', async () => {
+    const svc = makeService(errorSim('contract error'));
+    const result = await svc.readPlanCount(CONTRACT_ID);
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns ok=false on restore sim', async () => {
+    const svc = makeService(restoreSim());
+    const result = await svc.readPlanCount(CONTRACT_ID);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/backend/src/subscriptions/subscription-chain-reader.service.ts
+++ b/backend/src/subscriptions/subscription-chain-reader.service.ts
@@ -29,8 +29,52 @@ export type ChainPlanCountReadResult =
   | { ok: true; count: number }
   | { ok: false; error: string };
 
+/** Dummy source account used for read-only simulations. */
+const SIM_SOURCE = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+const PERMANENT_ERROR = (e: unknown) =>
+  e instanceof CircuitOpenError ||
+  (e instanceof Error && /invalid contract|not found/i.test(e.message));
+
 /**
- * Read-only Soroban simulation of the subscription contract `is_subscriber` method.
+ * Narrows a SimulateTransactionResponse to the retval, or returns an error
+ * string using the current @stellar/stellar-sdk discriminated unions:
+ *
+ *   SimulateTransactionResponse
+ *     ├─ SimulateTransactionErrorResponse   → .error: string
+ *     ├─ SimulateTransactionSuccessResponse → .result?: SimulateHostFunctionResult
+ *     └─ SimulateTransactionRestoreResponse → .result: SimulateHostFunctionResult (required)
+ *                                             .restorePreamble (ledger entry needs restore)
+ *
+ * A restore response means the entry exists but is expired/archived; we treat
+ * it as a transient error so the caller can retry after restoration.
+ */
+function extractRetval(
+  sim: rpc.Api.SimulateTransactionResponse,
+): { retval: import('@stellar/stellar-sdk').xdr.ScVal } | { error: string } {
+  if (rpc.Api.isSimulationError(sim)) {
+    return { error: sim.error };
+  }
+
+  if (rpc.Api.isSimulationRestore(sim)) {
+    // Entry is archived — caller should restore before retrying.
+    return { error: 'Ledger entry requires restoration before simulation can succeed.' };
+  }
+
+  // isSimulationSuccess: result is optional (only present for invocation sims)
+  if (!rpc.Api.isSimulationSuccess(sim)) {
+    return { error: 'Unknown simulation response shape.' };
+  }
+
+  if (!sim.result?.retval) {
+    return { error: 'Simulation succeeded but returned no retval (unexpected).' };
+  }
+
+  return { retval: sim.result.retval };
+}
+
+/**
+ * Read-only Soroban simulation of the subscription contract methods.
  * Skipped when no contract id is configured.
  */
 @Injectable()
@@ -64,6 +108,22 @@ export class SubscriptionChainReaderService {
     return map[n] ?? Networks.TESTNET;
   }
 
+  private makeServer(): rpc.Server {
+    const rpcUrl = this.getRpcUrl();
+    return new rpc.Server(rpcUrl, { allowHttp: rpcUrl.startsWith('http://') });
+  }
+
+  private buildTx(op: ReturnType<Contract['call']>): ReturnType<TransactionBuilder['build']> {
+    const source = new Account(SIM_SOURCE, '1');
+    return new TransactionBuilder(source, {
+      fee: '100000',
+      networkPassphrase: this.getNetworkPassphrase(),
+    })
+      .addOperation(op)
+      .setTimeout(30)
+      .build();
+  }
+
   /**
    * Simulates `is_subscriber(fan, creator)` on the deployed subscription contract.
    */
@@ -72,57 +132,26 @@ export class SubscriptionChainReaderService {
     fan: string,
     creator: string,
   ): Promise<ChainReadResult> {
-    const rpcUrl = this.getRpcUrl();
-    const server = new rpc.Server(rpcUrl, {
-      allowHttp: rpcUrl.startsWith('http://'),
-    });
-
     try {
       const contract = new Contract(contractId);
-      const fanAddr = Address.fromString(fan);
-      const creatorAddr = Address.fromString(creator);
       const op = contract.call(
         'is_subscriber',
-        fanAddr.toScVal(),
-        creatorAddr.toScVal(),
+        Address.fromString(fan).toScVal(),
+        Address.fromString(creator).toScVal(),
       );
-
-      const source = new Account(
-        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-        '1',
-      );
-
-      const tx = new TransactionBuilder(source, {
-        fee: '100000',
-        networkPassphrase: this.getNetworkPassphrase(),
-      })
-        .addOperation(op)
-        .setTimeout(30)
-        .build();
 
       const sim = await withRetry(
         'soroban-rpc',
-        () => server.simulateTransaction(tx),
-        {
-          isPermanentError: (e) =>
-            e instanceof CircuitOpenError ||
-            (e instanceof Error && /invalid contract|not found/i.test(e.message)),
-        },
+        () => this.makeServer().simulateTransaction(this.buildTx(op)),
+        { isPermanentError: PERMANENT_ERROR },
       );
 
-      if (rpc.Api.isSimulationError(sim)) {
-        return { ok: false, error: sim.error };
+      const extracted = extractRetval(sim);
+      if ('error' in extracted) {
+        return { ok: false, error: extracted.error };
       }
 
-      if (!sim.result?.retval) {
-        return {
-          ok: false,
-          error: 'Simulation succeeded but returned no retval (unexpected).',
-        };
-      }
-
-      const native = scValToNative(sim.result.retval);
-      return { ok: true, isSubscriber: Boolean(native) };
+      return { ok: true, isSubscriber: Boolean(scValToNative(extracted.retval)) };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.logger.warn(`Chain read is_subscriber failed: ${message}`);
@@ -131,80 +160,43 @@ export class SubscriptionChainReaderService {
   }
 
   /**
-   * Reads the subscription expiry ledger sequence from the contract storage,
-   * then converts it to a Unix timestamp using the current ledger close time
-   * as an anchor (skew-corrected).
+   * Reads the subscription expiry from the contract, skew-corrected via
+   * LedgerClockService.
    */
   async readExpiryUnix(
     contractId: string,
     fan: string,
     creator: string,
   ): Promise<ChainExpiryReadResult> {
-    const rpcUrl = this.getRpcUrl();
-    const server = new rpc.Server(rpcUrl, {
-      allowHttp: rpcUrl.startsWith('http://'),
-    });
-
     try {
       const contract = new Contract(contractId);
-      const fanAddr = Address.fromString(fan);
-      const creatorAddr = Address.fromString(creator);
       const op = contract.call(
         'get_expiry_unix',
-        fanAddr.toScVal(),
-        creatorAddr.toScVal(),
+        Address.fromString(fan).toScVal(),
+        Address.fromString(creator).toScVal(),
       );
-
-      const source = new Account(
-        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-        '1',
-      );
-
-      const tx = new TransactionBuilder(source, {
-        fee: '100000',
-        networkPassphrase: this.getNetworkPassphrase(),
-      })
-        .addOperation(op)
-        .setTimeout(30)
-        .build();
 
       const sim = await withRetry(
         'soroban-rpc',
-        () => server.simulateTransaction(tx),
-        {
-          isPermanentError: (e) =>
-            e instanceof CircuitOpenError ||
-            (e instanceof Error && /invalid contract|not found/i.test(e.message)),
-        },
+        () => this.makeServer().simulateTransaction(this.buildTx(op)),
+        { isPermanentError: PERMANENT_ERROR },
       );
 
-      if (rpc.Api.isSimulationError(sim)) {
-        return { ok: false, error: sim.error };
-      }
-
-      if (!sim.result?.retval) {
-        return { ok: false, error: 'No retval from get_expiry_unix simulation' };
+      const extracted = extractRetval(sim);
+      if ('error' in extracted) {
+        return { ok: false, error: extracted.error };
       }
 
       // Contract returns (expiry_ledger_seq: u64, expiry_unix: u64)
-      const native = scValToNative(sim.result.retval) as [bigint, bigint];
+      const native = scValToNative(extracted.retval) as [bigint, bigint];
       const expiryLedgerSeq = Number(native[0]);
       const contractExpiryUnix = Number(native[1]);
 
-      // Fetch ledger clock snapshot to compute skew
       const snapshot = await this.ledgerClock.fetchSnapshot();
-      // Cross-check: re-derive expiry from ledger seq using our anchor
       const derivedExpiryUnix = this.ledgerClock.ledgerSeqToUnix(expiryLedgerSeq, snapshot);
-
-      // Use contract-reported unix if available, otherwise use derived
       const expiryUnix = contractExpiryUnix > 0 ? contractExpiryUnix : derivedExpiryUnix;
 
-      return {
-        ok: true,
-        expiryUnix,
-        expiryLedgerSeq,
-        skewMs: snapshot.skewMs,
-      };
+      return { ok: true, expiryUnix, expiryLedgerSeq, skewMs: snapshot.skewMs };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.logger.warn(`Chain read get_expiry_unix failed: ${message}`);
@@ -219,45 +211,26 @@ export class SubscriptionChainReaderService {
     contractId: string,
     planId: number,
   ): Promise<ChainPlanReadResult> {
-    const rpcUrl = this.getRpcUrl();
-    const server = new rpc.Server(rpcUrl, {
-      allowHttp: rpcUrl.startsWith('http://'),
-    });
-
     try {
       const contract = new Contract(contractId);
       const op = contract.call('get_plan', nativeToScVal(planId));
 
-      const source = new Account(
-        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-        '1',
+      const sim = await withRetry(
+        'soroban-rpc',
+        () => this.makeServer().simulateTransaction(this.buildTx(op)),
+        { isPermanentError: PERMANENT_ERROR },
       );
 
-      const tx = new TransactionBuilder(source, {
-        fee: '100000',
-        networkPassphrase: this.getNetworkPassphrase(),
-      })
-        .addOperation(op)
-        .setTimeout(30)
-        .build();
-
-      const sim = await server.simulateTransaction(tx);
-
-      if (rpc.Api.isSimulationError(sim)) {
-        return { ok: false, error: sim.error };
+      const extracted = extractRetval(sim);
+      if ('error' in extracted) {
+        return { ok: false, error: extracted.error };
       }
 
-      if (!sim.result?.retval) {
-        return {
-          ok: false,
-          error: 'Simulation succeeded but returned no retval (unexpected).',
-        };
-      }
-
-      const native = scValToNative(sim.result.retval);
+      const native = scValToNative(extracted.retval);
       if (native === null) {
         return { ok: false, error: 'Plan not found' };
       }
+
       const plan = native as { creator: string; asset: string; amount: bigint; interval_days: number };
       return {
         ok: true,
@@ -279,43 +252,22 @@ export class SubscriptionChainReaderService {
    * Simulates `get_plan_count()` on the deployed contract.
    */
   async readPlanCount(contractId: string): Promise<ChainPlanCountReadResult> {
-    const rpcUrl = this.getRpcUrl();
-    const server = new rpc.Server(rpcUrl, {
-      allowHttp: rpcUrl.startsWith('http://'),
-    });
-
     try {
       const contract = new Contract(contractId);
       const op = contract.call('get_plan_count');
 
-      const source = new Account(
-        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-        '1',
+      const sim = await withRetry(
+        'soroban-rpc',
+        () => this.makeServer().simulateTransaction(this.buildTx(op)),
+        { isPermanentError: PERMANENT_ERROR },
       );
 
-      const tx = new TransactionBuilder(source, {
-        fee: '100000',
-        networkPassphrase: this.getNetworkPassphrase(),
-      })
-        .addOperation(op)
-        .setTimeout(30)
-        .build();
-
-      const sim = await server.simulateTransaction(tx);
-
-      if (rpc.Api.isSimulationError(sim)) {
-        return { ok: false, error: sim.error };
+      const extracted = extractRetval(sim);
+      if ('error' in extracted) {
+        return { ok: false, error: extracted.error };
       }
 
-      if (!sim.result?.retval) {
-        return {
-          ok: false,
-          error: 'Simulation succeeded but returned no retval (unexpected).',
-        };
-      }
-
-      const native = scValToNative(sim.result.retval);
-      return { ok: true, count: Number(native) };
+      return { ok: true, count: Number(scValToNative(extracted.retval)) };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.logger.warn(`Chain read get_plan_count failed: ${message}`);


### PR DESCRIPTION
…chain reader

- Extract retval via isSimulationError / isSimulationSuccess / isSimulationRestore instead of accessing sim.result?.retval directly on the union type
- Add extractRetval() helper that narrows all three branches and returns a typed { retval } | { error } result — no more unsafe property access
- Handle SimulateTransactionRestoreResponse (archived ledger entry) as a transient error with a clear message so callers can retry after restoration
- Apply withRetry to readPlan and readPlanCount (previously missing, inconsistent)
- Deduplicate server/tx construction into makeServer() and buildTx() helpers
- Tests: subscription-chain-reader.service.spec.ts — 14 cases covering success, error, restore, missing retval, and network rejection for all four read methods
closes #580 