### PR TITLE
Property tests for token transfers + non-interactive deploy mode

### DIFF
--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -30,6 +30,7 @@ publish = false
 
 [workspace.dependencies]
 soroban-sdk = "21.7.7"
+proptest = { version = "1.5.0", default-features = false, features = ["std"] }
 
 [profile.release]
 opt-level = "z"

--- a/contract/README.md
+++ b/contract/README.md
@@ -114,3 +114,77 @@ GitHub Actions `contracts` job now includes:
 4. Verify contract responses during deploy
 
 If contract deploy or verification fails, CI fails.
+
+## Non-interactive mode (CI / automation)
+
+Pass `--non-interactive` to disable all interactive prompts and key-generation side-effects.
+In this mode the script will **fail immediately** if the source identity does not already exist,
+rather than generating one on the fly.
+
+This is the recommended flag for any automated pipeline (GitHub Actions, GitLab CI, etc.).
+
+### Required pre-conditions
+
+Before running the script in non-interactive mode you must:
+
+1. **Create the identity** (once, outside CI):
+   ```bash
+   stellar keys generate myfans-deployer --network testnet --fund
+   ```
+2. **Export the secret key** and store it as a CI secret (e.g. `STELLAR_SECRET_KEY`).
+3. **Import the key inside the CI job** before calling the deploy script:
+   ```bash
+   stellar keys add myfans-deployer --secret-key "$STELLAR_SECRET_KEY"
+   ```
+
+### Typical CI invocation
+
+```bash
+# Dry-run (build + WASM validation only — no transactions):
+./contract/scripts/deploy.sh \
+  --network testnet \
+  --source myfans-deployer \
+  --non-interactive \
+  --dry-run
+
+# Full deploy (submits transactions):
+./contract/scripts/deploy.sh \
+  --network testnet \
+  --source myfans-deployer \
+  --non-interactive \
+  --no-fund \
+  --out /tmp/deployed.json \
+  --env-out /tmp/.env.deployed
+```
+
+### GitHub Actions example
+
+```yaml
+- name: Import deployer identity
+  run: stellar keys add myfans-deployer --secret-key "${{ secrets.STELLAR_SECRET_KEY }}"
+
+- name: Deploy contracts (dry-run)
+  run: |
+    ./contract/scripts/deploy.sh \
+      --network testnet \
+      --source myfans-deployer \
+      --non-interactive \
+      --dry-run
+```
+
+### Flag reference
+
+| Flag | Effect |
+|------|--------|
+| `--non-interactive` | Fail if identity is missing; never prompt or auto-generate |
+| `--dry-run` | Build + validate WASM artifacts; skip all on-chain transactions |
+| `--no-fund` | Skip friendbot funding (required when account is already funded) |
+| `--network` | `futurenet` \| `testnet` \| `mainnet` |
+| `--source` | Stellar identity name (must exist when `--non-interactive` is set) |
+
+### Manual checklist
+
+- [ ] `stellar keys public-key myfans-deployer` returns the expected public key
+- [ ] `./contract/scripts/deploy.sh --network testnet --non-interactive --dry-run` exits 0
+- [ ] `./contract/scripts/deploy.sh --network testnet --non-interactive --no-fund` exits 0 and writes `deployed.json`
+- [ ] Removing the identity and re-running with `--non-interactive` exits non-zero with a clear error message

--- a/contract/contracts/myfans-token/Cargo.toml
+++ b/contract/contracts/myfans-token/Cargo.toml
@@ -16,6 +16,7 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = { workspace = true }
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/contract/contracts/myfans-token/src/lib.rs
+++ b/contract/contracts/myfans-token/src/lib.rs
@@ -390,3 +390,6 @@ mod test;
 
 #[cfg(test)]
 mod allowance_expiry_tests;
+
+#[cfg(test)]
+mod property_tests;

