### PR TITLE
feat(backend): harden CreatorsService with Logger and resilient edges

### DIFF
--- a/backend/src/creators/creators.service.spec.ts
+++ b/backend/src/creators/creators.service.spec.ts
@@ -1,7 +1,9 @@
+import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { SelectQueryBuilder } from 'typeorm';
 import { CreatorsService } from './creators.service';
+import { PaginationDto } from '../common/dto';
 import { User } from '../users/entities/user.entity';
 import { EventBus } from '../events/event-bus';
 import { SearchCreatorsDto } from './dto/search-creators.dto';
@@ -10,8 +12,14 @@ import { UserRole } from '../common/enums/user-role.enum';
 describe('CreatorsService', () => {
   let service: CreatorsService;
   let mockQueryBuilder: Partial<SelectQueryBuilder<User>>;
+  let debugSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
 
   beforeEach(async () => {
+    debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
     // Create mock query builder
     mockQueryBuilder = {
       createQueryBuilder: jest.fn().mockReturnThis(),
@@ -40,6 +48,12 @@ describe('CreatorsService', () => {
     }).compile();
 
     service = module.get<CreatorsService>(CreatorsService);
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('should be defined', () => {
@@ -71,6 +85,9 @@ describe('CreatorsService', () => {
         expect(result.page).toBe(1);
         expect(result.limit).toBe(10);
         expect(mockQueryBuilder.andWhere).not.toHaveBeenCalled();
+        expect(debugSpy).toHaveBeenCalledWith(
+          'Creator search returned 2/2 rows for query ""',
+        );
       });
 
       it('should return all creators when query is undefined', async () => {
@@ -443,6 +460,86 @@ describe('CreatorsService', () => {
     });
   });
 
+  describe('logging and resilience', () => {
+    it('createPlan logs when EventBus is not injected and still persists plan', async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CreatorsService,
+          {
+            provide: getRepositoryToken(User),
+            useValue: {
+              createQueryBuilder: jest.fn(() => mockQueryBuilder),
+            },
+          },
+        ],
+      }).compile();
+
+      const isolated = module.get<CreatorsService>(CreatorsService);
+      const plan = isolated.createPlan('addr1', 'USDC:1', '5', 7);
+
+      expect(plan.creator).toBe('addr1');
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /Plan \d+ created for addr1; EventBus not wired, skipping PlanCreatedEvent/,
+        ),
+      );
+    });
+
+    it('createPlan survives publish throwing and logs a warning', () => {
+      const publish = jest.fn().mockImplementation(() => {
+        throw new Error('bus down');
+      });
+      const busModule = Test.createTestingModule({
+        providers: [
+          CreatorsService,
+          { provide: EventBus, useValue: { publish } },
+          {
+            provide: getRepositoryToken(User),
+            useValue: {
+              createQueryBuilder: jest.fn(() => mockQueryBuilder),
+            },
+          },
+        ],
+      });
+
+      return busModule.compile().then((m) => {
+        const svc = m.get<CreatorsService>(CreatorsService);
+        const plan = svc.createPlan('c1', 'XLM', '1', 1);
+        expect(plan.id).toBeGreaterThan(0);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /Plan \d+ created but PlanCreatedEvent publish failed: bus down/,
+          ),
+        );
+      });
+    });
+
+    it('findAllPlans ignores invalid cursor and logs debug', () => {
+      service.createPlan('a', 'USDC', '1', 30);
+      service.findAllPlans({ cursor: 'not-a-number', limit: 10 } as PaginationDto);
+      expect(debugSpy).toHaveBeenCalledWith(
+        'Ignoring invalid plans pagination cursor "not-a-number"',
+      );
+    });
+
+    it('searchCreators logs error and rethrows when the query fails', async () => {
+      (mockQueryBuilder.getCount as jest.Mock).mockRejectedValue(
+        new Error('connection reset'),
+      );
+      (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue({
+        entities: [],
+        raw: [],
+      });
+
+      await expect(
+        service.searchCreators({ q: 'x', page: 1, limit: 10 }),
+      ).rejects.toThrow('connection reset');
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Creator search failed: connection reset',
+      );
+    });
+  });
 });
 
 // Helper function to create mock users

--- a/backend/src/creators/creators.service.ts
+++ b/backend/src/creators/creators.service.ts
@@ -40,9 +40,21 @@ export class CreatorsService {
   ): Plan {
     const plan = { id: ++this.planCounter, creator, asset, amount, intervalDays };
     this.plans.set(plan.id, plan);
-    this.eventBus?.publish(
-      new PlanCreatedEvent(plan.id, creator, asset, amount),
-    );
+    if (!this.eventBus) {
+      this.logger.debug(
+        `Plan ${plan.id} created for ${creator}; EventBus not wired, skipping PlanCreatedEvent`,
+      );
+    } else {
+      try {
+        this.eventBus.publish(
+          new PlanCreatedEvent(plan.id, creator, asset, amount),
+        );
+      } catch (err) {
+        this.logger.warn(
+          `Plan ${plan.id} created but PlanCreatedEvent publish failed: ${(err as Error).message}`,
+        );
+      }
+    }
     return plan;
   }
 
@@ -62,6 +74,8 @@ export class CreatorsService {
       const cursorId = parseInt(cursor, 10);
       if (!isNaN(cursorId)) {
         allPlans = allPlans.filter((p) => p.id > cursorId);
+      } else {
+        this.logger.debug(`Ignoring invalid plans pagination cursor "${cursor}"`);
       }
     }
 
@@ -95,6 +109,10 @@ export class CreatorsService {
       const cursorId = parseInt(cursor, 10);
       if (!isNaN(cursorId)) {
         creatorPlans = creatorPlans.filter((p) => p.id > cursorId);
+      } else {
+        this.logger.debug(
+          `Ignoring invalid creator plans pagination cursor "${cursor}" for ${creator}`,
+        );
       }
     }
 
@@ -139,10 +157,22 @@ export class CreatorsService {
       );
     }
 
-    const [{ entities, raw }, total] = await Promise.all([
-      qb.getRawAndEntities(),
-      qb.getCount(),
-    ]);
+    let entities: User[];
+    let raw: { creator_bio?: string }[];
+    let total: number;
+    try {
+      const [{ entities: e, raw: r }, t] = await Promise.all([
+        qb.getRawAndEntities(),
+        qb.getCount(),
+      ]);
+      entities = e;
+      raw = r as { creator_bio?: string }[];
+      total = t;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Creator search failed: ${message}`);
+      throw err;
+    }
 
     const data = entities.map((user, index) => {
       const dto = new PublicCreatorDto(user, user.creator);


### PR DESCRIPTION
- Log and skip PlanCreatedEvent when EventBus is optional; warn if publish throws
- Debug-log invalid plan pagination cursors instead of failing silently
- Log and rethrow creator search DB failures
- Add unit tests for logging and resilience paths

closes #585 