### PR TITLE
feat(subscriptions): track worst-case simulation resource fees

### DIFF
--- a/backend/src/subscriptions/subscription-chain-reader.service.spec.ts
+++ b/backend/src/subscriptions/subscription-chain-reader.service.spec.ts
@@ -217,3 +217,90 @@ describe('SubscriptionChainReaderService.readPlanCount', () => {
     expect(result.ok).toBe(false);
   });
 });
+
+describe('SubscriptionChainReaderService simulation cost tracking', () => {
+  const VALID_ACCOUNT = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+  it('tracks worst-case minResourceFee across multiple simulations', async () => {
+    const ledgerClock = {
+      fetchSnapshot: jest.fn().mockResolvedValue({
+        ledgerSeq: 1000,
+        ledgerCloseTimeUnix: 1_700_000_000,
+        capturedAtMs: 1_700_000_000_000,
+        skewMs: 0,
+      }),
+      ledgerSeqToUnix: jest.fn().mockReturnValue(1_700_000_000),
+    } as unknown as LedgerClockService;
+
+    const svc = new SubscriptionChainReaderService(ledgerClock);
+    const simulateTransaction = jest
+      .fn()
+      .mockResolvedValueOnce(successSim(nativeToScVal(true)))
+      .mockResolvedValueOnce({
+        ...restoreSim(),
+        minResourceFee: '150',
+        restorePreamble: { minResourceFee: '400', transactionData: {} as any },
+      } as rpc.Api.SimulateTransactionRestoreResponse);
+
+    jest.spyOn(svc as any, 'makeServer').mockReturnValue({ simulateTransaction });
+
+    await svc.readIsSubscriber(CONTRACT_ID, VALID_ACCOUNT, VALID_ACCOUNT);
+    await svc.readIsSubscriber(CONTRACT_ID, VALID_ACCOUNT, VALID_ACCOUNT);
+
+    const summary = svc.getSimulationCostSummary(
+      'is_subscriber',
+      60_000,
+    ) as {
+      method: string;
+      worstCaseMinResourceFee: string | null;
+      lastObservedMinResourceFee: string | null;
+      updatedAt: string | null;
+      stale: boolean;
+    };
+
+    expect(summary.method).toBe('is_subscriber');
+    expect(summary.worstCaseMinResourceFee).toBe('400');
+    expect(summary.lastObservedMinResourceFee).toBe('400');
+    expect(summary.updatedAt).toEqual(expect.any(String));
+    expect(summary.stale).toBe(false);
+  });
+
+  it('keeps prior worst-case when a simulation has invalid fee data', async () => {
+    const ledgerClock = {
+      fetchSnapshot: jest.fn().mockResolvedValue({
+        ledgerSeq: 1000,
+        ledgerCloseTimeUnix: 1_700_000_000,
+        capturedAtMs: 1_700_000_000_000,
+        skewMs: 0,
+      }),
+      ledgerSeqToUnix: jest.fn().mockReturnValue(1_700_000_000),
+    } as unknown as LedgerClockService;
+
+    const svc = new SubscriptionChainReaderService(ledgerClock);
+    const simulateTransaction = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ...successSim(nativeToScVal(5, { type: 'u32' })),
+        minResourceFee: '200',
+      } as rpc.Api.SimulateTransactionSuccessResponse)
+      .mockResolvedValueOnce({
+        ...successSim(nativeToScVal(6, { type: 'u32' })),
+        minResourceFee: 'not-a-number',
+      } as unknown as rpc.Api.SimulateTransactionSuccessResponse);
+
+    jest.spyOn(svc as any, 'makeServer').mockReturnValue({ simulateTransaction });
+
+    await svc.readPlanCount(CONTRACT_ID);
+    await svc.readPlanCount(CONTRACT_ID);
+
+    const summary = svc.getSimulationCostSummary(
+      'get_plan_count',
+      60_000,
+    ) as {
+      worstCaseMinResourceFee: string | null;
+      lastObservedMinResourceFee: string | null;
+    };
+    expect(summary.worstCaseMinResourceFee).toBe('200');
+    expect(summary.lastObservedMinResourceFee).toBe('200');
+  });
+});

--- a/backend/src/subscriptions/subscription-chain-reader.service.ts
+++ b/backend/src/subscriptions/subscription-chain-reader.service.ts
@@ -29,8 +29,17 @@ export type ChainPlanCountReadResult =
   | { ok: true; count: number }
   | { ok: false; error: string };
 
