### PR TITLE
Document Freighter vs other wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ You will keep only these three folders and this README; other files can be remov
 - **Fans**: Discover creators, view plans, subscribe (sign Soroban tx), manage active subscriptions.
 - **UX**: Show subscription status, next billing, and “access granted” for gated content.
 
+### Wallet support today
+
+The current frontend wallet implementation does not treat all wallets equally:
+
+| Wallet | Current repo status | Practical difference in MyFans |
+|--------|----------------------|--------------------------------|
+| **Freighter** | Fully wired for connection and transaction signing | Best choice for creator and fan flows that need Soroban transaction approval today |
+| **Lobstr** | Wallet selection UI and install guidance exist, but the integration is still marked pending | Discoverability is documented, but users should not assume full signing parity with Freighter yet |
+| **WalletConnect** | Wallet selection UI exists, but protocol integration is still marked pending | Treat it as planned support rather than a production-ready path in this repo |
+
+If you are documenting or testing wallet-based flows in this repository, assume **Freighter is the reference implementation** until Lobstr and WalletConnect move from interface-ready to fully integrated.
+
 ### Tech
 
 - **Next.js** (App Router or Pages as you prefer).


### PR DESCRIPTION
Adds README guidance clarifying Freighter as the reference wired wallet path and Lobstr/WalletConnect as not equivalent production signing paths yet.

Validation:
- git diff --check main...docs/705-freighter-vs-wallets
- cd contract && cargo fmt --check (attempted; existing Rust formatting issues are unrelated)

closes #705