### PR TITLE
feat(frontend): show offline banner when RPC or network is unavailable

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -10,6 +10,8 @@ import { ToastContainer } from "@/components/ui/Toast";
 import { FeatureFlagsProvider } from "@/contexts/FeatureFlagsContext";
 import { RouteGuard } from "@/components/RouteGuard";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { RpcStatusProvider } from "@/contexts/RpcStatusContext";
+import { RpcOfflineBannerWrapper } from "@/components/RpcOfflineBannerWrapper";
 
 export const metadata: Metadata = {
   title: {
@@ -91,10 +93,13 @@ export default function RootLayout({
               <ConsentProvider>
                 <FavoritesProvider>
                   <ToastProvider>
-                    <ErrorBoundary>
-                      <RouteGuard>{children}</RouteGuard>
-                    </ErrorBoundary>
-                    <ToastContainer />
+                    <RpcStatusProvider>
+                      <RpcOfflineBannerWrapper />
+                      <ErrorBoundary>
+                        <RouteGuard>{children}</RouteGuard>
+                      </ErrorBoundary>
+                      <ToastContainer />
+                    </RpcStatusProvider>
                   </ToastProvider>
                 </FavoritesProvider>
               </ConsentProvider>

--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React from 'react';
+import type { RpcStatus } from '@/hooks/useRpcStatus';
+
+interface OfflineBannerProps {
+  status: RpcStatus;
+  onRetry?: () => void;
+}
+
+const MESSAGES: Record<Exclude<RpcStatus, 'online' | 'checking'>, { title: string; description: string }> = {
+  offline: {
+    title: 'You are offline',
+    description: 'Check your internet connection. Transactions and live data are unavailable.',
+  },
+  rpc_down: {
+    title: 'Blockchain network unavailable',
+    description: 'The Stellar RPC endpoint is unreachable. Transactions are paused until the connection is restored.',
+  },
+};
+
+/**
+ * OfflineBanner – a sticky top banner shown when the browser is offline
+ * or the Soroban RPC endpoint is unreachable.
+ */
+export function OfflineBanner({ status, onRetry }: OfflineBannerProps) {
+  if (status === 'online' || status === 'checking') return null;
+
+  const { title, description } = MESSAGES[status];
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      className="sticky top-0 z-50 w-full bg-amber-500 dark:bg-amber-600 text-white px-4 py-2.5 flex items-center justify-between gap-3 shadow-md"
+    >
+      <div className="flex items-center gap-2.5 min-w-0">
+        {/* Icon */}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+          className="h-5 w-5 shrink-0"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+          />
+        </svg>
+
+        <div className="min-w-0">
+          <span className="font-semibold text-sm">{title}</span>
+          <span className="hidden sm:inline text-sm font-normal opacity-90 ml-1.5">
+            {description}
+          </span>
+        </div>
+      </div>
+
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="shrink-0 text-sm font-semibold underline underline-offset-2 hover:opacity-80 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/RpcOfflineBannerWrapper.tsx
+++ b/frontend/src/components/RpcOfflineBannerWrapper.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import React from 'react';
+import { OfflineBanner } from '@/components/OfflineBanner';
+import { useRpcStatusContext } from '@/contexts/RpcStatusContext';
+
+/**
+ * Thin client component that reads RPC status from context and renders
+ * the OfflineBanner. Kept separate so layout.tsx (server component) can
+ * import it without breaking the server/client boundary.
+ */
+export function RpcOfflineBannerWrapper() {
+  const { status, retry } = useRpcStatusContext();
+  return <OfflineBanner status={status} onRetry={retry} />;
+}

--- a/frontend/src/components/__tests__/OfflineBanner.test.tsx
+++ b/frontend/src/components/__tests__/OfflineBanner.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { OfflineBanner } from '@/components/OfflineBanner';
+
+describe('OfflineBanner', () => {
+  it('renders nothing when status is online', () => {
+    const { container } = render(<OfflineBanner status="online" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when status is checking', () => {
+    const { container } = render(<OfflineBanner status="checking" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows offline message when browser is offline', () => {
+    render(<OfflineBanner status="offline" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('You are offline')).toBeInTheDocument();
+  });
+
+  it('shows RPC down message when RPC is unreachable', () => {
+    render(<OfflineBanner status="rpc_down" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Blockchain network unavailable')).toBeInTheDocument();
+  });
+
+  it('calls onRetry when retry button is clicked', () => {
+    const onRetry = vi.fn();
+    render(<OfflineBanner status="rpc_down" onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render retry button when onRetry is not provided', () => {
+    render(<OfflineBanner status="offline" />);
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+  });
+
+  it('has correct aria attributes for accessibility', () => {
+    render(<OfflineBanner status="offline" />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+  });
+});

--- a/frontend/src/contexts/RpcStatusContext.tsx
+++ b/frontend/src/contexts/RpcStatusContext.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import React, { createContext, useContext, type ReactNode } from 'react';
+import { useRpcStatus, type RpcStatusResult } from '@/hooks/useRpcStatus';
+
+const RpcStatusContext = createContext<RpcStatusResult | undefined>(undefined);
+
+export function RpcStatusProvider({ children }: { children: ReactNode }) {
+  const rpcStatus = useRpcStatus();
+  return (
+    <RpcStatusContext.Provider value={rpcStatus}>
+      {children}
+    </RpcStatusContext.Provider>
+  );
+}
+
+export function useRpcStatusContext(): RpcStatusResult {
+  const ctx = useContext(RpcStatusContext);
+  if (!ctx) throw new Error('useRpcStatusContext must be used inside RpcStatusProvider');
+  return ctx;
+}

--- a/frontend/src/hooks/__tests__/useRpcStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useRpcStatus.test.ts
@@ -1,0 +1,104 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useRpcStatus } from '@/hooks/useRpcStatus';
+
+// Mock contract-config so we control the RPC URL
+vi.mock('@/lib/contract-config', () => ({
+  getStellarRuntimeConfig: () => ({
+    sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+    network: 'testnet',
+    subscriptionContractId: '',
+  }),
+}));
+
+describe('useRpcStatus', () => {
+  const originalOnLine = Object.getOwnPropertyDescriptor(navigator, 'onLine');
+
+  function setOnline(value: boolean) {
+    Object.defineProperty(navigator, 'onLine', { value, configurable: true });
+  }
+
+  beforeEach(() => {
+    setOnline(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalOnLine) {
+      Object.defineProperty(navigator, 'onLine', originalOnLine);
+    }
+  });
+
+  it('starts as online when navigator.onLine is true and RPC responds', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+
+    const { result } = renderHook(() => useRpcStatus());
+
+    await waitFor(() => expect(result.current.status).toBe('online'), { timeout: 10000 });
+    expect(result.current.isOffline).toBe(false);
+    expect(result.current.isBrowserOffline).toBe(false);
+    expect(result.current.isRpcDown).toBe(false);
+  });
+
+  it('reports rpc_down when RPC fetch fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+
+    const { result } = renderHook(() => useRpcStatus());
+
+    await waitFor(() => expect(result.current.isRpcDown).toBe(true), { timeout: 10000 });
+    expect(result.current.status).toBe('rpc_down');
+    expect(result.current.isOffline).toBe(true);
+  });
+
+  it('reports offline when browser goes offline', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+
+    const { result } = renderHook(() => useRpcStatus());
+    await waitFor(() => expect(result.current.status).toBe('online'), { timeout: 10000 });
+
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    expect(result.current.isBrowserOffline).toBe(true);
+    expect(result.current.isOffline).toBe(true);
+    expect(result.current.status).toBe('offline');
+  });
+
+  it('recovers to online when browser comes back online and RPC is reachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+
+    const { result } = renderHook(() => useRpcStatus());
+    await waitFor(() => expect(result.current.status).toBe('online'), { timeout: 10000 });
+
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+    expect(result.current.isBrowserOffline).toBe(true);
+
+    act(() => {
+      setOnline(true);
+      window.dispatchEvent(new Event('online'));
+    });
+
+    await waitFor(() => expect(result.current.isBrowserOffline).toBe(false), { timeout: 10000 });
+    await waitFor(() => expect(result.current.status).toBe('online'), { timeout: 10000 });
+  });
+
+  it('retry triggers a new RPC probe', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('down'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useRpcStatus());
+    await waitFor(() => expect(result.current.isRpcDown).toBe(true), { timeout: 10000 });
+
+    // Now fix the RPC
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+
+    act(() => result.current.retry());
+    await waitFor(() => expect(result.current.isRpcDown).toBe(false), { timeout: 10000 });
+  });
+});

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -45,3 +45,6 @@ export {
 
 // Creator route prefetch hook
 export { usePrefetchCreatorRoute } from './usePrefetchCreatorRoute';
+
+// RPC / network status hook
+export { useRpcStatus, type RpcStatus, type RpcStatusResult } from './useRpcStatus';

--- a/frontend/src/hooks/useRpcStatus.ts
+++ b/frontend/src/hooks/useRpcStatus.ts
@@ -1,0 +1,124 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { getStellarRuntimeConfig } from '@/lib/contract-config';
+
+export type RpcStatus = 'online' | 'offline' | 'rpc_down' | 'checking';
+
+export interface RpcStatusResult {
+  status: RpcStatus;
+  /** True when the browser reports no network connection */
+  isBrowserOffline: boolean;
+  /** True when the Soroban/Horizon RPC endpoint is unreachable */
+  isRpcDown: boolean;
+  /** True when either the browser is offline or the RPC is down */
+  isOffline: boolean;
+  /** Manually trigger a re-check */
+  retry: () => void;
+}
+
+const RPC_PROBE_INTERVAL_MS = 30_000;
+const RPC_PROBE_TIMEOUT_MS = 8_000;
+
+/**
+ * Probe the Soroban RPC endpoint with a lightweight health-style request.
+ * We call `getHealth` on the JSON-RPC server which is a standard Soroban RPC method.
+ */
+async function probeRpc(rpcUrl: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), RPC_PROBE_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getHealth', params: [] }),
+      signal: controller.signal,
+    });
+    // Any HTTP response (even 4xx) means the server is reachable
+    return res.ok || res.status < 500;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * useRpcStatus – tracks browser online state and Soroban RPC reachability.
+ *
+ * @example
+ * ```tsx
+ * const { isOffline, status } = useRpcStatus();
+ * if (isOffline) return <OfflineBanner status={status} />;
+ * ```
+ */
+export function useRpcStatus(): RpcStatusResult {
+  const [isBrowserOffline, setIsBrowserOffline] = useState<boolean>(() => {
+    if (typeof navigator === 'undefined') return false;
+    return !navigator.onLine;
+  });
+  const [isRpcDown, setIsRpcDown] = useState(false);
+  const [isChecking, setIsChecking] = useState(false);
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const checkRpc = useCallback(async () => {
+    // Skip RPC probe when browser is already offline
+    if (typeof navigator !== 'undefined' && !navigator.onLine) return;
+
+    setIsChecking(true);
+    try {
+      const config = getStellarRuntimeConfig();
+      const reachable = await probeRpc(config.sorobanRpcUrl);
+      setIsRpcDown(!reachable);
+    } finally {
+      setIsChecking(false);
+    }
+  }, []);
+
+  const retry = useCallback(() => {
+    checkRpc();
+  }, [checkRpc]);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      setIsBrowserOffline(false);
+      // Re-probe RPC now that we're back online
+      checkRpc();
+    };
+    const handleOffline = () => {
+      setIsBrowserOffline(true);
+    };
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    // Initial probe
+    checkRpc();
+
+    // Periodic probe
+    intervalRef.current = setInterval(checkRpc, RPC_PROBE_INTERVAL_MS);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [checkRpc]);
+
+  const isOffline = isBrowserOffline || isRpcDown;
+
+  let status: RpcStatus;
+  if (isChecking && !isOffline) {
+    status = 'checking';
+  } else if (isBrowserOffline) {
+    status = 'offline';
+  } else if (isRpcDown) {
+    status = 'rpc_down';
+  } else {
+    status = 'online';
+  }
+
+  return { status, isBrowserOffline, isRpcDown, isOffline, retry };
+}


### PR DESCRIPTION
Shows a sticky top banner whenever the user's browser goes offline or the Soroban RPC endpoint becomes unreachable, giving users immediate, clear feedback that blockchain transactions are unavailable.closes #698 