### PR TITLE
feat(contract): link interface docs to code with drift check

### DIFF
--- a/contract/docs/interfaces/README.md
+++ b/contract/docs/interfaces/README.md
@@ -25,3 +25,12 @@ Examples assume local deployment (`contract/deployed-local.json`). Replace:
 
 Run: `soroban contract invoke --network local --source registry --wasm path/to/target.wasm --dry-run` to validate.
 
+## Drift Check
+
+To ensure contract interface docs stay linked to code, run:
+
+- `npm run check:interfaces` (validates all `docs/interfaces/*.md` method tables against referenced `contracts/**/src/lib.rs` files)
+- `npm run test:interfaces` (parser/unit tests for the drift check)
+
+The release checklist (`npm run release-check`) now includes the interface drift check.
+

--- a/contract/docs/interfaces/content-access.md
+++ b/contract/docs/interfaces/content-access.md
@@ -11,7 +11,11 @@ Pay-per-content unlocking.
 | `has_access` | `buyer: Address, creator: Address, content_id: u64` | `bool` | none | `soroban contract invoke ... has_access -- BUYER CREATOR 123` | None |
 | `get_content_price` | `creator: Address, content_id: u64` | `Option<i128>` | none | `soroban contract invoke ... get_content_price -- CREATOR 123` | None |
 | `set_content_price` | `creator: Address, content_id: u64, price: i128` | `()` | creator | `soroban contract invoke ... set_content_price -- CREATOR 123 100` | None |
+| `verify_access` | `claimer: Address, creator: Address, content_id: u64` | `()` | none | `soroban contract invoke ... verify_access -- BUYER CREATOR 123` | None |
+| `set_max_price` | `max_price: i128` | `()` | admin | `soroban contract invoke ... set_max_price -- 1000000` | None |
+| `get_max_price` | `()` | `Option<i128>` | none | `soroban contract invoke ... get_max_price` | None |
 | `set_admin` | `new_admin: Address` | `()` | current admin | `soroban contract invoke ... set_admin -- NEW_ADMIN` | None |
+| `admin` | `()` | `Address` | none | `soroban contract invoke ... admin` | None |
 
 ## Overview
 Buyer pays creator-set price to unlock specific content. Access buyer/creator/content-specific. Idempotent unlocks.

--- a/contract/docs/interfaces/creator-registry.md
+++ b/contract/docs/interfaces/creator-registry.md
@@ -7,7 +7,11 @@ Rate-limited creator registration.
 | Method | Args | Returns | Auth | Example Invoke | Expected Events |
 |--------|------|---------|------|---------------|-----------------|
 | `initialize` | `admin: Address` | `()` | admin | `soroban contract invoke ... initialize -- ADMIN` | None |
+| `set_rate_limit` | `ledgers: u32` | `()` | admin | `soroban contract invoke ... set_rate_limit -- 10` | None |
+| `set_spam_fee` | `token: Address, amount: i128` | `()` | admin | `soroban contract invoke ... set_spam_fee -- TOKEN 1000` | None |
 | `register_creator` | `caller: Address, creator_address: Address, creator_id: u64` | `()` | admin/creator (+ rate limit) | `soroban contract invoke ... register_creator -- CALLER CREATOR 456` | None |
+| `unregister_creator` | `creator_address: Address` | `()` | admin | `soroban contract invoke ... unregister_creator -- CREATOR` | None |
+| `admin` | `()` | `Address` | none | `soroban contract invoke ... admin` | None |
 | `get_creator_id` | `address: Address` | `Option<u64>` | none | `soroban contract invoke ... get_creator_id -- ADDR` | None |
 
 ## Overview

--- a/contract/docs/interfaces/earnings.md
+++ b/contract/docs/interfaces/earnings.md
@@ -10,6 +10,7 @@ Admin-tracked earnings totals.
 | `admin` | `()` | `Address` | none | `soroban contract invoke ... admin` | None |
 | `record` | `creator: Address, amount: i128` | `()` | admin | `soroban contract invoke ... record -- CREATOR 1000` | None |
 | `get_earnings` | `creator: Address` | `i128` | none | `soroban contract invoke ... get_earnings -- CREATOR` | None |
