### PR TITLE
 Viewport export + network mismatch UX

### DIFF
--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -30,6 +30,7 @@ publish = false
 
 [workspace.dependencies]
 soroban-sdk = "21.7.7"
+proptest = { version = "1.5.0", default-features = false, features = ["std"] }
 
 [profile.release]
 opt-level = "z"

--- a/contract/README.md
+++ b/contract/README.md
@@ -114,3 +114,77 @@ GitHub Actions `contracts` job now includes:
 4. Verify contract responses during deploy
 
 If contract deploy or verification fails, CI fails.
+
+## Non-interactive mode (CI / automation)
+
+Pass `--non-interactive` to disable all interactive prompts and key-generation side-effects.
+In this mode the script will **fail immediately** if the source identity does not already exist,
+rather than generating one on the fly.
+
+This is the recommended flag for any automated pipeline (GitHub Actions, GitLab CI, etc.).
+
+### Required pre-conditions
+
+Before running the script in non-interactive mode you must:
+
+1. **Create the identity** (once, outside CI):
+   ```bash
+   stellar keys generate myfans-deployer --network testnet --fund
+   ```
+2. **Export the secret key** and store it as a CI secret (e.g. `STELLAR_SECRET_KEY`).
+3. **Import the key inside the CI job** before calling the deploy script:
+   ```bash
+   stellar keys add myfans-deployer --secret-key "$STELLAR_SECRET_KEY"
+   ```
+
+### Typical CI invocation
+
+```bash
+# Dry-run (build + WASM validation only — no transactions):
+./contract/scripts/deploy.sh \
+  --network testnet \
+  --source myfans-deployer \
+  --non-interactive \
+  --dry-run
+
+# Full deploy (submits transactions):
+./contract/scripts/deploy.sh \
+  --network testnet \
+  --source myfans-deployer \
+  --non-interactive \
+  --no-fund \
+  --out /tmp/deployed.json \
+  --env-out /tmp/.env.deployed
+```
+
+### GitHub Actions example
+
+```yaml
+- name: Import deployer identity
+  run: stellar keys add myfans-deployer --secret-key "${{ secrets.STELLAR_SECRET_KEY }}"
+
+- name: Deploy contracts (dry-run)
+  run: |
+    ./contract/scripts/deploy.sh \
+      --network testnet \
+      --source myfans-deployer \
+      --non-interactive \
+      --dry-run
+```
+
+### Flag reference
+
+| Flag | Effect |
+|------|--------|
+| `--non-interactive` | Fail if identity is missing; never prompt or auto-generate |
+| `--dry-run` | Build + validate WASM artifacts; skip all on-chain transactions |
+| `--no-fund` | Skip friendbot funding (required when account is already funded) |
+| `--network` | `futurenet` \| `testnet` \| `mainnet` |
+| `--source` | Stellar identity name (must exist when `--non-interactive` is set) |
+
+### Manual checklist
+
+- [ ] `stellar keys public-key myfans-deployer` returns the expected public key
+- [ ] `./contract/scripts/deploy.sh --network testnet --non-interactive --dry-run` exits 0
+- [ ] `./contract/scripts/deploy.sh --network testnet --non-interactive --no-fund` exits 0 and writes `deployed.json`
+- [ ] Removing the identity and re-running with `--non-interactive` exits non-zero with a clear error message

--- a/contract/contracts/myfans-token/Cargo.toml
+++ b/contract/contracts/myfans-token/Cargo.toml
@@ -16,6 +16,7 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = { workspace = true }
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/contract/contracts/myfans-token/src/lib.rs
+++ b/contract/contracts/myfans-token/src/lib.rs
@@ -390,3 +390,6 @@ mod test;
 
 #[cfg(test)]
 mod allowance_expiry_tests;
+
+#[cfg(test)]
+mod property_tests;