--- a/contract/contracts/myfans-token/src/property_tests.rs
+++ b/contract/contracts/myfans-token/src/property_tests.rs
@@ -1,0 +1,305 @@
+//! Property-based tests for myfans-token transfer operations.
+//!
+//! These tests use `proptest` to drive arbitrary inputs through the token's
+//! transfer, transfer_from, mint, and burn paths, verifying invariants that
+//! must hold for any valid combination of amounts and balances.
+//!
+//! Run with: `cargo test -p myfans-token prop_`
+
+#[cfg(test)]
+mod props {
+    use crate::{Error, MyFansToken, MyFansTokenClient};
+    use proptest::prelude::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Env, String,
+    };
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    fn setup(env: &Env) -> (MyFansTokenClient<'_>, Address) {
+        let contract_id = env.register_contract(None, MyFansToken);
+        let client = MyFansTokenClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(
+            &admin,
+            &String::from_str(env, "MyFans Token"),
+            &String::from_str(env, "MFAN"),
+            &7,
+            &0,
+        );
+        (client, admin)
+    }
+
+    // ── transfer invariants ──────────────────────────────────────────────────
+
+    proptest! {
+        /// For any valid transfer amount (1..=balance), balances shift by exactly
+        /// `amount` and total supply is conserved.
+        #[test]
+        fn prop_transfer_conserves_supply(
+            mint_amount in 1i128..=1_000_000_000i128,
+            transfer_amount in 1i128..=1_000_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let sender = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            client.mint(&sender, &mint_amount);
+            let supply_before = client.total_supply();
+
+            // Only transfer if we have enough balance.
+            if transfer_amount <= mint_amount {
+                client.transfer(&sender, &receiver, &transfer_amount);
+
+                prop_assert_eq!(client.balance(&sender), mint_amount - transfer_amount);
+                prop_assert_eq!(client.balance(&receiver), transfer_amount);
+                prop_assert_eq!(client.total_supply(), supply_before, "supply must not change on transfer");
+            }
+        }
+
+        /// Zero and negative amounts must always be rejected with InvalidAmount.
+        #[test]
+        fn prop_transfer_rejects_non_positive_amount(
+            mint_amount in 1i128..=1_000_000i128,
+            bad_amount in i128::MIN..=0i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let sender = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            client.mint(&sender, &mint_amount);
+
+            prop_assert_eq!(
+                client.try_transfer(&sender, &receiver, &bad_amount),
+                Err(Ok(Error::InvalidAmount))
+            );
+        }
+
+        /// Transferring more than the balance must always fail with InsufficientBalance.
+        #[test]
+        fn prop_transfer_fails_when_exceeds_balance(
+            mint_amount in 0i128..=1_000_000i128,
+            excess in 1i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let sender = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            if mint_amount > 0 {
+                client.mint(&sender, &mint_amount);
+            }
+
+            let over_amount = mint_amount.saturating_add(excess);
+            // over_amount is always > mint_amount (balance), so must fail.
+            prop_assert_eq!(
+                client.try_transfer(&sender, &receiver, &over_amount),
+                Err(Ok(Error::InsufficientBalance))
+            );
+        }
+
+        /// Self-transfer of a valid amount must succeed and leave balances unchanged.
+        #[test]
+        fn prop_self_transfer_is_noop(
+            mint_amount in 1i128..=1_000_000i128,
+            transfer_amount in 1i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let user = Address::generate(&env);
+            client.mint(&user, &mint_amount);
+
+            if transfer_amount <= mint_amount {
+                client.transfer(&user, &user, &transfer_amount);
+                // Balance must be unchanged after self-transfer.
+                prop_assert_eq!(client.balance(&user), mint_amount);
+            }
+        }
+    }
+
+    // ── transfer_from invariants ─────────────────────────────────────────────
+
+    proptest! {
+        /// transfer_from with a valid allowance and sufficient balance must
+        /// deduct from both the owner's balance and the remaining allowance.
+        #[test]
+        fn prop_transfer_from_deducts_allowance_and_balance(
+            mint_amount   in 1i128..=1_000_000i128,
+            allowance_amt in 1i128..=1_000_000i128,
+            spend_amount  in 1i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let owner    = Address::generate(&env);
+            let spender  = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            client.mint(&owner, &mint_amount);
+            // Approve with a ledger far in the future.
+            client.approve(&owner, &spender, &allowance_amt, &10_000);
+
+            if spend_amount <= allowance_amt && spend_amount <= mint_amount {
+                client.transfer_from(&spender, &owner, &receiver, &spend_amount);
+
+                prop_assert_eq!(client.balance(&owner),    mint_amount   - spend_amount);
+                prop_assert_eq!(client.balance(&receiver), spend_amount);
+                prop_assert_eq!(client.allowance(&owner, &spender), allowance_amt - spend_amount);
+            }
+        }
+
+        /// transfer_from must fail with InsufficientAllowance when spend > allowance.
+        #[test]
+        fn prop_transfer_from_fails_when_exceeds_allowance(
+            mint_amount   in 1i128..=1_000_000i128,
+            allowance_amt in 1i128..=999_999i128,
+            excess        in 1i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let owner    = Address::generate(&env);
+            let spender  = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            // Ensure owner has enough balance so the failure is about allowance.
+            let big_mint = mint_amount.saturating_add(excess).saturating_add(allowance_amt);
+            client.mint(&owner, &big_mint);
+            client.approve(&owner, &spender, &allowance_amt, &10_000);
+
+            let over_spend = allowance_amt.saturating_add(excess);
+            prop_assert_eq!(
+                client.try_transfer_from(&spender, &owner, &receiver, &over_spend),
+                Err(Ok(Error::InsufficientAllowance))
+            );
+        }
+
+        /// transfer_from must fail with AllowanceExpired when ledger > expiration.
+        #[test]
+        fn prop_transfer_from_fails_after_expiry(
+            mint_amount  in 1i128..=1_000_000i128,
+            spend_amount in 1i128..=1_000_000i128,
+            expiry       in 2u32..=1_000u32,
+            past_offset  in 1u32..=500u32,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let owner    = Address::generate(&env);
+            let spender  = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            let big_mint = mint_amount.max(spend_amount);
+            client.mint(&owner, &big_mint);
+            client.approve(&owner, &spender, &big_mint, &expiry);
+
+            // Advance ledger past expiry.
+            let past_ledger = expiry.saturating_add(past_offset);
+            env.ledger().with_mut(|li| li.sequence_number = past_ledger);
+
+            prop_assert_eq!(
+                client.try_transfer_from(&spender, &owner, &receiver, &spend_amount),
+                Err(Ok(Error::AllowanceExpired))
+            );
+        }
+    }
+
+    // ── mint / burn invariants ───────────────────────────────────────────────
+
+    proptest! {
+        /// Minting must increase both the recipient's balance and total supply
+        /// by exactly `amount`.
+        #[test]
+        fn prop_mint_increases_supply(amount in 1i128..=1_000_000_000i128) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let recipient = Address::generate(&env);
+            let supply_before = client.total_supply();
+
+            client.mint(&recipient, &amount);
+
+            prop_assert_eq!(client.balance(&recipient), amount);
+            prop_assert_eq!(client.total_supply(), supply_before + amount);
+        }
+
+        /// Burning must decrease both the holder's balance and total supply
+        /// by exactly `amount`.
+        #[test]
+        fn prop_burn_decreases_supply(
+            mint_amount in 1i128..=1_000_000_000i128,
+            burn_amount in 1i128..=1_000_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let holder = Address::generate(&env);
+            client.mint(&holder, &mint_amount);
+
+            if burn_amount <= mint_amount {
+                let supply_before = client.total_supply();
+                client.burn(&holder, &burn_amount);
+
+                prop_assert_eq!(client.balance(&holder), mint_amount - burn_amount);
+                prop_assert_eq!(client.total_supply(), supply_before - burn_amount);
+            }
+        }
+
+        /// Burning more than the balance must fail with InsufficientBalance.
+        #[test]
+        fn prop_burn_fails_when_exceeds_balance(
+            mint_amount in 0i128..=1_000_000i128,
+            excess      in 1i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let holder = Address::generate(&env);
+            if mint_amount > 0 {
+                client.mint(&holder, &mint_amount);
+            }
+
+            let over_burn = mint_amount.saturating_add(excess);
+            prop_assert_eq!(
+                client.try_burn(&holder, &over_burn),
+                Err(Ok(Error::InsufficientBalance))
+            );
+        }
+
+        /// Zero and negative burn amounts must be rejected with InvalidAmount.
+        #[test]
+        fn prop_burn_rejects_non_positive_amount(
+            mint_amount in 1i128..=1_000_000i128,
+            bad_amount  in i128::MIN..=0i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let holder = Address::generate(&env);
+            client.mint(&holder, &mint_amount);
+
+            prop_assert_eq!(
+                client.try_burn(&holder, &bad_amount),
+                Err(Ok(Error::InvalidAmount))
+            );
+        }
+    }
+}