+| `withdraw` | `creator: Address, amount: i128` | `()` | creator | `soroban contract invoke ... withdraw -- CREATOR 500` | `("withdrawn", creator) -> amount` |
 
 ## Overview
 Admin records per-creator earnings totals. Simple accumulator.

--- a/contract/docs/interfaces/myfans-main.md
+++ b/contract/docs/interfaces/myfans-main.md
@@ -1,4 +1,4 @@
-# MyFans Main Contract Interface (contract/src/lib.rs)
+# MyFans Main Contract Interface (contracts/myfans-contract/src/lib.rs)
 
 Core subscription and creator registry.
 
@@ -12,6 +12,8 @@ Core subscription and creator registry.
 | `get_creator` | `address: Address` | `Option<CreatorInfo>` | none | `soroban contract invoke ... get_creator -- ADDR` | None |
 | `create_plan` | `creator: Address, asset: Address, amount: i128, interval_days: u32` | `u32` (plan_id) | creator | `soroban contract invoke ... create_plan -- CREATOR TOKEN_ID 1000 30` | `("plan_created", plan_id) -> creator` |
 | `subscribe` | `fan: Address, plan_id: u32` | `()` | fan | `soroban contract invoke ... subscribe -- FAN_ADDR 1` (fund fan balance first) | `("subscribed", plan_id) -> fan` |
+| `get_plan` | `plan_id: u32` | `Option<Plan>` | none | `soroban contract invoke ... get_plan -- 1` | None |
+| `get_plan_count` | `()` | `u32` | none | `soroban contract invoke ... get_plan_count` | None |
 | `is_subscriber` / `is_subscribed` | `fan: Address, creator: Address` | `bool` | none | `soroban contract invoke ... is_subscriber -- FAN CREATOR` | None |
 | `get_subscription_expiry` | `fan: Address, creator: Address` | `Option<u64>` | none | `soroban contract invoke ... get_subscription_expiry -- FAN CREATOR` | None |
 | `cancel` | `fan: Address, creator: Address` | `()` | fan | `soroban contract invoke ... cancel -- FAN CREATOR` | `("cancelled",) -> fan` |

--- a/contract/docs/interfaces/myfans-token.md
+++ b/contract/docs/interfaces/myfans-token.md
@@ -12,8 +12,10 @@ Standard token implementation.
 | `name` / `symbol` / `decimals` / `total_supply` | `()` | `String/u32/i128` | none | `soroban contract invoke ... name` | None |
 | `approve` | `from: Address, spender: Address, amount: i128, expiration_ledger: u32` | `()` | from | `soroban contract invoke ... approve -- FROM SPENDER 100 1000000` | `("approve", from, spender) -> amount` |
 | `transfer_from` | `spender: Address, from: Address, to: Address, amount: i128` | `()` | spender | `soroban contract invoke ... transfer_from -- SPENDER FROM TO 100` | `("transfer", from, to) -> amount` |
+| `clear_allowance` | `from: Address, spender: Address` | `()` | from | `soroban contract invoke ... clear_allowance -- FROM SPENDER` | None |
 | `allowance` | `from: Address, spender: Address` | `i128` | none | `soroban contract invoke ... allowance -- FROM SPENDER` | None |
 | `mint` | `to: Address, amount: i128` | `()` | admin? | `soroban contract invoke ... mint -- TO 1000` | `("mint", to) -> amount` |
+| `burn` | `from: Address, amount: i128` | `()` | from | `soroban contract invoke ... burn -- FROM 100` | `("burn", from) -> amount` |
 | `balance` / `transfer` | `id: Address` / `from: Address, to: Address, amount: i128` | `i128` / `()` | none/from | `soroban contract invoke ... transfer -- FROM TO 100` | `("transfer", from, to) -> amount` |
 
 ## Overview

--- a/contract/docs/interfaces/subscription.md
+++ b/contract/docs/interfaces/subscription.md
@@ -7,6 +7,7 @@ Advanced subscription with ledger expiry.
 | Method | Args | Returns | Auth | Example Invoke | Expected Events |
 |--------|------|---------|------|---------------|-----------------|
 | `init` | `admin: Address, fee_bps: u32, fee_recipient: Address, token: Address, price: i128` | `()` | admin | `soroban contract invoke ... init -- ADMIN 100 TREASURY TOKEN 1000` | None |