+export interface SimulationCostSummary {
+  method: string;
+  worstCaseMinResourceFee: string | null;
+  lastObservedMinResourceFee: string | null;
+  updatedAt: string | null;
+  stale: boolean;
+}
+
 /** Dummy source account used for read-only simulations. */
 const SIM_SOURCE = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const DEFAULT_COST_STALE_MS = 10 * 60 * 1000; // 10 minutes
 
 const PERMANENT_ERROR = (e: unknown) =>
   e instanceof CircuitOpenError ||
@@ -80,6 +89,14 @@ function extractRetval(
 @Injectable()
 export class SubscriptionChainReaderService {
   private readonly logger = new Logger(SubscriptionChainReaderService.name);
+  private readonly simulationCosts = new Map<
+    string,
+    {
+      worstCaseMinResourceFee: bigint;
+      lastObservedMinResourceFee: bigint;
+      updatedAtMs: number;
+    }
+  >();
 
   constructor(private readonly ledgerClock: LedgerClockService) {}
 
@@ -124,6 +141,112 @@ export class SubscriptionChainReaderService {
       .build();
   }
 
+  private parsePositiveBigInt(value: unknown): bigint | null {
+    if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+      return null;
+    }
+    try {
+      const parsed = BigInt(value);
+      return parsed >= 0n ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private extractMinResourceFee(
+    sim: rpc.Api.SimulateTransactionResponse,
+  ): bigint | null {
+    // Restore responses can include two fee estimates; track whichever is larger.
+    const candidates: Array<unknown> = [];
+
+    if ('minResourceFee' in sim) {
+      candidates.push(sim.minResourceFee);
+    }
+    if (rpc.Api.isSimulationRestore(sim)) {
+      candidates.push(sim.restorePreamble?.minResourceFee);
+    }
+
+    let maxFee: bigint | null = null;
+    for (const candidate of candidates) {
+      const parsed = this.parsePositiveBigInt(candidate);
+      if (parsed === null) {
+        continue;
+      }
+      maxFee = maxFee === null || parsed > maxFee ? parsed : maxFee;
+    }
+
+    return maxFee;
+  }
+
+  private trackSimulationCost(
+    method: string,
+    sim: rpc.Api.SimulateTransactionResponse,
+  ): void {
+    const observedFee = this.extractMinResourceFee(sim);
+    if (observedFee === null) {
+      return;
+    }
+
+    const now = Date.now();
+    const prev = this.simulationCosts.get(method);
+    if (!prev) {
+      this.simulationCosts.set(method, {
+        worstCaseMinResourceFee: observedFee,
+        lastObservedMinResourceFee: observedFee,
+        updatedAtMs: now,
+      });
+      return;
+    }
+
+    this.simulationCosts.set(method, {
+      worstCaseMinResourceFee:
+        observedFee > prev.worstCaseMinResourceFee
+          ? observedFee
+          : prev.worstCaseMinResourceFee,
+      lastObservedMinResourceFee: observedFee,
+      updatedAtMs: now,
+    });
+  }
+
+  private getSimulationCostSummaryForMethod(
+    method: string,
+    maxAgeMs: number = DEFAULT_COST_STALE_MS,
+  ): SimulationCostSummary {
+    const metric = this.simulationCosts.get(method);
+    if (!metric) {
+      return {
+        method,
+        worstCaseMinResourceFee: null,
+        lastObservedMinResourceFee: null,
+        updatedAt: null,
+        stale: true,
+      };
+    }
+
+    const stale =
+      maxAgeMs <= 0 ? true : Date.now() - metric.updatedAtMs > maxAgeMs;
+    return {
+      method,
+      worstCaseMinResourceFee: metric.worstCaseMinResourceFee.toString(),
+      lastObservedMinResourceFee: metric.lastObservedMinResourceFee.toString(),
+      updatedAt: new Date(metric.updatedAtMs).toISOString(),
+      stale,
+    };
+  }
+
+  getSimulationCostSummary(
+    method?: string,
+    maxAgeMs: number = DEFAULT_COST_STALE_MS,
+  ): SimulationCostSummary | SimulationCostSummary[] {
+    if (method) {
+      return this.getSimulationCostSummaryForMethod(method, maxAgeMs);
+    }
+    const methods = Array.from(this.simulationCosts.keys()).sort();
+    return methods.map((name) =>
+      this.getSimulationCostSummaryForMethod(name, maxAgeMs),
+    );
+  }
+
   /**
    * Simulates `is_subscriber(fan, creator)` on the deployed subscription contract.
    */
@@ -145,6 +268,7 @@ export class SubscriptionChainReaderService {
         () => this.makeServer().simulateTransaction(this.buildTx(op)),
         { isPermanentError: PERMANENT_ERROR },
       );
+      this.trackSimulationCost('is_subscriber', sim);
 
       const extracted = extractRetval(sim);
       if ('error' in extracted) {
@@ -181,6 +305,7 @@ export class SubscriptionChainReaderService {
         () => this.makeServer().simulateTransaction(this.buildTx(op)),
         { isPermanentError: PERMANENT_ERROR },
       );
+      this.trackSimulationCost('get_expiry_unix', sim);
 
       const extracted = extractRetval(sim);
       if ('error' in extracted) {
@@ -220,6 +345,7 @@ export class SubscriptionChainReaderService {
         () => this.makeServer().simulateTransaction(this.buildTx(op)),
         { isPermanentError: PERMANENT_ERROR },
       );
+      this.trackSimulationCost('get_plan', sim);
 
       const extracted = extractRetval(sim);
       if ('error' in extracted) {
@@ -261,6 +387,7 @@ export class SubscriptionChainReaderService {
         () => this.makeServer().simulateTransaction(this.buildTx(op)),
         { isPermanentError: PERMANENT_ERROR },
       );
+      this.trackSimulationCost('get_plan_count', sim);
 
       const extracted = extractRetval(sim);
       if ('error' in extracted) {

--- a/backend/src/subscriptions/subscriptions.controller.spec.ts
+++ b/backend/src/subscriptions/subscriptions.controller.spec.ts
@@ -30,7 +30,17 @@ describe('SubscriptionsController', () => {
         active: false,
         indexedStatus: 'none',
         indexed: null,
-        chain: { configured: false, isSubscriber: null },
+        chain: {
+          configured: false,
+          isSubscriber: null,
+          simulationCost: {
+            method: 'is_subscriber',
+            worstCaseMinResourceFee: null,
+            lastObservedMinResourceFee: null,
+            updatedAt: null,
+            stale: true,
+          },
+        },
       }),
       listCreatorSubscribers: jest.fn().mockResolvedValue({
         data: [],
@@ -62,7 +72,15 @@ describe('SubscriptionsController', () => {
       fan,
       creator,
     );
-    expect(result).toMatchObject({ indexedStatus: 'none' });
+    expect(result).toMatchObject({
+      indexedStatus: 'none',
+      chain: {
+        simulationCost: {
+          method: 'is_subscriber',
+          stale: true,
+        },
+      },
+    });
   });
 
   it('delegates creator subscriber query to the service', async () => {

--- a/backend/src/subscriptions/subscriptions.service.ts
+++ b/backend/src/subscriptions/subscriptions.service.ts
@@ -334,6 +334,13 @@ export class SubscriptionsService {
       configured: boolean;
       isSubscriber: boolean | null;
       error?: string;
+      simulationCost?: {
+        method: string;
+        worstCaseMinResourceFee: string | null;
+        lastObservedMinResourceFee: string | null;
+        updatedAt: string | null;
+        stale: boolean;
+      };
     };
 
     if (!contractId || !this.chainReader) {
@@ -344,9 +351,27 @@ export class SubscriptionsService {
         fan,
         creator,
       );
+      const simulationCost = this.chainReader.getSimulationCostSummary(
+        'is_subscriber',
+      ) as {
+        method: string;
+        worstCaseMinResourceFee: string | null;
+        lastObservedMinResourceFee: string | null;
+        updatedAt: string | null;
+        stale: boolean;
+      };
       chain = result.ok
-        ? { configured: true, isSubscriber: result.isSubscriber }
-        : { configured: true, isSubscriber: null, error: result.error };
+        ? {
+            configured: true,
+            isSubscriber: result.isSubscriber,
+            simulationCost,
+          }
+        : {
+            configured: true,
+            isSubscriber: null,
+            error: result.error,
+            simulationCost,
+          };
     }
 
     return {


### PR DESCRIPTION
Persist and expose per-method worst-case simulation minResourceFee so subscription status responses include budget risk signals while handling stale or invalid simulation data safely.

Made-with: Cursor

## Summary

<!-- One or two sentences describing what this PR does and why. -->

## Changes

<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [ ] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [ ] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [ ] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [ ] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [ ] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [ ] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [ ] Happy path works end-to-end in a local environment
- [ ] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [ ] No regressions in closely related API or UI flows
- [ ] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [ ] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues
closes #613 