--- a/contract/scripts/deploy.sh
+++ b/contract/scripts/deploy.sh
@@ -22,6 +22,7 @@ OUTPUT_JSON="$ROOT_DIR/deployed.json"
 OUTPUT_ENV="$ROOT_DIR/.env.deployed"
 AUTO_FUND="true"
 DRY_RUN="false"
+NON_INTERACTIVE="false"
 
 usage() {
   cat <<USAGE
@@ -36,6 +37,7 @@ Options:
   --env-out <path>                       Output env path (default: contract/.env.deployed)
   --no-fund                              Disable auto funding on futurenet/testnet
   --dry-run                              Validate build and config without submitting transactions
+  --non-interactive                      CI mode: never prompt; fail if identity is missing
   -h, --help                             Show this help
 USAGE
 }
@@ -77,6 +79,10 @@ while [[ $# -gt 0 ]]; do
       DRY_RUN="true"
       shift
       ;;
+    --non-interactive)
+      NON_INTERACTIVE="true"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -114,6 +120,9 @@ NETWORK_PASSPHRASE="${NETWORK_PASSPHRASE:-$DEFAULT_NETWORK_PASSPHRASE}"
 if [[ "$DRY_RUN" == "true" ]]; then
   echo "[deploy] *** DRY-RUN MODE — no transactions will be submitted ***"
 fi
+if [[ "$NON_INTERACTIVE" == "true" ]]; then
+  echo "[deploy] *** NON-INTERACTIVE MODE — identity auto-generation disabled ***"
+fi
 echo "[deploy] network=$NETWORK"
 echo "[deploy] rpc=$RPC_URL"
 
@@ -132,6 +141,12 @@ fi
 if ! "${STELLAR[@]}" keys public-key "$SOURCE_ACCOUNT" >/dev/null 2>&1; then
   if [[ "$NETWORK" == "mainnet" ]]; then
     echo "Source account '$SOURCE_ACCOUNT' not found and auto-generation on mainnet is disabled." >&2
+    exit 1
+  fi
+
+  if [[ "$NON_INTERACTIVE" == "true" ]]; then
+    echo "[deploy] ERROR: identity '$SOURCE_ACCOUNT' not found and --non-interactive is set." >&2
+    echo "[deploy] Pre-create the identity with: stellar keys generate $SOURCE_ACCOUNT --network $NETWORK" >&2
     exit 1
   fi
 


### PR DESCRIPTION
closes #612 
closes #616 


PR Description
  
  Task 1 — Property-based tests for token transfers
  
  Added contract/contracts/myfans-token/src/property_tests.rs using proptest
  (https://github.com/proptest-rs/proptest) to drive arbitrary inputs through every token transfer
  path and verify invariants that must hold for any valid combination of amounts and balances.
  
  What is covered:
  
  
  Files changed:
  
  - contract/contracts/myfans-token/src/property_tests.rs — new file (305 lines)
  - contract/contracts/myfans-token/src/lib.rs — wired mod property_tests
  - contract/contracts/myfans-token/Cargo.toml — added proptest dev-dependency
  - contract/Cargo.toml — pinned proptest = "1.5.0" in workspace dependencies
  
  How to verify:
  
  cd contract && cargo test -p myfans-token prop_
  
  ────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 2 — E2E deploy script: non-interactive mode docs
  
  Added a --non-interactive flag to contract/scripts/deploy.sh for safe use in CI pipelines, and
  documented the full usage pattern in contract/README.md.
  
  Behaviour of --non-interactive:
  
  - Disables all interactive side-effects (no key generation, no prompts)
  - Fails immediately with a clear error message if the source identity does not already exist
  - Combines cleanly with --dry-run (build + WASM validation only) and --no-fund
  - Mainnet already blocked auto-generation; this extends the same safety to testnet/futurenet in
  CI
  
  Files changed:
  
  - contract/scripts/deploy.sh — added NON_INTERACTIVE variable, --non-interactive flag in usage +
  arg parser, guard in identity-generation block, log line
  - contract/README.md — new Non-interactive mode (CI / automation) section with: pre-conditions,
  typical CI invocation, GitHub Actions example snippet, flag reference table, and manual
  checklist
  How to verify:
  
  
  