+| `admin` | `()` | `Address` | none | `soroban contract invoke ... admin` | None |
 | `create_plan` | `creator: Address, asset: Address, amount: i128, interval_days: u32` | `u32` | creator | `soroban contract invoke ... create_plan -- CREATOR TOKEN 1000 30` | `("plan_created", plan_id) -> creator` |
 | `subscribe` | `fan: Address, plan_id: u32, token: Address` | `()` | fan | `soroban contract invoke ... subscribe -- FAN 1 TOKEN` | `("subscribed", plan_id) -> fan` |
 | `is_subscriber` | `fan: Address, creator: Address` | `bool` | none | `soroban contract invoke ... is_subscriber -- FAN CREATOR` | None |
@@ -14,7 +15,10 @@ Advanced subscription with ledger expiry.
 | `cancel` | `fan: Address, creator: Address, reason: u32` | `()` | fan | `soroban contract invoke ... cancel -- FAN CREATOR 0` | `("cancelled", fan, creator) -> (true, reason)` |
 | `create_subscription` | `fan: Address, creator: Address, duration_ledgers: u32` | `()` | fan | `soroban contract invoke ... create_subscription -- FAN CREATOR 17280` | None (internal) |
 | `pause` / `unpause` | `()` | `()` | admin | `soroban contract invoke ... pause --` | `("paused" / "unpaused",) -> admin` |
+| `set_fee_recipient` | `new_fee_recipient: Address` | `()` | admin | `soroban contract invoke ... set_fee_recipient -- RECIPIENT` | `("fee_recipient_updated", old, new) -> ()` |
+| `set_fee_bps` | `new_fee_bps: u32` | `()` | admin | `soroban contract invoke ... set_fee_bps -- 250` | `("fee_updated",) -> (old, new)` |
 | `is_paused` | `()` | `bool` | none | `soroban contract invoke ... is_paused` | None |
+| `get_expiry_unix` | `fan: Address, creator: Address` | `(u64, u64)` | none | `soroban contract invoke ... get_expiry_unix -- FAN CREATOR` | None |
 
 ## Overview
 Subscription plans with extend/cancel; overlaps main contract. Uses ledger seq for expiry.

--- a/contract/docs/interfaces/treasury-src.md
+++ b/contract/docs/interfaces/treasury-src.md
@@ -1,4 +1,4 @@
-# Treasury (src/treasury.rs)
+# Treasury (contracts/myfans-contract/src/treasury.rs)
 
 Basic treasury.
 