--- a/contract/contracts/myfans-token/src/property_tests.rs
+++ b/contract/contracts/myfans-token/src/property_tests.rs
@@ -1,0 +1,305 @@
+//! Property-based tests for myfans-token transfer operations.
+//!
+//! These tests use `proptest` to drive arbitrary inputs through the token's
+//! transfer, transfer_from, mint, and burn paths, verifying invariants that
+//! must hold for any valid combination of amounts and balances.
+//!
+//! Run with: `cargo test -p myfans-token prop_`
+
+#[cfg(test)]
+mod props {
+    use crate::{Error, MyFansToken, MyFansTokenClient};
+    use proptest::prelude::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Env, String,
+    };
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    fn setup(env: &Env) -> (MyFansTokenClient<'_>, Address) {
+        let contract_id = env.register_contract(None, MyFansToken);
+        let client = MyFansTokenClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(
+            &admin,
+            &String::from_str(env, "MyFans Token"),
+            &String::from_str(env, "MFAN"),
+            &7,
+            &0,
+        );
+        (client, admin)
+    }
+
+    // ── transfer invariants ──────────────────────────────────────────────────
+
+    proptest! {
+        /// For any valid transfer amount (1..=balance), balances shift by exactly
+        /// `amount` and total supply is conserved.
+        #[test]
+        fn prop_transfer_conserves_supply(
+            mint_amount in 1i128..=1_000_000_000i128,
+            transfer_amount in 1i128..=1_000_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let sender = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            client.mint(&sender, &mint_amount);
+            let supply_before = client.total_supply();
+
+            // Only transfer if we have enough balance.
+            if transfer_amount <= mint_amount {
+                client.transfer(&sender, &receiver, &transfer_amount);
+
+                prop_assert_eq!(client.balance(&sender), mint_amount - transfer_amount);
+                prop_assert_eq!(client.balance(&receiver), transfer_amount);
+                prop_assert_eq!(client.total_supply(), supply_before, "supply must not change on transfer");
+            }
+        }
+
+        /// Zero and negative amounts must always be rejected with InvalidAmount.
+        #[test]
+        fn prop_transfer_rejects_non_positive_amount(
+            mint_amount in 1i128..=1_000_000i128,
+            bad_amount in i128::MIN..=0i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let sender = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            client.mint(&sender, &mint_amount);
+
+            prop_assert_eq!(
+                client.try_transfer(&sender, &receiver, &bad_amount),
+                Err(Ok(Error::InvalidAmount))
+            );
+        }
+
+        /// Transferring more than the balance must always fail with InsufficientBalance.
+        #[test]
+        fn prop_transfer_fails_when_exceeds_balance(
+            mint_amount in 0i128..=1_000_000i128,
+            excess in 1i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let sender = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            if mint_amount > 0 {
+                client.mint(&sender, &mint_amount);
+            }
+
+            let over_amount = mint_amount.saturating_add(excess);
+            // over_amount is always > mint_amount (balance), so must fail.
+            prop_assert_eq!(
+                client.try_transfer(&sender, &receiver, &over_amount),
+                Err(Ok(Error::InsufficientBalance))
+            );
+        }
+
+        /// Self-transfer of a valid amount must succeed and leave balances unchanged.
+        #[test]
+        fn prop_self_transfer_is_noop(
+            mint_amount in 1i128..=1_000_000i128,
+            transfer_amount in 1i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let user = Address::generate(&env);
+            client.mint(&user, &mint_amount);
+
+            if transfer_amount <= mint_amount {
+                client.transfer(&user, &user, &transfer_amount);
+                // Balance must be unchanged after self-transfer.
+                prop_assert_eq!(client.balance(&user), mint_amount);
+            }
+        }
+    }
+
+    // ── transfer_from invariants ─────────────────────────────────────────────
+
+    proptest! {
+        /// transfer_from with a valid allowance and sufficient balance must
+        /// deduct from both the owner's balance and the remaining allowance.
+        #[test]
+        fn prop_transfer_from_deducts_allowance_and_balance(
+            mint_amount   in 1i128..=1_000_000i128,
+            allowance_amt in 1i128..=1_000_000i128,
+            spend_amount  in 1i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let owner    = Address::generate(&env);
+            let spender  = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            client.mint(&owner, &mint_amount);
+            // Approve with a ledger far in the future.
+            client.approve(&owner, &spender, &allowance_amt, &10_000);
+
+            if spend_amount <= allowance_amt && spend_amount <= mint_amount {
+                client.transfer_from(&spender, &owner, &receiver, &spend_amount);
+
+                prop_assert_eq!(client.balance(&owner),    mint_amount   - spend_amount);
+                prop_assert_eq!(client.balance(&receiver), spend_amount);
+                prop_assert_eq!(client.allowance(&owner, &spender), allowance_amt - spend_amount);
+            }
+        }
+
+        /// transfer_from must fail with InsufficientAllowance when spend > allowance.
+        #[test]
+        fn prop_transfer_from_fails_when_exceeds_allowance(
+            mint_amount   in 1i128..=1_000_000i128,
+            allowance_amt in 1i128..=999_999i128,
+            excess        in 1i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let owner    = Address::generate(&env);
+            let spender  = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            // Ensure owner has enough balance so the failure is about allowance.
+            let big_mint = mint_amount.saturating_add(excess).saturating_add(allowance_amt);
+            client.mint(&owner, &big_mint);
+            client.approve(&owner, &spender, &allowance_amt, &10_000);
+
+            let over_spend = allowance_amt.saturating_add(excess);
+            prop_assert_eq!(
+                client.try_transfer_from(&spender, &owner, &receiver, &over_spend),
+                Err(Ok(Error::InsufficientAllowance))
+            );
+        }
+
+        /// transfer_from must fail with AllowanceExpired when ledger > expiration.
+        #[test]
+        fn prop_transfer_from_fails_after_expiry(
+            mint_amount  in 1i128..=1_000_000i128,
+            spend_amount in 1i128..=1_000_000i128,
+            expiry       in 2u32..=1_000u32,
+            past_offset  in 1u32..=500u32,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let owner    = Address::generate(&env);
+            let spender  = Address::generate(&env);
+            let receiver = Address::generate(&env);
+
+            let big_mint = mint_amount.max(spend_amount);
+            client.mint(&owner, &big_mint);
+            client.approve(&owner, &spender, &big_mint, &expiry);
+
+            // Advance ledger past expiry.
+            let past_ledger = expiry.saturating_add(past_offset);
+            env.ledger().with_mut(|li| li.sequence_number = past_ledger);
+
+            prop_assert_eq!(
+                client.try_transfer_from(&spender, &owner, &receiver, &spend_amount),
+                Err(Ok(Error::AllowanceExpired))
+            );
+        }
+    }
+
+    // ── mint / burn invariants ───────────────────────────────────────────────
+
+    proptest! {
+        /// Minting must increase both the recipient's balance and total supply
+        /// by exactly `amount`.
+        #[test]
+        fn prop_mint_increases_supply(amount in 1i128..=1_000_000_000i128) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let recipient = Address::generate(&env);
+            let supply_before = client.total_supply();
+
+            client.mint(&recipient, &amount);
+
+            prop_assert_eq!(client.balance(&recipient), amount);
+            prop_assert_eq!(client.total_supply(), supply_before + amount);
+        }
+
+        /// Burning must decrease both the holder's balance and total supply
+        /// by exactly `amount`.
+        #[test]
+        fn prop_burn_decreases_supply(
+            mint_amount in 1i128..=1_000_000_000i128,
+            burn_amount in 1i128..=1_000_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let holder = Address::generate(&env);
+            client.mint(&holder, &mint_amount);
+
+            if burn_amount <= mint_amount {
+                let supply_before = client.total_supply();
+                client.burn(&holder, &burn_amount);
+
+                prop_assert_eq!(client.balance(&holder), mint_amount - burn_amount);
+                prop_assert_eq!(client.total_supply(), supply_before - burn_amount);
+            }
+        }
+
+        /// Burning more than the balance must fail with InsufficientBalance.
+        #[test]
+        fn prop_burn_fails_when_exceeds_balance(
+            mint_amount in 0i128..=1_000_000i128,
+            excess      in 1i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let holder = Address::generate(&env);
+            if mint_amount > 0 {
+                client.mint(&holder, &mint_amount);
+            }
+
+            let over_burn = mint_amount.saturating_add(excess);
+            prop_assert_eq!(
+                client.try_burn(&holder, &over_burn),
+                Err(Ok(Error::InsufficientBalance))
+            );
+        }
+
+        /// Zero and negative burn amounts must be rejected with InvalidAmount.
+        #[test]
+        fn prop_burn_rejects_non_positive_amount(
+            mint_amount in 1i128..=1_000_000i128,
+            bad_amount  in i128::MIN..=0i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _) = setup(&env);
+
+            let holder = Address::generate(&env);
+            client.mint(&holder, &mint_amount);
+
+            prop_assert_eq!(
+                client.try_burn(&holder, &bad_amount),
+                Err(Ok(Error::InvalidAmount))
+            );
+        }
+    }
+}

