### PR TITLE
feat: remove dead code

### DIFF
--- a/contract/contracts/test-consumer/src/lib.rs
+++ b/contract/contracts/test-consumer/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use myfans_lib::{ContentType, SubscriptionStatus};
+use myfans_lib::{ContentType, MyfansError, SubscriptionStatus};
 use soroban_sdk::{contract, contractimpl, Env};
 
 #[contract]
@@ -7,32 +7,80 @@ pub struct TestConsumer;
 
 #[contractimpl]
 impl TestConsumer {
-    pub fn get_status(_env: Env) -> SubscriptionStatus {
-        SubscriptionStatus::Active
-    }
-
-    pub fn get_content(_env: Env) -> ContentType {
-        ContentType::Paid
-    }
-
+    /// Returns true only when `status` is `Active`.
     pub fn is_active(_env: Env, status: SubscriptionStatus) -> bool {
         status == SubscriptionStatus::Active
+    }
+
+    /// Returns the numeric discriminant of a `MyfansError` variant, confirming
+    /// the shared error type is importable and its codes are stable.
+    pub fn error_code(_env: Env, err: MyfansError) -> u32 {
+        err as u32
+    }
+
+    /// Returns the numeric discriminant of a `ContentType` variant.
+    pub fn content_code(_env: Env, ct: ContentType) -> u32 {
+        ct as u32
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use soroban_sdk::Env;
+
+    // ── SubscriptionStatus ────────────────────────────────────────────────
 
     #[test]
-    fn test_import_and_use() {
+    fn active_is_active() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, TestConsumer);
-        let client = TestConsumerClient::new(&env, &contract_id);
-
-        assert_eq!(client.get_status(), SubscriptionStatus::Active);
-        assert_eq!(client.get_content(), ContentType::Paid);
+        let id = env.register_contract(None, TestConsumer);
+        let client = TestConsumerClient::new(&env, &id);
         assert!(client.is_active(&SubscriptionStatus::Active));
+    }
+
+    #[test]
+    fn non_active_statuses_are_not_active() {
+        let env = Env::default();
+        let id = env.register_contract(None, TestConsumer);
+        let client = TestConsumerClient::new(&env, &id);
         assert!(!client.is_active(&SubscriptionStatus::Pending));
+        assert!(!client.is_active(&SubscriptionStatus::Cancelled));
+        assert!(!client.is_active(&SubscriptionStatus::Expired));
+    }
+
+    // ── MyfansError discriminants ─────────────────────────────────────────
+
+    #[test]
+    fn error_codes_are_stable() {
+        let env = Env::default();
+        let id = env.register_contract(None, TestConsumer);
+        let client = TestConsumerClient::new(&env, &id);
+        assert_eq!(client.error_code(&MyfansError::AlreadyInitialized), 1);
+        assert_eq!(client.error_code(&MyfansError::NotInitialized), 2);
+        assert_eq!(client.error_code(&MyfansError::NotAuthorized), 3);
+        assert_eq!(client.error_code(&MyfansError::InsufficientBalance), 4);
+        assert_eq!(client.error_code(&MyfansError::InvalidFeeBps), 5);
+        assert_eq!(client.error_code(&MyfansError::RateLimited), 6);
+        assert_eq!(client.error_code(&MyfansError::AlreadyRegistered), 7);
+        assert_eq!(client.error_code(&MyfansError::NotLiked), 8);
+        assert_eq!(client.error_code(&MyfansError::Paused), 9);
+        assert_eq!(client.error_code(&MyfansError::ContentPriceNotSet), 101);
+        assert_eq!(client.error_code(&MyfansError::SubscriptionNotFound), 102);
+        assert_eq!(client.error_code(&MyfansError::SubscriptionExpired), 103);
+        assert_eq!(client.error_code(&MyfansError::AdminNotInitialized), 104);
+        assert_eq!(client.error_code(&MyfansError::NegativeMinBalance), 105);
+        assert_eq!(client.error_code(&MyfansError::MinBalanceViolation), 106);
+    }
+
+    // ── ContentType discriminants ─────────────────────────────────────────
+
+    #[test]
+    fn content_type_codes_are_stable() {
+        let env = Env::default();
+        let id = env.register_contract(None, TestConsumer);
+        let client = TestConsumerClient::new(&env, &id);
+        assert_eq!(client.content_code(&ContentType::Free), 0);
+        assert_eq!(client.content_code(&ContentType::Paid), 1);
     }
 }


### PR DESCRIPTION
  Here's what was done and why:
  
  Dead code removed:
  
  - get_status() — hardcoded SubscriptionStatus::Active, never exercised any logic
  - get_content() — hardcoded ContentType::Paid, same problem
  
  Both were pure stubs that returned constants. They added Wasm surface without testing anything.
  
  What replaced them:
  
  ┌─────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ New entry point │ Purpose                                                                                                         │
  ├─────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ is_active()     │ Kept — it has real logic (equality check)                                                                       │
  ├─────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ error_code()    │ New — proves MyfansError is importable from myfans-lib and its discriminants are stable across crate boundaries │
  ├─────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ content_code()  │ New — same for ContentType                                                                                      │
  └─────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  
  Tests added (4 total):
  
  - active_is_active — positive case for is_active
  - non_active_statuses_are_not_active — covers all 3 non-active variants (Pending, Cancelled, Expired)
  - error_codes_are_stable — asserts all 15 MyfansError discriminants match their documented values; this acts as a regression guard — if anyone renumbers an error
  code in myfans-lib, this test breaks immediately
  - content_type_codes_are_stable — same for ContentType
  
  No regressions: the crate's public contract interface still exports is_active, and the test patterns match the existing repo style (inline Env::default() +
  register_contract + Client::new).

closes #621 