--- a/contract/package.json
+++ b/contract/package.json
@@ -4,6 +4,8 @@
   "scripts": {
     "build": "cargo build --release --target wasm32-unknown-unknown",
     "test": "cargo test",
+    "test:interfaces": "node --test ./scripts/check-interface-docs-drift.test.mjs",
+    "check:interfaces": "node ./scripts/check-interface-docs-drift.mjs",
     "release-check": "./scripts/release-check.sh",
     "release-check:skip-abi": "./scripts/release-check.sh --skip-abi",
     "release-check:ci": "./scripts/release-check.sh --skip-abi --skip-dry-run"

--- a/contract/scripts/check-interface-docs-drift.mjs
+++ b/contract/scripts/check-interface-docs-drift.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DEFAULT_ROOT = path.resolve(__dirname, '..');
+const INTERFACES_DIR = path.join(DEFAULT_ROOT, 'docs', 'interfaces');
+
+const KNOWN_NON_CONTRACT_DOCS = new Set(['README.md', 'runbook.md']);
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function parseSourcePathFromHeading(markdown) {
+  const heading = markdown.match(/^# .*\(([^)]+)\)/m);
+  if (!heading) return null;
+  return heading[1].trim();
+}
+
+function parseDocumentedMethods(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const methods = new Set();
+  let inMethodsTable = false;
+
+  for (const line of lines) {
+    if (/^\s*\|\s*Method\s*\|/i.test(line)) {
+      inMethodsTable = true;
+      continue;
+    }
+
+    if (!inMethodsTable) {
+      continue;
+    }
+
+    if (!line.trim().startsWith('|')) {
+      break;
+    }
+
+    if (/^\s*\|\s*-+\s*\|/.test(line)) {
+      continue;
+    }
+
+    const columns = line.split('|');
+    if (columns.length < 3) {
+      continue;
+    }
+
+    const rawMethodCell = columns[1].trim();
+    if (!rawMethodCell) {
+      continue;
+    }
+
+    const unquoted = rawMethodCell.replace(/`/g, '');
+    // Support grouped rows such as "pause / unpause"
+    const grouped = unquoted.split('/').map((part) => part.trim());
+    for (const methodName of grouped) {
+      if (!methodName || /\s/.test(methodName)) {
+        continue;
+      }
+      methods.add(methodName);
+    }
+  }
+
+  return methods;
+}
+
+function parseContractMethods(rustSource) {
+  const blocks = extractContractImplBlocks(rustSource);
+  const methods = new Set();
+  if (blocks.length === 0) {
+    return methods;
+  }
+
+  // Production contract entrypoints are expected in the first #[contractimpl] block.
+  // This intentionally ignores test-only helper contracts declared later in #[cfg(test)] modules.
+  const targetBlock = blocks[0];
+  const regex = /\bpub\s+fn\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/g;
+  let match;
+  while ((match = regex.exec(targetBlock)) !== null) {
+    methods.add(match[1]);
+  }
+  return methods;
+}
+
+function extractContractImplBlocks(rustSource) {
+  const blocks = [];
+  const marker = '#[contractimpl]';
+  let cursor = 0;
+
+  while (cursor < rustSource.length) {
+    const markerIdx = rustSource.indexOf(marker, cursor);
+    if (markerIdx === -1) {
+      break;
+    }
+
+    const implIdx = rustSource.indexOf('impl', markerIdx + marker.length);
+    if (implIdx === -1) {
+      break;
+    }
+
+    const braceStart = rustSource.indexOf('{', implIdx);
+    if (braceStart === -1) {
+      break;
+    }
+
+    let depth = 0;
+    let end = braceStart;
+    for (; end < rustSource.length; end++) {
+      const ch = rustSource[end];
+      if (ch === '{') {
+        depth += 1;
+      } else if (ch === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          end += 1;
+          break;
+        }
+      }
+    }
+
+    if (depth === 0) {
+      blocks.push(rustSource.slice(braceStart, end));
+      cursor = end;
+    } else {
+      break;
+    }
+  }
+
+  return blocks;
+}
+
+function toSortedArray(set) {
+  return Array.from(set).sort();
+}
+
+function setDiff(left, right) {
+  const diff = new Set();
+  for (const item of left) {
+    if (!right.has(item)) {
+      diff.add(item);
+    }
+  }
+  return diff;
+}
+
+function collectInterfaceMarkdownFiles(interfacesDir) {
+  return fs
+    .readdirSync(interfacesDir)
+    .filter((entry) => entry.endsWith('.md'))
+    .filter((entry) => !KNOWN_NON_CONTRACT_DOCS.has(entry))
+    .sort()
+    .map((entry) => path.join(interfacesDir, entry));
+}
+
+function validateDocFile(rootDir, docPath) {
+  const markdown = readText(docPath);
+  const headingSourcePath = parseSourcePathFromHeading(markdown);
+  if (!headingSourcePath) {
+    return {
+      ok: false,
+      docPath,
+      error:
+        'Missing source path in H1 heading, expected e.g. "# Name (contracts/.../src/lib.rs)".',
+    };
+  }
+
+  const sourcePath = path.join(rootDir, headingSourcePath);
+  if (!fs.existsSync(sourcePath)) {
+    return {
+      ok: false,
+      docPath,
+      sourcePath,
+      error: `Referenced source file does not exist: ${headingSourcePath}`,
+    };
+  }
+
+  const documentedMethods = parseDocumentedMethods(markdown);
+  if (documentedMethods.size === 0) {
+    return {
+      ok: false,
+      docPath,
+      sourcePath,
+      error: 'No methods found in Methods table.',
+    };
+  }
+
+  const contractMethods = parseContractMethods(readText(sourcePath));
+  const undocumented = setDiff(contractMethods, documentedMethods);
+  const staleDocs = setDiff(documentedMethods, contractMethods);
+
+  return {
+    ok: undocumented.size === 0 && staleDocs.size === 0,
+    docPath,
+    sourcePath,
+    undocumented: toSortedArray(undocumented),
+    staleDocs: toSortedArray(staleDocs),
+  };
+}
+
+export function checkInterfaceDocsDrift(rootDir = DEFAULT_ROOT) {
+  const interfacesDir = path.join(rootDir, 'docs', 'interfaces');
+  const docFiles = collectInterfaceMarkdownFiles(interfacesDir);
+
+  const results = docFiles.map((docPath) => validateDocFile(rootDir, docPath));
+  const failed = results.filter((result) => !result.ok);
+
+  return {
+    ok: failed.length === 0,
+    checked: results.length,
+    results,
+    failed,
+  };
+}
+
+function relativeFromRoot(filePath, rootDir) {
+  return path.relative(rootDir, filePath) || filePath;
+}
+
+function printFailures(summary, rootDir) {
+  for (const result of summary.failed) {
+    const label = relativeFromRoot(result.docPath, rootDir);
+    console.error(`- ${label}`);
+    if (result.error) {
+      console.error(`  error: ${result.error}`);
+      continue;
+    }
+    if (result.undocumented?.length) {
+      console.error(`  undocumented methods: ${result.undocumented.join(', ')}`);
+    }
+    if (result.staleDocs?.length) {
+      console.error(`  stale docs methods: ${result.staleDocs.join(', ')}`);
+    }
+  }
+}
+
+function runCli() {
+  if (!fs.existsSync(INTERFACES_DIR)) {
+    console.error(`interfaces dir not found: ${INTERFACES_DIR}`);
+    process.exit(1);
+  }
+
+  const summary = checkInterfaceDocsDrift(DEFAULT_ROOT);
+  if (summary.ok) {
+    console.log(
+      `Interface docs drift check passed (${summary.checked} files).`,
+    );
+    return;
+  }
+
+  console.error(
+    `Interface docs drift check failed (${summary.failed.length}/${summary.checked} files).`,
+  );
+  printFailures(summary, DEFAULT_ROOT);
+  process.exit(1);
+}
+
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === __filename;
+
+if (invokedDirectly) {
+  runCli();
+}
+
+export {
+  parseSourcePathFromHeading,
+  parseDocumentedMethods,
+  parseContractMethods,
+  extractContractImplBlocks,
+  collectInterfaceMarkdownFiles,
+  validateDocFile,
+};

--- a/contract/scripts/check-interface-docs-drift.test.mjs
+++ b/contract/scripts/check-interface-docs-drift.test.mjs
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  parseSourcePathFromHeading,
+  parseDocumentedMethods,
+  parseContractMethods,
+  extractContractImplBlocks,
+  checkInterfaceDocsDrift,
+} from './check-interface-docs-drift.mjs';
+
+test('parseSourcePathFromHeading reads source path from H1', () => {
+  const md = '# Subscription (contracts/subscription/src/lib.rs)\n\n## Methods';
+  assert.equal(
+    parseSourcePathFromHeading(md),
+    'contracts/subscription/src/lib.rs',
+  );
+});
+
+test('parseDocumentedMethods splits grouped rows and strips backticks', () => {
+  const md = `
+| Method | Args | Returns |
+|---|---|---|
+| \`init\` | x | y |
+| \`pause / unpause\` | x | y |
+| \`is_paused\` | x | y |
+`;
+  const methods = parseDocumentedMethods(md);
+  assert.deepEqual(Array.from(methods).sort(), [
+    'init',
+    'is_paused',
+    'pause',
+    'unpause',
+  ]);
+});
+
+test('parseContractMethods reads pub fn names', () => {
+  const source = `
+impl Helper {
+  pub fn helper() {}
+}
+
+#[contractimpl]
+impl Demo {
+  pub fn init() {}
+  pub fn pause(env: Env) {}
+  fn helper() {}
+}
+`;
+  const methods = parseContractMethods(source);
+  assert.deepEqual(Array.from(methods).sort(), ['init', 'pause']);
+});
+
+test('extractContractImplBlocks returns only contractimpl sections', () => {
+  const source = `
+impl Helper {
+  pub fn helper() {}
+}
+
+#[contractimpl]
+impl Demo {
+  pub fn init() {}
+}
+
+#[contractimpl]
+impl Second {
+  pub fn ping() {}
+}
+`;
+  const blocks = extractContractImplBlocks(source);
+  assert.equal(blocks.length, 2);
+  assert.equal(blocks[0].includes('pub fn init() {}'), true);
+  assert.equal(blocks[1].includes('pub fn ping() {}'), true);
+});
+
+test('checkInterfaceDocsDrift reports stale and undocumented methods', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'iface-drift-'));
+  const docsDir = path.join(root, 'docs', 'interfaces');
+  const srcDir = path.join(root, 'contracts', 'demo', 'src');
+  fs.mkdirSync(docsDir, { recursive: true });
+  fs.mkdirSync(srcDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(srcDir, 'lib.rs'),
+    `
+#[contractimpl]
+impl Demo {
+pub fn init() {}
+pub fn pause() {}
+pub fn health() {}
+}
+`,
+  );
+
+  fs.writeFileSync(
+    path.join(docsDir, 'demo.md'),
+    `# Demo (contracts/demo/src/lib.rs)
+
+## Methods
+| Method | Args | Returns |
+|---|---|---|
+| \`init\` | - | - |
+| \`pause / unpause\` | - | - |
+`,
+  );
+
+  const result = checkInterfaceDocsDrift(root);
+  assert.equal(result.ok, false);
+  assert.equal(result.failed.length, 1);
+  assert.deepEqual(result.failed[0].undocumented, ['health']);
+  assert.deepEqual(result.failed[0].staleDocs, ['unpause']);
+});

