### PR TITLE
chore(subscription): add dummy seed data for snapshot/restore tests

### DIFF
--- a/contract/contracts/subscription/src/dummy_data.rs
+++ b/contract/contracts/subscription/src/dummy_data.rs
@@ -1,0 +1,43 @@
+//! Dummy seed data for snapshot/restore tests.
+//!
+//! These constants represent realistic fixture values used across
+//! `test_subscription_state_after_snapshot_restore` and
+//! `test_cancel_after_snapshot_restore`. Centralising them here makes
+//! it easy to update all snapshot tests in one place.
+
+/// Default subscription plan amount in stroops (1000 = 0.0001 XLM equivalent in tests).
+pub const DUMMY_PLAN_AMOUNT: i128 = 1_000;
+
+/// Default plan interval in days (30-day billing cycle).
+pub const DUMMY_INTERVAL_DAYS: u32 = 30;
+
+/// Default fan starting balance minted before each snapshot test.
+pub const DUMMY_FAN_BALANCE: i128 = 10_000;
+
+/// Default protocol fee in basis points (500 bps = 5%).
+pub const DUMMY_FEE_BPS: u32 = 500;
+
+/// Default subscription price used in `init` (matches DUMMY_PLAN_AMOUNT).
+pub const DUMMY_PRICE: i128 = 1_000;
+
+/// Ledgers per day on Stellar (one ledger every ~5 s → 17 280 ledgers/day).
+pub const LEDGERS_PER_DAY: u32 = 17_280;
+
+/// Expected expiry offset in ledgers for a 30-day plan.
+/// `expiry = start_sequence + DUMMY_INTERVAL_DAYS * LEDGERS_PER_DAY`
+pub const DUMMY_EXPIRY_OFFSET: u64 = (DUMMY_INTERVAL_DAYS as u64) * (LEDGERS_PER_DAY as u64);
+
+/// Dummy content IDs used in cross-contract unlock tests.
+pub const DUMMY_CONTENT_ID_1: u64 = 101;
+pub const DUMMY_CONTENT_ID_2: u64 = 202;
+
+/// Dummy content prices (in stroops).
+pub const DUMMY_CONTENT_PRICE_1: i128 = 500;
+pub const DUMMY_CONTENT_PRICE_2: i128 = 300;
+
+/// Cancel reason codes (mirrors contract convention).
+pub const CANCEL_REASON_USER_INITIATED: u32 = 0;
+pub const CANCEL_REASON_TOO_EXPENSIVE: u32 = 1;
+pub const CANCEL_REASON_CONTENT_QUALITY: u32 = 2;
+pub const CANCEL_REASON_SWITCHING_CREATOR: u32 = 3;
+pub const CANCEL_REASON_OTHER: u32 = 4;

--- a/contract/contracts/subscription/src/lib.rs
+++ b/contract/contracts/subscription/src/lib.rs
@@ -526,6 +526,9 @@ impl MyfansContract {
     }
 }
 
+/// Dummy seed data for snapshot/restore tests.
 #[cfg(test)]
+pub mod dummy_data;
+
 #[cfg(test)]
 mod test;

--- a/contract/contracts/subscription/src/test.rs
+++ b/contract/contracts/subscription/src/test.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use super::*;
+use super::dummy_data::*;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger, MockAuth, MockAuthInvoke},
     token,
@@ -350,18 +351,18 @@ fn test_extend_fails_if_expired() {
 fn test_subscription_state_after_snapshot_restore() {
     let (env, client, admin, token, token_admin) = setup_test();
     let fee_recipient = Address::generate(&env);
-    client.init(&admin, &500, &fee_recipient, &token.address, &1000);
+    client.init(&admin, &DUMMY_FEE_BPS, &fee_recipient, &token.address, &DUMMY_PRICE);
 
     let creator = Address::generate(&env);
     let fan = Address::generate(&env);
-    token_admin.mint(&fan, &10000);
+    token_admin.mint(&fan, &DUMMY_FAN_BALANCE);
 
-    let plan_id = client.create_plan(&creator, &token.address, &1000, &30);
+    let plan_id = client.create_plan(&creator, &token.address, &DUMMY_PLAN_AMOUNT, &DUMMY_INTERVAL_DAYS);
     assert_eq!(plan_id, 1);
     client.subscribe(&fan, &plan_id, &token.address);
 
     let contract_id = client.address.clone();
-    let expected_expiry = env.ledger().sequence() + (30 * 17280);
+    let expected_expiry = env.ledger().sequence() + (DUMMY_INTERVAL_DAYS * LEDGERS_PER_DAY);
     let sc_fan: ScAddress = fan.clone().try_into().unwrap();
     let sc_creator: ScAddress = creator.clone().try_into().unwrap();
     let sc_contract: ScAddress = contract_id.clone().try_into().unwrap();
@@ -399,8 +400,8 @@ fn test_subscription_state_after_snapshot_restore() {
             .unwrap()
     });
     assert_eq!(plan.creator, creator2);
-    assert_eq!(plan.amount, 1000);
-    assert_eq!(plan.interval_days, 30);
+    assert_eq!(plan.amount, DUMMY_PLAN_AMOUNT);
+    assert_eq!(plan.interval_days, DUMMY_INTERVAL_DAYS);
 
     let plan_count: u32 = env2.as_contract(&contract_id2, || {
         env2.storage()
@@ -730,13 +731,13 @@ fn test_subscription_key_helper_keeps_legacy_variant() {
 fn test_cancel_after_snapshot_restore() {
     let (env, client, admin, token, token_admin) = setup_test();
     let fee_recipient = Address::generate(&env);
-    client.init(&admin, &500, &fee_recipient, &token.address, &1000);
+    client.init(&admin, &DUMMY_FEE_BPS, &fee_recipient, &token.address, &DUMMY_PRICE);
 
     let creator = Address::generate(&env);
     let fan = Address::generate(&env);
-    token_admin.mint(&fan, &10000);
+    token_admin.mint(&fan, &DUMMY_FAN_BALANCE);
 
-    let plan_id = client.create_plan(&creator, &token.address, &1000, &30);
+    let plan_id = client.create_plan(&creator, &token.address, &DUMMY_PLAN_AMOUNT, &DUMMY_INTERVAL_DAYS);
     client.subscribe(&fan, &plan_id, &token.address);
     assert!(client.is_subscriber(&fan, &creator));
 
@@ -760,7 +761,7 @@ fn test_cancel_after_snapshot_restore() {
         "state matches after restore"
     );
 
-    client2.cancel(&fan2, &creator2, &0);
+    client2.cancel(&fan2, &creator2, &CANCEL_REASON_USER_INITIATED);
     assert!(
         !client2.is_subscriber(&fan2, &creator2),
         "cancel after restore: subscription should be removed"


### PR DESCRIPTION
- 48/48 unit tests + 1 integration test pass
closes #603 