--- a/contract/scripts/deploy.sh
+++ b/contract/scripts/deploy.sh
@@ -22,6 +22,7 @@ OUTPUT_JSON="$ROOT_DIR/deployed.json"
 OUTPUT_ENV="$ROOT_DIR/.env.deployed"
 AUTO_FUND="true"
 DRY_RUN="false"
+NON_INTERACTIVE="false"
 
 usage() {
   cat <<USAGE
@@ -36,6 +37,7 @@ Options:
   --env-out <path>                       Output env path (default: contract/.env.deployed)
   --no-fund                              Disable auto funding on futurenet/testnet
   --dry-run                              Validate build and config without submitting transactions
+  --non-interactive                      CI mode: never prompt; fail if identity is missing
   -h, --help                             Show this help
 USAGE
 }
@@ -77,6 +79,10 @@ while [[ $# -gt 0 ]]; do
       DRY_RUN="true"
       shift
       ;;
+    --non-interactive)
+      NON_INTERACTIVE="true"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -114,6 +120,9 @@ NETWORK_PASSPHRASE="${NETWORK_PASSPHRASE:-$DEFAULT_NETWORK_PASSPHRASE}"
 if [[ "$DRY_RUN" == "true" ]]; then
   echo "[deploy] *** DRY-RUN MODE — no transactions will be submitted ***"
 fi
+if [[ "$NON_INTERACTIVE" == "true" ]]; then
+  echo "[deploy] *** NON-INTERACTIVE MODE — identity auto-generation disabled ***"
+fi
 echo "[deploy] network=$NETWORK"
 echo "[deploy] rpc=$RPC_URL"
 
@@ -132,6 +141,12 @@ fi
 if ! "${STELLAR[@]}" keys public-key "$SOURCE_ACCOUNT" >/dev/null 2>&1; then
   if [[ "$NETWORK" == "mainnet" ]]; then
     echo "Source account '$SOURCE_ACCOUNT' not found and auto-generation on mainnet is disabled." >&2
+    exit 1
+  fi
+
+  if [[ "$NON_INTERACTIVE" == "true" ]]; then
+    echo "[deploy] ERROR: identity '$SOURCE_ACCOUNT' not found and --non-interactive is set." >&2
+    echo "[deploy] Pre-create the identity with: stellar keys generate $SOURCE_ACCOUNT --network $NETWORK" >&2
     exit 1
   fi
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { FavoritesProvider } from "@/hooks/useFavorites";
@@ -69,11 +69,12 @@ export const metadata: Metadata = {
       "max-snippet": -1,
     },
   },