--- a/contract/scripts/release-check.sh
+++ b/contract/scripts/release-check.sh
@@ -76,13 +76,18 @@ run_step "cargo clippy" \
 run_step "cargo test" \
   cargo test --all-features --manifest-path "$ROOT_DIR/Cargo.toml"
 
-# ── Step 4: WASM release build ────────────────────────────────────────────────
+# ── Step 4: Interface docs drift check ────────────────────────────────────────
+
+run_step "interface docs drift check" \
+  node "$SCRIPT_DIR/check-interface-docs-drift.mjs"
+
+# ── Step 5: WASM release build ────────────────────────────────────────────────
 
 run_step "cargo build --release (wasm32)" \
   cargo build --release --target wasm32-unknown-unknown \
     --manifest-path "$ROOT_DIR/Cargo.toml"
 
-# ── Step 5: ABI snapshot check ────────────────────────────────────────────────
+# ── Step 6: ABI snapshot check ────────────────────────────────────────────────
 
 if [[ "$SKIP_ABI" == true ]]; then
   echo "[release-check] skipping ABI snapshot check (--skip-abi)"
@@ -93,7 +98,7 @@ else
     bash "$SCRIPT_DIR/snapshot-abi.sh" --check
 fi
 
-# ── Step 6: Deploy dry-run ────────────────────────────────────────────────────
+# ── Step 7: Deploy dry-run ────────────────────────────────────────────────────
 
 if [[ "$SKIP_DRY_RUN" == true ]]; then
   echo "[release-check] skipping deploy dry-run (--skip-dry-run)"
@@ -107,7 +112,7 @@ else
       --dry-run
 fi
 
-# ── Step 7: Deploy output schema check (if deployed.json exists) ──────────────
+# ── Step 8: Deploy output schema check (if deployed.json exists) ──────────────
 
 DEPLOYED_JSON="$ROOT_DIR/deployed.json"
 if [[ -f "$DEPLOYED_JSON" ]]; then


### PR DESCRIPTION
Add check-interface-docs-drift script and npm scripts; wire into release-check. Align docs/interfaces with actual contractimpl entrypoints and fix source paths.

Made-with: Cursor

## Summary

<!-- One or two sentences describing what this PR does and why. -->

## Changes

<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [ ] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [ ] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [ ] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [ ] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [ ] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [ ] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```
closes #614 