### PR TITLE
feat: wasm build size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,3 +268,91 @@ jobs:
       - name: Build
         run: cargo build --release
         working-directory: contract
+
+  wasm-size:
+    name: Wasm Build Size
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: contract
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Cache Cargo registry
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ~/.cargo/git/checkouts
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('contract/**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache Cargo target directory
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: contract/target
+          key: ${{ runner.os }}-contract-target-${{ hashFiles('contract/**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-contract-target-
+
+      - name: Install toolchain
+        run: rustup target add wasm32-unknown-unknown
+        working-directory: contract
+
+      - name: Build Wasm (release)
+        run: cargo build --release --target wasm32-unknown-unknown
+        working-directory: contract
+
+      - name: Generate size report
+        working-directory: contract
+        run: |
+          REPORT="wasm-size-report.txt"
+          WASM_DIR="target/wasm32-unknown-unknown/release"
+          echo "# Wasm Build Size Report" > "$REPORT"
+          echo "Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> "$REPORT"
+          echo "Commit:    ${GITHUB_SHA}" >> "$REPORT"
+          echo "" >> "$REPORT"
+          printf "%-40s %10s %10s\n" "Contract" "Bytes" "KiB" >> "$REPORT"
+          printf "%-40s %10s %10s\n" "--------" "-----" "---" >> "$REPORT"
+          TOTAL=0
+          while IFS= read -r -d '' f; do
+            name=$(basename "$f")
+            bytes=$(stat -c%s "$f")
+            kib=$(echo "scale=1; $bytes / 1024" | bc)
+            printf "%-40s %10d %10s\n" "$name" "$bytes" "$kib" >> "$REPORT"
+            TOTAL=$((TOTAL + bytes))
+          done < <(find "$WASM_DIR" -maxdepth 1 -name '*.wasm' -print0 | sort -z)
+          TOTAL_KIB=$(echo "scale=1; $TOTAL / 1024" | bc)
+          echo "" >> "$REPORT"
+          printf "%-40s %10d %10s\n" "TOTAL" "$TOTAL" "$TOTAL_KIB" >> "$REPORT"
+          cat "$REPORT"
+
+      - name: Upload size report artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wasm-size-report
+          path: contract/wasm-size-report.txt
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Write step summary
+        working-directory: contract
+        run: |
+          WASM_DIR="target/wasm32-unknown-unknown/release"
+          echo "## Wasm Build Size" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Contract | Bytes | KiB |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|------:|----:|" >> $GITHUB_STEP_SUMMARY
+          TOTAL=0
+          while IFS= read -r -d '' f; do
+            name=$(basename "$f")
+            bytes=$(stat -c%s "$f")
+            kib=$(echo "scale=1; $bytes / 1024" | bc)
+            echo "| \`$name\` | $bytes | $kib |" >> $GITHUB_STEP_SUMMARY
+            TOTAL=$((TOTAL + bytes))
+          done < <(find "$WASM_DIR" -maxdepth 1 -name '*.wasm' -print0 | sort -z)
+          TOTAL_KIB=$(echo "scale=1; $TOTAL / 1024" | bc)
+          echo "| **TOTAL** | **$TOTAL** | **$TOTAL_KIB** |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -99,6 +99,37 @@ jobs:
             >> $GITHUB_STEP_SUMMARY
         working-directory: contract
 
+      - name: 📏 Generate Wasm size report
+        run: |
+          REPORT="wasm-size-report.txt"
+          WASM_DIR="target/wasm32-unknown-unknown/release"
+          echo "# Wasm Build Size Report" > "$REPORT"
+          echo "Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> "$REPORT"
+          echo "Commit:    ${GITHUB_SHA}" >> "$REPORT"
+          echo "" >> "$REPORT"
+          printf "%-40s %10s %10s\n" "Contract" "Bytes" "KiB" >> "$REPORT"
+          printf "%-40s %10s %10s\n" "--------" "-----" "---" >> "$REPORT"
+          TOTAL=0
+          while IFS= read -r -d '' f; do
+            name=$(basename "$f")
+            bytes=$(stat -c%s "$f")
+            kib=$(echo "scale=1; $bytes / 1024" | bc)
+            printf "%-40s %10d %10s\n" "$name" "$bytes" "$kib" >> "$REPORT"
+            TOTAL=$((TOTAL + bytes))
+          done < <(find "$WASM_DIR" -maxdepth 1 -name '*.wasm' -print0 | sort -z)
+          TOTAL_KIB=$(echo "scale=1; $TOTAL / 1024" | bc)
+          echo "" >> "$REPORT"
+          printf "%-40s %10d %10s\n" "TOTAL" "$TOTAL" "$TOTAL_KIB" >> "$REPORT"
+        working-directory: contract
+
+      - name: 📦 Upload Wasm size report artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wasm-size-report
+          path: contract/wasm-size-report.txt
+          retention-days: 30
+          if-no-files-found: error
+
       # ── Step 5: ABI snapshot check ────────────────────────────────────────
       # stellar CLI is not available in standard CI runners; we verify the
       # snapshot files are committed and non-empty as a proxy check.

--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -1,0 +1,109 @@
+name: Wasm Build Size
+
+# Builds every cdylib contract to wasm32-unknown-unknown (release profile),
+# writes a size report, and uploads it as a downloadable CI artifact.
+# Runs on every PR / push that touches contract code, and on demand.
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'contract/**'
+      - '.github/workflows/wasm-size.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'contract/**'
+      - '.github/workflows/wasm-size.yml'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+
+permissions:
+  contents: read
+
+jobs:
+  wasm-size:
+    name: Wasm Build Size Report
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: contract
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          workspaces: contract
+
+      - name: Build Wasm (release)
+        run: cargo build --release --target wasm32-unknown-unknown
+
+      - name: Generate size report
+        run: |
+          REPORT="wasm-size-report.txt"
+          WASM_DIR="target/wasm32-unknown-unknown/release"
+
+          echo "# Wasm Build Size Report" > "$REPORT"
+          echo "Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> "$REPORT"
+          echo "Commit:    ${GITHUB_SHA:-local}" >> "$REPORT"
+          echo "" >> "$REPORT"
+          printf "%-40s %10s %10s\n" "Contract" "Bytes" "KiB" >> "$REPORT"
+          printf "%-40s %10s %10s\n" "--------" "-----" "---" >> "$REPORT"
+
+          TOTAL=0
+          while IFS= read -r -d '' f; do
+            name=$(basename "$f")
+            bytes=$(stat -c%s "$f")
+            kib=$(echo "scale=1; $bytes / 1024" | bc)
+            printf "%-40s %10d %10s\n" "$name" "$bytes" "${kib}" >> "$REPORT"
+            TOTAL=$((TOTAL + bytes))
+          done < <(find "$WASM_DIR" -maxdepth 1 -name '*.wasm' -print0 | sort -z)
+
+          TOTAL_KIB=$(echo "scale=1; $TOTAL / 1024" | bc)
+          echo "" >> "$REPORT"
+          printf "%-40s %10d %10s\n" "TOTAL" "$TOTAL" "${TOTAL_KIB}" >> "$REPORT"
+
+          cat "$REPORT"
+
+      - name: Upload size report artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wasm-size-report
+          path: contract/wasm-size-report.txt
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Write step summary
+        run: |
+          WASM_DIR="target/wasm32-unknown-unknown/release"
+          echo "## Wasm Build Size Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Contract | Bytes | KiB |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|------:|----:|" >> $GITHUB_STEP_SUMMARY
+
+          TOTAL=0
+          while IFS= read -r -d '' f; do
+            name=$(basename "$f")
+            bytes=$(stat -c%s "$f")
+            kib=$(echo "scale=1; $bytes / 1024" | bc)
+            echo "| \`$name\` | $bytes | $kib |" >> $GITHUB_STEP_SUMMARY
+            TOTAL=$((TOTAL + bytes))
+          done < <(find "$WASM_DIR" -maxdepth 1 -name '*.wasm' -print0 | sort -z)
+
+          TOTAL_KIB=$(echo "scale=1; $TOTAL / 1024" | bc)
+          echo "| **TOTAL** | **$TOTAL** | **$TOTAL_KIB** |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Artifact: \`wasm-size-report\` (retained 30 days)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What was implemented
 .github/workflows/wasm-size.yml (new, 109 lines)
  A dedicated workflow that triggers on any contract/** change. It:
  
  - Installs the stable Rust toolchain with wasm32-unknown-unknown target
  - Runs cargo build --release --target wasm32-unknown-unknown
  - Generates wasm-size-report.txt with per-contract byte count, KiB, and a total row
  - Uploads it as the wasm-size-report artifact (retained 30 days) — this is the downloadable CI artifact
  - Writes a Markdown table to the GitHub step summary for inline visibility
  
  .github/workflows/ci.yml (modified)
  Added a wasm-size job that runs after the existing contract job (needs: contract). It reuses the same Cargo cache keys so the Wasm build is fast (registry already
  warm), then generates the same report and uploads the same artifact.
  
  .github/workflows/contract-release.yml (modified)
  The existing 🏗️ Build WASM release artifacts step already built Wasm but discarded the output. Two steps were inserted immediately after it:
  
  - 📏 Generate Wasm size report — writes wasm-size-report.txt
  - 📦 Upload Wasm size report artifact — uploads it with if-no-files-found: error so a missing report fails the job
  
  Manual checklist to verify:
  
  1. Open any PR touching contract/ → CI runs → "Wasm Build Size" job appears
  2. Click the job → step summary shows the size table
  3. Go to the run's "Artifacts" section → download wasm-size-report → open wasm-size-report.txt and confirm per-contract sizes and total are present

closes #622 