-  viewport: {
-    width: "device-width",
-    initialScale: 1,
-    maximumScale: 5,
-  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
 };
 
 export default function RootLayout({

--- a/frontend/src/components/NetworkMismatchBanner.tsx
+++ b/frontend/src/components/NetworkMismatchBanner.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useNetworkGuard } from '@/hooks/useNetworkGuard';
+
+/**
+ * Renders a blocking banner when the connected wallet is on the wrong
+ * Stellar network. Pass `children` to wrap pay-action buttons so they
+ * are hidden while the mismatch is active.
+ */
+export default function NetworkMismatchBanner({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  const { checking, mismatch, expected, detected } = useNetworkGuard();
+
+  if (checking || !mismatch) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div role="alert" aria-live="assertive" className="space-y-3">
+      <div className="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4 dark:border-amber-600 dark:bg-amber-900/30">
+        {/* Icon */}
+        <svg
+          className="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+            clipRule="evenodd"
+          />
+        </svg>
+
+        <div className="text-sm">
+          <p className="font-semibold text-amber-800 dark:text-amber-200">
+            Wrong network
+          </p>
+          <p className="mt-1 text-amber-700 dark:text-amber-300">
+            Your wallet is on{' '}
+            <span className="font-mono font-medium">{detected}</span> but this
+            app requires{' '}
+            <span className="font-mono font-medium">{expected}</span>. Switch
+            networks in Freighter to continue.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/NetworkMismatchBanner.test.tsx
+++ b/frontend/src/components/__tests__/NetworkMismatchBanner.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import NetworkMismatchBanner from '../NetworkMismatchBanner';
+import type { NetworkGuardState } from '@/hooks/useNetworkGuard';
+
+vi.mock('@/hooks/useNetworkGuard', () => ({
+  useNetworkGuard: vi.fn(),
+}));
+
+import { useNetworkGuard } from '@/hooks/useNetworkGuard';
+
+function mockGuard(overrides: Partial<NetworkGuardState>) {
+  (useNetworkGuard as ReturnType<typeof vi.fn>).mockReturnValue({
+    checking: false,
+    mismatch: false,
+    expected: 'testnet',
+    detected: null,
+    ...overrides,
+  } satisfies NetworkGuardState);
+}
+
+describe('NetworkMismatchBanner', () => {
+  it('renders children when there is no mismatch', () => {
+    mockGuard({ mismatch: false });
+    render(
+      <NetworkMismatchBanner>
+        <button>Pay</button>
+      </NetworkMismatchBanner>,
+    );
+    expect(screen.getByRole('button', { name: 'Pay' })).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('renders children while still checking', () => {
+    mockGuard({ checking: true, mismatch: false });
+    render(
+      <NetworkMismatchBanner>
+        <button>Pay</button>
+      </NetworkMismatchBanner>,
+    );
+    expect(screen.getByRole('button', { name: 'Pay' })).toBeInTheDocument();
+  });
+
+  it('shows alert banner and hides children on mismatch', () => {
+    mockGuard({ mismatch: true, expected: 'testnet', detected: 'PUBLIC' });
+    render(
+      <NetworkMismatchBanner>
+        <button>Pay</button>
+      </NetworkMismatchBanner>,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Pay' })).toBeNull();
+  });
+
+  it('displays the expected and detected network names in the banner', () => {
+    mockGuard({ mismatch: true, expected: 'testnet', detected: 'PUBLIC' });
+    render(<NetworkMismatchBanner />);
+    expect(screen.getByText(/testnet/i)).toBeInTheDocument();
+    expect(screen.getByText(/PUBLIC/i)).toBeInTheDocument();
+  });
+
+  it('has role="alert" and aria-live="assertive" for screen readers', () => {
+    mockGuard({ mismatch: true, expected: 'testnet', detected: 'FUTURENET' });
+    render(<NetworkMismatchBanner />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+  });
+});

--- a/frontend/src/components/subscribe/ConfirmationScreen.tsx
+++ b/frontend/src/components/subscribe/ConfirmationScreen.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { SubscriptionPlan } from '@/types/subscribe';
+import NetworkMismatchBanner from '@/components/NetworkMismatchBanner';
+import { useNetworkGuard } from '@/hooks/useNetworkGuard';
 
 interface ConfirmationScreenProps {
   plan: SubscriptionPlan;
@@ -22,6 +24,8 @@ export default function ConfirmationScreen({
   onCancel,
   disabled,
 }: ConfirmationScreenProps) {
+  const { mismatch } = useNetworkGuard();
+
   const billingLabel =
     plan.billingInterval === 'monthly'
       ? 'per month'
@@ -97,13 +101,19 @@ export default function ConfirmationScreen({
         >
           Cancel
         </button>
-        <button
-          onClick={onConfirm}
-          disabled={disabled}
-          className="flex-1 rounded-lg bg-primary-500 px-4 py-3 font-medium text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-primary-600 dark:hover:bg-primary-700"
-        >
-          Sign &amp; Subscribe
-        </button>
+        {mismatch ? (
+          <div className="flex-1">
+            <NetworkMismatchBanner />
+          </div>
+        ) : (
+          <button
+            onClick={onConfirm}
+            disabled={disabled}
+            className="flex-1 rounded-lg bg-primary-500 px-4 py-3 font-medium text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-primary-600 dark:hover:bg-primary-700"
+          >
+            Sign &amp; Subscribe
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/hooks/__tests__/useNetworkGuard.test.ts
+++ b/frontend/src/hooks/__tests__/useNetworkGuard.test.ts
@@ -1,0 +1,64 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useNetworkGuard } from '../useNetworkGuard';
+
+// Mock contract-config so we control the expected network
+vi.mock('@/lib/contract-config', () => ({
+  getRuntimeContractConfig: vi.fn(() => ({ network: 'testnet' })),
+}));
+
+function setFreighter(getNetwork: (() => Promise<{ network: string; networkPassphrase: string }>) | undefined) {
+  (window as any).freighter = getNetwork ? { getNetwork } : undefined;
+}
+
+describe('useNetworkGuard', () => {
+  afterEach(() => {
+    delete (window as any).freighter;
+    vi.clearAllMocks();
+  });
+
+  it('reports no mismatch when freighter is absent', async () => {
+    setFreighter(undefined);
+    const { result } = renderHook(() => useNetworkGuard());
+    await waitFor(() => expect(result.current.checking).toBe(false));
+    expect(result.current.mismatch).toBe(false);
+    expect(result.current.detected).toBeNull();
+  });
+
+  it('reports no mismatch when wallet is on the correct network', async () => {
+    setFreighter(async () => ({ network: 'TESTNET', networkPassphrase: '' }));
+    const { result } = renderHook(() => useNetworkGuard());
+    await waitFor(() => expect(result.current.checking).toBe(false));
+    expect(result.current.mismatch).toBe(false);
+    expect(result.current.expected).toBe('testnet');
+  });
+
+  it('reports mismatch when wallet is on a different network', async () => {
+    setFreighter(async () => ({ network: 'PUBLIC', networkPassphrase: '' }));
+    const { result } = renderHook(() => useNetworkGuard());
+    await waitFor(() => expect(result.current.checking).toBe(false));
+    expect(result.current.mismatch).toBe(true);
+    expect(result.current.detected).toBe('PUBLIC');
+  });
+
+  it('re-checks on freighter:networkChanged event', async () => {
+    // Start on wrong network
+    setFreighter(async () => ({ network: 'PUBLIC', networkPassphrase: '' }));
+    const { result } = renderHook(() => useNetworkGuard());
+    await waitFor(() => expect(result.current.mismatch).toBe(true));
+
+    // Switch to correct network
+    setFreighter(async () => ({ network: 'TESTNET', networkPassphrase: '' }));
+    act(() => {
+      window.dispatchEvent(new Event('freighter:networkChanged'));
+    });
+    await waitFor(() => expect(result.current.mismatch).toBe(false));
+  });
+
+  it('handles getNetwork() throwing without crashing', async () => {
+    setFreighter(async () => { throw new Error('wallet locked'); });
+    const { result } = renderHook(() => useNetworkGuard());
+    await waitFor(() => expect(result.current.checking).toBe(false));
+    expect(result.current.mismatch).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useNetworkGuard.ts
+++ b/frontend/src/hooks/useNetworkGuard.ts
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getRuntimeContractConfig } from '@/lib/contract-config';
+
+/** Freighter's getNetwork() response shape */
+interface FreighterNetwork {
+  network: string;
+  networkPassphrase: string;
+}
+
+interface WindowWithFreighter extends Window {
+  freighter?: {
+    getNetwork?: () => Promise<FreighterNetwork>;
+  };
+}
+
+/** Maps our config network names to Freighter's reported network strings */
+const NETWORK_NAME_MAP: Record<string, string> = {
+  testnet: 'TESTNET',
+  futurenet: 'FUTURENET',
+  mainnet: 'PUBLIC',
+};
+
+export interface NetworkGuardState {
+  /** true while the check is in progress */
+  checking: boolean;
+  /** true when the wallet is on the wrong network */
+  mismatch: boolean;
+  /** the network the app expects (e.g. "testnet") */
+  expected: string;
+  /** the network the wallet reported (null if unknown/not connected) */
+  detected: string | null;
+}
+
+/**
+ * Detects whether the connected Freighter wallet is on the same Stellar
+ * network as the app's runtime config. Re-checks on the
+ * `freighter:networkChanged` event.
+ */
+export function useNetworkGuard(): NetworkGuardState {
+  const expected = getRuntimeContractConfig().network;
+
+  const [state, setState] = useState<NetworkGuardState>({
+    checking: true,
+    mismatch: false,
+    expected,
+    detected: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function check() {
+      setState((s) => ({ ...s, checking: true }));
+
+      const freighter = (window as WindowWithFreighter).freighter;
+      if (!freighter?.getNetwork) {
+        // Wallet not present — no mismatch to report
+        if (!cancelled) {
+          setState({ checking: false, mismatch: false, expected, detected: null });
+        }
+        return;
+      }
+
+      try {
+        const { network } = await freighter.getNetwork();
+        const normalised = network?.toUpperCase();
+        const expectedUpper = (NETWORK_NAME_MAP[expected] ?? expected).toUpperCase();
+        if (!cancelled) {
+          setState({
+            checking: false,
+            mismatch: normalised !== expectedUpper,
+            expected,
+            detected: network ?? null,
+          });
+        }
+      } catch {
+        if (!cancelled) {
+          setState({ checking: false, mismatch: false, expected, detected: null });
+        }
+      }
+    }
+
+    void check();
+
+    window.addEventListener('freighter:networkChanged', check);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('freighter:networkChanged', check);
+    };
+  }, [expected]);
+
+  return state;
+}


### PR DESCRIPTION
closes #624
closes #625

PR Description
  
  Task 1 — Next.js: move viewport to export const viewport
  
  Next.js 14+ emits a build warning when viewport is nested inside the metadata export. This
  change silences it across all routes by moving the value to the dedicated Viewport export.
  
  Change:
  
  - frontend/src/app/layout.tsx — imported Viewport type from next, removed viewport from the
  metadata object, added export const viewport: Viewport = { ... } at module level. Values are
  identical (width: "device-width", initialScale: 1, maximumScale: 5).
  
  How to verify:
  
  cd frontend && npm run build
  No "viewport" deprecation warning in output
  
  ────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 2 — Network mismatch UX
  
  Detects when the connected Freighter wallet is on a different Stellar network than the app's
  runtime config, and blocks the "Sign & Subscribe" pay action with a clear inline banner.
  
  Files added/changed:
  
  
  
  Behaviour:
  
  - No wallet connected → no banner, no blocking (graceful degradation)
  - Wallet on correct network → pay button shown normally
  - Wallet on wrong network → pay button replaced by amber warning banner; user must switch
  networks in Freighter
  - Network switch in Freighter → banner clears automatically via freighter:networkChanged event
  
  How to verify:
  
  cd frontend && npm test
   useNetworkGuard.test.ts — 5 passing
  NetworkMismatchBanner.test.tsx — 5 passing
  
  