### PR TITLE
Feature/pr 020 creator onboarding progress UI

### DIFF
--- a/backend/src/subscriptions/dto/list-creator-subscribers-query.dto.ts
+++ b/backend/src/subscriptions/dto/list-creator-subscribers-query.dto.ts
@@ -2,6 +2,9 @@ import { IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PaginationDto } from '../../common/dto';
 
+export const SUBSCRIBER_SORT_VALUES = ['created', 'expiry'] as const;
+export type SubscriberSort = (typeof SUBSCRIBER_SORT_VALUES)[number];
+
 export class ListCreatorSubscribersQueryDto extends PaginationDto {
   @ApiProperty({ description: 'Creator Stellar G-address' })
   @IsString()
@@ -12,4 +15,9 @@ export class ListCreatorSubscribersQueryDto extends PaginationDto {
   @IsOptional()
   @IsIn(['active', 'expired'])
   status?: 'active' | 'expired';
+
+  @ApiPropertyOptional({ description: 'Sort field', enum: SUBSCRIBER_SORT_VALUES })
+  @IsOptional()
+  @IsIn(SUBSCRIBER_SORT_VALUES, { message: `sort must be one of: ${SUBSCRIBER_SORT_VALUES.join(', ')}` })
+  sort?: SubscriberSort;
 }

--- a/backend/src/subscriptions/dto/list-subscriptions-query.dto.ts
+++ b/backend/src/subscriptions/dto/list-subscriptions-query.dto.ts
@@ -1,11 +1,10 @@
- treasury-deposit-event
-import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
-
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsEnum, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
- main
 import { PaginationDto } from '../../common/dto';
-import { SubscriptionStatus } from '../subscriptions.service';
+import { SubscriptionStatus } from '../entities/subscription-index.entity';
+
+export const SUBSCRIPTION_SORT_VALUES = ['created', 'expiry'] as const;
+export type SubscriptionSort = (typeof SUBSCRIPTION_SORT_VALUES)[number];
 
 export class ListSubscriptionsQueryDto extends PaginationDto {
   @ApiProperty({ description: 'Fan Stellar G-address' })
@@ -13,15 +12,15 @@ export class ListSubscriptionsQueryDto extends PaginationDto {
   @IsNotEmpty()
   fan: string;
 
-  @ApiPropertyOptional({ description: 'Filter by status', enum: ['active', 'expired', 'cancelled'] })
+  @ApiPropertyOptional({ description: 'Filter by status', enum: SubscriptionStatus })
   @IsOptional()
   @IsEnum(SubscriptionStatus, {
     message: `status must be one of: ${Object.values(SubscriptionStatus).join(', ')}`,
   })
   status?: SubscriptionStatus;
 
-  @ApiPropertyOptional({ description: 'Sort field', enum: ['created', 'expiry'] })
+  @ApiPropertyOptional({ description: 'Sort field', enum: SUBSCRIPTION_SORT_VALUES })
   @IsOptional()
-  @IsString()
-  sort?: string;
+  @IsIn(SUBSCRIPTION_SORT_VALUES, { message: `sort must be one of: ${SUBSCRIPTION_SORT_VALUES.join(', ')}` })
+  sort?: SubscriptionSort;
 }

--- a/backend/src/subscriptions/subscriptions.controller.spec.ts
+++ b/backend/src/subscriptions/subscriptions.controller.spec.ts
@@ -3,7 +3,8 @@ import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import { SubscriptionsController } from './subscriptions.controller';
-import { SubscriptionsService, SubscriptionStatus } from './subscriptions.service';
+import { SubscriptionsService } from './subscriptions.service';
+import { SubscriptionStatus } from './entities/subscription-index.entity';
 import {
   FanBearerGuard,
   RequestWithFan,
@@ -15,7 +16,7 @@ describe('SubscriptionsController', () => {
   let service: jest.Mocked<
     Pick<
       SubscriptionsService,
-      'getFanCreatorSubscriptionState' | 'listCreatorSubscribers'
+      'getFanCreatorSubscriptionState' | 'listCreatorSubscribers' | 'listSubscriptions'
     >
   >;
 
@@ -48,6 +49,16 @@ describe('SubscriptionsController', () => {
         page: 1,
         limit: 20,
         totalPages: 0,
+      }),
+      listSubscriptions: jest.fn().mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+        hasMore: false,
+        nextCursor: null,
+        cursor: null,
       }),
     };
 
@@ -87,15 +98,53 @@ describe('SubscriptionsController', () => {
     await controller.listCreatorSubscribers({
       creator,
       status: 'active',
-      page: 2,
+      cursor: 'abc',
       limit: 5,
     });
 
     expect(service.listCreatorSubscribers).toHaveBeenCalledWith(
       creator,
       'active',
-      2,
+      'abc',
       5,
+      undefined,
+    );
+  });
+
+  it('listMySubscriptions delegates to listSubscriptions with fan from request', async () => {
+    const req = { fanAddress: fan } as RequestWithFan;
+    await controller.listMySubscriptions(req, {
+      fan,
+      status: SubscriptionStatus.ACTIVE,
+      sort: 'created',
+      cursor: undefined,
+      limit: 10,
+    });
+
+    expect(service.listSubscriptions).toHaveBeenCalledWith(
+      fan,
+      SubscriptionStatus.ACTIVE,
+      'created',
+      undefined,
+      10,
+    );
+  });
+
+  it('listMySubscriptions passes sort=expiry to service', async () => {
+    const req = { fanAddress: fan } as RequestWithFan;
+    await controller.listMySubscriptions(req, {
+      fan,
+      sort: 'expiry',
+      cursor: undefined,
+      limit: 20,
+    });
+
+    expect(service.listSubscriptions).toHaveBeenCalledWith(
+      fan,
+      undefined,
+      'expiry',
+      undefined,
+      20,
     );
   });
 });
@@ -126,6 +175,28 @@ describe('ListSubscriptionsQueryDto – status validation', () => {
     const errors = await validateDto({ fan: 'GFAN' });
     expect(errors.filter((e) => e.property === 'status')).toHaveLength(0);
   });
+
+  it('passes when sort is "created"', async () => {
+    const errors = await validateDto({ fan: 'GFAN', sort: 'created' });
+    expect(errors.filter((e) => e.property === 'sort')).toHaveLength(0);
+  });
+
+  it('passes when sort is "expiry"', async () => {
+    const errors = await validateDto({ fan: 'GFAN', sort: 'expiry' });
+    expect(errors.filter((e) => e.property === 'sort')).toHaveLength(0);
+  });
+
+  it('fails when sort is an invalid value', async () => {
+    const errors = await validateDto({ fan: 'GFAN', sort: 'invalid' });
+    const sortErrors = errors.filter((e) => e.property === 'sort');
+    expect(sortErrors).toHaveLength(1);
+    expect(Object.values(sortErrors[0].constraints ?? {})[0]).toMatch(/created, expiry/);
+  });
+
+  it('passes when sort is omitted', async () => {
+    const errors = await validateDto({ fan: 'GFAN' });
+    expect(errors.filter((e) => e.property === 'sort')).toHaveLength(0);
+  });
 });
 
 describe('SubscriptionsController – listSubscriptions', () => {
@@ -136,7 +207,7 @@ describe('SubscriptionsController – listSubscriptions', () => {
 
   beforeEach(async () => {
     service = {
-      listSubscriptions: jest.fn().mockReturnValue({ data: [], total: 0, page: 1, limit: 20, totalPages: 0 }),
+      listSubscriptions: jest.fn().mockReturnValue({ data: [], total: 0, page: 1, limit: 20, totalPages: 0, hasMore: false, nextCursor: null, cursor: null }),
       getFanCreatorSubscriptionState: jest.fn(),
     };
 
@@ -152,37 +223,73 @@ describe('SubscriptionsController – listSubscriptions', () => {
   });
 
   it('passes typed SubscriptionStatus.ACTIVE to service', () => {
-    const query: ListSubscriptionsQueryDto = { fan, status: SubscriptionStatus.ACTIVE, page: 1, limit: 20 };
+    const query: ListSubscriptionsQueryDto = { fan, status: SubscriptionStatus.ACTIVE, cursor: undefined, limit: 20 };
     controller.listSubscriptions(query);
     expect(service.listSubscriptions).toHaveBeenCalledWith(
       fan,
       SubscriptionStatus.ACTIVE,
       undefined,
-      1,
+      undefined,
       20,
     );
   });
 
   it('passes typed SubscriptionStatus.EXPIRED to service', () => {
-    const query: ListSubscriptionsQueryDto = { fan, status: SubscriptionStatus.EXPIRED, page: 1, limit: 20 };
+    const query: ListSubscriptionsQueryDto = { fan, status: SubscriptionStatus.EXPIRED, cursor: undefined, limit: 20 };
     controller.listSubscriptions(query);
     expect(service.listSubscriptions).toHaveBeenCalledWith(
       fan,
       SubscriptionStatus.EXPIRED,
       undefined,
-      1,
+      undefined,
       20,
     );
   });
 
-  it('passes undefined status when omitted', () => {
-    const query: ListSubscriptionsQueryDto = { fan, page: 1, limit: 20 };
+  it('passes sort=created to service', () => {
+    const query: ListSubscriptionsQueryDto = { fan, sort: 'created', cursor: undefined, limit: 20 };
+    controller.listSubscriptions(query);
+    expect(service.listSubscriptions).toHaveBeenCalledWith(
+      fan,
+      undefined,
+      'created',
+      undefined,
+      20,
+    );
+  });
+
+  it('passes sort=expiry to service', () => {
+    const query: ListSubscriptionsQueryDto = { fan, sort: 'expiry', cursor: undefined, limit: 20 };
+    controller.listSubscriptions(query);
+    expect(service.listSubscriptions).toHaveBeenCalledWith(
+      fan,
+      undefined,
+      'expiry',
+      undefined,
+      20,
+    );
+  });
+
+  it('passes cursor to service', () => {
+    const query: ListSubscriptionsQueryDto = { fan, cursor: 'some-cursor', limit: 10 };
     controller.listSubscriptions(query);
     expect(service.listSubscriptions).toHaveBeenCalledWith(
       fan,
       undefined,
       undefined,
-      1,
+      'some-cursor',
+      10,
+    );
+  });
+
+  it('passes undefined status when omitted', () => {
+    const query: ListSubscriptionsQueryDto = { fan, cursor: undefined, limit: 20 };
+    controller.listSubscriptions(query);
+    expect(service.listSubscriptions).toHaveBeenCalledWith(
+      fan,
+      undefined,
+      undefined,
+      undefined,
       20,
     );
   });

--- a/backend/src/subscriptions/subscriptions.controller.ts
+++ b/backend/src/subscriptions/subscriptions.controller.ts
@@ -69,7 +69,26 @@ export class SubscriptionsController {
       query.fan,
       query.status as never,
       query.sort,
-      query.page,
+      query.cursor,
+      query.limit,
+    );
+  }
+
+  @Get('me/list')
+  @UseGuards(FanBearerGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List subscriptions for the authenticated fan with status and sort filters' })
+  @ApiResponse({ status: 200, description: 'Paginated subscriptions list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  listMySubscriptions(
+    @Req() req: RequestWithFan,
+    @Query() query: ListSubscriptionsQueryDto,
+  ) {
+    return this.subscriptionsService.listSubscriptions(
+      req.fanAddress,
+      query.status,
+      query.sort,
+      query.cursor,
       query.limit,
     );
   }
@@ -79,8 +98,9 @@ export class SubscriptionsController {
     return this.subscriptionsService.listCreatorSubscribers(
       query.creator,
       query.status,
-      query.page,
+      query.cursor,
       query.limit,
+      query.sort,
     );
   }
 

--- a/backend/src/subscriptions/subscriptions.service.spec.ts
+++ b/backend/src/subscriptions/subscriptions.service.spec.ts
@@ -2,11 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { EventBus } from '../events/event-bus';
 import { InProcessEventBus } from '../events/in-process-event-bus';
 import { SubscriptionChainReaderService } from './subscription-chain-reader.service';
- treasury-deposit-event
-import { SERVER_NETWORK, SubscriptionsService, SubscriptionStatus } from './subscriptions.service';
-
 import { SubscriptionsService } from './subscriptions.service';
- main
 import {
   SUBSCRIPTION_EVENT_PUBLISHER,
   SUBSCRIPTION_RENEWAL_FAILED,
@@ -166,45 +162,8 @@ describe('SubscriptionsService', () => {
       'GFANADDRESS333333333333333333333333333333333333333333333333',
     );
 
-  treasury-deposit-event
-    it('should filter by status', () => {
-      const expiry = Math.floor(Date.now() / 1000) + 86400;
-      const pastExpiry = Math.floor(Date.now() / 1000) - 86400;
-      service.addSubscription(fan, 'CREATOR_A_XXXXXXX', 1, expiry);
-      service.addSubscription(fan, 'CREATOR_B_XXXXXXX', 1, pastExpiry);
-
-      const activeOnly = service.listSubscriptions(fan, SubscriptionStatus.ACTIVE);
-      expect(activeOnly.data).toHaveLength(1);
-      expect(activeOnly.total).toBe(1);
-
-      const expiredOnly = service.listSubscriptions(fan, SubscriptionStatus.EXPIRED);
-      expect(expiredOnly.data).toHaveLength(1);
-      expect(expiredOnly.total).toBe(1);
-    });
-
-    it('should return empty page when page exceeds total pages', () => {
-      const expiry = Math.floor(Date.now() / 1000) + 86400;
-      service.addSubscription(fan, 'CREATOR_A_XXXXXXX', 1, expiry);
-
-      const result = service.listSubscriptions(
-        fan,
-        undefined,
-        undefined,
-        5,
-        20,
-      );
-      expect(result.data).toEqual([]);
-      expect(result.total).toBe(1);
-      expect(result.page).toBe(5);
-      expect(result.totalPages).toBe(1);
-    });
-
     expect(result.data).toHaveLength(1);
-main
     expect(result.total).toBe(1);
-    expect(repo.findAndCountForFan).toHaveBeenCalled();
- main
-=======
     expect(repo.findWithCursor).toHaveBeenCalledWith(
       'GFANADDRESS333333333333333333333333333333333333333333333333',
       undefined,
@@ -237,7 +196,73 @@ main
       'some-cursor',
       10,
     );
- main
+  });
+
+  it('filters by status=active via findWithCursor', async () => {
+    const fan = 'GFANADDRESS777777777777777777777777777777777777777777777777';
+    await service.addSubscription(fan, 'GAAAAAAAAAAAAAAA', 1, Math.floor(Date.now() / 1000) + 3600);
+
+    await service.listSubscriptions(fan, SubscriptionStatus.ACTIVE, undefined, undefined, 20);
+
+    expect(repo.findWithCursor).toHaveBeenCalledWith(fan, SubscriptionStatus.ACTIVE, undefined, undefined, 20);
+  });
+
+  it('filters by status=expired via findWithCursor', async () => {
+    const fan = 'GFANADDRESS888888888888888888888888888888888888888888888888';
+    await service.addSubscription(fan, 'GAAAAAAAAAAAAAAA', 1, Math.floor(Date.now() / 1000) - 3600);
+
+    await service.listSubscriptions(fan, SubscriptionStatus.EXPIRED, undefined, undefined, 20);
+
+    expect(repo.findWithCursor).toHaveBeenCalledWith(fan, SubscriptionStatus.EXPIRED, undefined, undefined, 20);
+  });
+
+  it('passes sort=expiry to findWithCursor', async () => {
+    const fan = 'GFANADDRESS999999999999999999999999999999999999999999999999';
+    await service.listSubscriptions(fan, undefined, 'expiry', undefined, 20);
+
+    expect(repo.findWithCursor).toHaveBeenCalledWith(fan, undefined, 'expiry', undefined, 20);
+  });
+
+  it('listCreatorSubscribers sorts by expiry when sort=expiry', async () => {
+    const creator = 'GCREATOR1111111111111111111111111111111111111111111111111111';
+    const now = Math.floor(Date.now() / 1000);
+    currentSubs.push(
+      makeSub({ id: 'sub-a', fan: 'GFAN_A', creator, expiryUnix: now + 7200, createdAt: new Date(Date.now() - 1000) }),
+      makeSub({ id: 'sub-b', fan: 'GFAN_B', creator, expiryUnix: now + 3600, createdAt: new Date() }),
+    );
+
+    const result = await service.listCreatorSubscribers(creator, undefined, undefined, 20, 'expiry');
+
+    expect(result.data[0].fanAddress).toBe('GFAN_B'); // earlier expiry first
+    expect(result.data[1].fanAddress).toBe('GFAN_A');
+  });
+
+  it('listCreatorSubscribers sorts by created desc by default', async () => {
+    const creator = 'GCREATOR2222222222222222222222222222222222222222222222222222';
+    const now = Math.floor(Date.now() / 1000);
+    currentSubs.push(
+      makeSub({ id: 'sub-c', fan: 'GFAN_C', creator, expiryUnix: now + 3600, createdAt: new Date(Date.now() - 5000) }),
+      makeSub({ id: 'sub-d', fan: 'GFAN_D', creator, expiryUnix: now + 3600, createdAt: new Date() }),
+    );
+
+    const result = await service.listCreatorSubscribers(creator, undefined, undefined, 20);
+
+    expect(result.data[0].fanAddress).toBe('GFAN_D'); // most recently created first
+    expect(result.data[1].fanAddress).toBe('GFAN_C');
+  });
+
+  it('listCreatorSubscribers filters by status=active', async () => {
+    const creator = 'GCREATOR3333333333333333333333333333333333333333333333333333';
+    const now = Math.floor(Date.now() / 1000);
+    currentSubs.push(
+      makeSub({ id: 'sub-e', fan: 'GFAN_E', creator, expiryUnix: now + 3600, status: SubscriptionStatus.ACTIVE }),
+      makeSub({ id: 'sub-f', fan: 'GFAN_F', creator, expiryUnix: now - 3600, status: SubscriptionStatus.EXPIRED }),
+    );
+
+    const result = await service.listCreatorSubscribers(creator, 'active', undefined, 20);
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].fanAddress).toBe('GFAN_E');
   });
 
   it('publishes a renewal event when confirming an existing subscription', async () => {

--- a/backend/src/subscriptions/subscriptions.service.ts
+++ b/backend/src/subscriptions/subscriptions.service.ts
@@ -438,8 +438,7 @@ export class SubscriptionsService {
     cursor?: string,
     limit: number = 20,
   ) {
-    const results = await this.indexRepo.findWithCursor(fan, status, sort, cursor, limit);
-    const hasMore = results.length > limit;
+    const results = await this.indexRepo.findWithCursor(fan, status, sort, cursor, limit);    const hasMore = results.length > limit;
     if (hasMore) {
       results.pop();
     }
@@ -471,6 +470,7 @@ export class SubscriptionsService {
     status?: SubscriberListStatus,
     cursor?: string,
     limit: number = 20,
+    sort?: string,
   ) {
     const nowSecs = Math.floor(Date.now() / 1000);
     let subscribers = (await this.indexRepo.listForCreator(creator))
@@ -491,10 +491,16 @@ export class SubscriptionsService {
       subscribers = subscribers.filter((sub) => sub.status === status);
     }
 
-    subscribers.sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
+    if (sort === 'expiry') {
+      subscribers.sort(
+        (a, b) => new Date(a.expiresAt).getTime() - new Date(b.expiresAt).getTime(),
+      );
+    } else {
+      // default: sort by created desc
+      subscribers.sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+    }
 
     if (cursor) {
       const cursorId = parseInt(cursor, 10);

--- a/frontend/src/app/subscriptions/page.tsx
+++ b/frontend/src/app/subscriptions/page.tsx
@@ -37,13 +37,13 @@ export default function SubscriptionsPage() {
     const fetchSubscriptions = async () => {
       setIsLoading(true);
       try {
-        // Hardcode a fan address for demo purposes, since auth context isn't visible here
-        const fanAddress = 'fan_demo_address';
-        const res = await fetch(`http://localhost:3001/subscriptions/list?fan=${fanAddress}&status=${statusFilter}&sort=${sortOption}`);
+        const params = new URLSearchParams({ status: statusFilter, sort: sortOption });
+        const res = await fetch(`/api/v1/subscriptions/me/list?${params.toString()}`);
         if (!res.ok) throw new Error('Failed to fetch subscriptions');
         const data = await res.json();
         if (mounted) {
-          setActiveList(data);
+          // API returns { data: [...], ... } paginated shape
+          setActiveList(Array.isArray(data) ? data : (data.data ?? []));
         }
       } catch (err) {
         console.error(err);
@@ -171,12 +171,12 @@ export default function SubscriptionsPage() {
       
       showSuccess('Subscription renewed', `${renewTarget.creatorName} ${renewTarget.planName} is active again.`);
       
-      // Refresh list if it was a history item or expired
-      const fanAddress = 'fan_demo_address';
-      const res = await fetch(`http://localhost:3001/subscriptions/list?fan=${fanAddress}&status=${statusFilter}&sort=${sortOption}`);
+      // Refresh list after renewal
+      const params = new URLSearchParams({ status: statusFilter, sort: sortOption });
+      const res = await fetch(`/api/v1/subscriptions/me/list?${params.toString()}`);
       if (res.ok) {
         const data = await res.json();
-        setActiveList(data);
+        setActiveList(Array.isArray(data) ? data : (data.data ?? []));
       }
       
       setRenewTarget(null);
@@ -220,20 +220,26 @@ export default function SubscriptionsPage() {
             </div>
 
             <div className="flex items-center gap-3">
+              <label htmlFor="status-filter" className="sr-only">Filter by status</label>
               <select
+                id="status-filter"
                 value={statusFilter}
                 onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setStatusFilter(e.target.value)}
                 className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-sm px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                aria-label="Filter by status"
               >
                 <option value="active">Active</option>
                 <option value="expired">Expired</option>
                 <option value="cancelled">Cancelled</option>
               </select>
 
+              <label htmlFor="sort-option" className="sr-only">Sort by</label>
               <select
+                id="sort-option"
                 value={sortOption}
                 onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setSortOption(e.target.value)}
                 className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-sm px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                aria-label="Sort subscriptions"
               >
                 <option value="expiry">Sort by Expiry</option>
                 <option value="created">Sort by Created</option>

--- a/frontend/src/app/subscriptions/subscriptions-filters.test.tsx
+++ b/frontend/src/app/subscriptions/subscriptions-filters.test.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SubscriptionsPage from './page';
+
+// Minimal mocks for dependencies
+vi.mock('@/lib/subscriptions', () => ({
+  MOCK_HISTORY: [],
+  MOCK_PAYMENTS: [],
+}));
+
+vi.mock('@/lib/formatting', () => ({
+  formatCurrency: (amount: number, currency: string) => `${currency}${amount}`,
+  formatDate: (iso: string) => iso,
+  getCurrencySymbol: (c: string) => c,
+}));
+
+vi.mock('@/components/cards/BaseCard', () => ({
+  BaseCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/HistoryCardSkeleton', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/lib/error-copy', () => ({
+  subscriptionActionToast: { cancelFailed: () => 'cancel failed', renewFailed: () => 'renew failed' },
+  subscriptionsLoadFailed: () => 'load failed',
+}));
+
+vi.mock('@/lib/stellar', () => ({
+  cancelSubscriptionOnSoroban: vi.fn(),
+}));
+
+vi.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({
+    showInfo: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    showLoading: vi.fn().mockReturnValue('toast-id'),
+    dismiss: vi.fn(),
+  }),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function makePagedResponse(items: unknown[] = []) {
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ data: items, total: items.length, hasMore: false, nextCursor: null }),
+  });
+}
+
+describe('SubscriptionsPage – filter and sort controls', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockReturnValue(makePagedResponse([]));
+  });
+
+  it('renders status filter and sort select controls', async () => {
+    render(<SubscriptionsPage />);
+
+    expect(screen.getByLabelText('Filter by status')).toBeInTheDocument();
+    expect(screen.getByLabelText('Sort subscriptions')).toBeInTheDocument();
+  });
+
+  it('fetches with default status=active and sort=expiry on mount', async () => {
+    render(<SubscriptionsPage />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('status=active'),
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('sort=expiry'),
+      );
+    });
+  });
+
+  it('re-fetches when status filter changes to expired', async () => {
+    render(<SubscriptionsPage />);
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('Filter by status'), {
+      target: { value: 'expired' },
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('status=expired'),
+      );
+    });
+  });
+
+  it('re-fetches when status filter changes to cancelled', async () => {
+    render(<SubscriptionsPage />);
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('Filter by status'), {
+      target: { value: 'cancelled' },
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('status=cancelled'),
+      );
+    });
+  });
+
+  it('re-fetches when sort changes to created', async () => {
+    render(<SubscriptionsPage />);
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('Sort subscriptions'), {
+      target: { value: 'created' },
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('sort=created'),
+      );
+    });
+  });
+
+  it('calls the correct API endpoint', async () => {
+    render(<SubscriptionsPage />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/subscriptions/me/list'),
+      );
+    });
+  });
+
+  it('shows empty state when API returns no subscriptions', async () => {
+    render(<SubscriptionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No subscriptions found')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state gracefully when fetch fails', async () => {
+    mockFetch.mockReturnValue(Promise.resolve({ ok: false }));
+
+    render(<SubscriptionsPage />);
+
+    // Should not throw; loading state resolves
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/components/onboarding/OnboardingProgress.test.tsx
+++ b/frontend/src/components/onboarding/OnboardingProgress.test.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { OnboardingProgress } from './OnboardingProgress';
+import type { OnboardingStep } from '@/lib/onboarding-types';
+
+const ALL_STEPS: OnboardingStep[] = [
+  'account-type',
+  'profile',
+  'social-links',
+  'verification',
+];
+
+describe('OnboardingProgress', () => {
+  it('renders all four steps', () => {
+    render(
+      <OnboardingProgress
+        currentStep="account-type"
+        completedSteps={[]}
+      />,
+    );
+    // Desktop labels (hidden on mobile via CSS, but still in DOM)
+    expect(screen.getAllByText('Account Type').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Profile').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Social Links').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Verification').length).toBeGreaterThan(0);
+  });
+
+  it('shows progress bar with 0% when no steps done', () => {
+    render(
+      <OnboardingProgress
+        currentStep="account-type"
+        completedSteps={[]}
+      />,
+    );
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '0');
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '4');
+  });
+
+  it('reflects completed steps in progress bar', () => {
+    render(
+      <OnboardingProgress
+        currentStep="profile"
+        completedSteps={['account-type']}
+      />,
+    );
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '1');
+  });
+
+  it('counts skipped steps toward progress', () => {
+    render(
+      <OnboardingProgress
+        currentStep="verification"
+        completedSteps={['account-type', 'profile']}
+        skippedSteps={['social-links']}
+      />,
+    );
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '3');
+  });
+
+  it('shows "X of 4 steps done" summary text', () => {
+    render(
+      <OnboardingProgress
+        currentStep="social-links"
+        completedSteps={['account-type', 'profile']}
+      />,
+    );
+    expect(screen.getByText('2 of 4 steps done')).toBeInTheDocument();
+  });
+
+  it('uses creator-specific step labels when intent is creator', () => {
+    render(
+      <OnboardingProgress
+        currentStep="account-type"
+        completedSteps={[]}
+        intent="creator"
+      />,
+    );
+    expect(screen.getAllByText('Creator setup').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Public profile').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Wallet').length).toBeGreaterThan(0);
+  });
+
+  it('uses creator-specific labels when intent is both', () => {
+    render(
+      <OnboardingProgress
+        currentStep="account-type"
+        completedSteps={[]}
+        intent="both"
+      />,
+    );
+    expect(screen.getAllByText('Creator setup').length).toBeGreaterThan(0);
+  });
+
+  it('uses default labels when intent is fan', () => {
+    render(
+      <OnboardingProgress
+        currentStep="account-type"
+        completedSteps={[]}
+        intent="fan"
+      />,
+    );
+    expect(screen.getAllByText('Account Type').length).toBeGreaterThan(0);
+  });
+
+  it('shows skipped description for skipped steps', () => {
+    render(
+      <OnboardingProgress
+        currentStep="verification"
+        completedSteps={[]}
+        skippedSteps={['account-type']}
+      />,
+    );
+    expect(
+      screen.getAllByText('Skipped — finish later in settings').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <OnboardingProgress
+        currentStep="account-type"
+        completedSteps={[]}
+        className="my-custom-class"
+      />,
+    );
+    expect(container.firstChild).toHaveClass('my-custom-class');
+  });
+
+  it('has accessible aria-label on progress bar', () => {
+    render(
+      <OnboardingProgress
+        currentStep="account-type"
+        completedSteps={[]}
+      />,
+    );
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-label',
+      'Onboarding progress',
+    );
+  });
+
+  it('shows full progress when all steps completed', () => {
+    render(
+      <OnboardingProgress
+        currentStep="verification"
+        completedSteps={ALL_STEPS}
+      />,
+    );
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '4');
+    expect(screen.getByText('4 of 4 steps done')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/onboarding/OnboardingResumeBanner.test.tsx
+++ b/frontend/src/components/onboarding/OnboardingResumeBanner.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OnboardingResumeBanner } from './OnboardingResumeBanner';
+import * as hooks from '@/hooks';
+
+vi.mock('@/hooks', () => ({
+  useOnboarding: vi.fn(),
+}));
+
+const mockUseOnboarding = vi.mocked(hooks.useOnboarding);
+
+function setOnboardingState(overrides: Partial<ReturnType<typeof hooks.useOnboarding>>) {
+  mockUseOnboarding.mockReturnValue({
+    isComplete: false,
+    progressCount: 0,
+    totalSteps: 4,
+    onboardingIntent: null,
+    currentStep: 'account-type',
+    completedSteps: [],
+    skippedSteps: [],
+    canResume: false,
+    savedAt: null,
+    completeStep: vi.fn(),
+    skipStep: vi.fn(),
+    skipCurrentStep: vi.fn(),
+    goToStep: vi.fn(),
+    setOnboardingIntent: vi.fn(),
+    resetOnboarding: vi.fn(),
+    checkAndUpdateProgress: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof hooks.useOnboarding>);
+}
+
+describe('OnboardingResumeBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when onboarding is complete', () => {
+    setOnboardingState({ isComplete: true, progressCount: 4 });
+    const { container } = render(<OnboardingResumeBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when no progress has been made', () => {
+    setOnboardingState({ isComplete: false, progressCount: 0 });
+    const { container } = render(<OnboardingResumeBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the banner when progress is partial', () => {
+    setOnboardingState({ isComplete: false, progressCount: 2, totalSteps: 4 });
+    render(<OnboardingResumeBanner />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows generic copy for non-creator intent', () => {
+    setOnboardingState({
+      isComplete: false,
+      progressCount: 1,
+      totalSteps: 4,
+      onboardingIntent: 'fan',
+    });
+    render(<OnboardingResumeBanner />);
+    expect(
+      screen.getByText('Finish setting up your account'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows creator-specific copy when intent is creator', () => {
+    setOnboardingState({
+      isComplete: false,
+      progressCount: 1,
+      totalSteps: 4,
+      onboardingIntent: 'creator',
+    });
+    render(<OnboardingResumeBanner />);
+    expect(screen.getByText('Finish your creator setup')).toBeInTheDocument();
+  });
+
+  it('shows creator-specific copy when intent is both', () => {
+    setOnboardingState({
+      isComplete: false,
+      progressCount: 2,
+      totalSteps: 4,
+      onboardingIntent: 'both',
+    });
+    render(<OnboardingResumeBanner />);
+    expect(screen.getByText('Finish your creator setup')).toBeInTheDocument();
+  });
+
+  it('shows step progress count in the banner', () => {
+    setOnboardingState({
+      isComplete: false,
+      progressCount: 2,
+      totalSteps: 4,
+      onboardingIntent: null,
+    });
+    render(<OnboardingResumeBanner />);
+    expect(screen.getByText(/2 of 4 steps done/)).toBeInTheDocument();
+  });
+
+  it('renders a Resume setup link pointing to /onboarding', () => {
+    setOnboardingState({ isComplete: false, progressCount: 1, totalSteps: 4 });
+    render(<OnboardingResumeBanner />);
+    const link = screen.getByRole('link', { name: 'Resume setup' });
+    expect(link).toHaveAttribute('href', '/onboarding');
+  });
+});

--- a/frontend/src/hooks/useOnboarding.test.ts
+++ b/frontend/src/hooks/useOnboarding.test.ts
@@ -5,6 +5,7 @@ import {
   isFlowFinished,
   STEP_ORDER,
   ONBOARDING_STORAGE_KEY,
+  STALE_THRESHOLD_MS,
 } from "./useOnboarding";
 
 describe("isFlowFinished", () => {
@@ -95,5 +96,125 @@ describe("useOnboarding", () => {
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
     expect(parsed.completedSteps).toEqual([]);
+  });
+});
+
+describe("stale / invalid state handling", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("resets to fresh state when savedAt is older than STALE_THRESHOLD_MS", () => {
+    const staleDate = new Date(Date.now() - STALE_THRESHOLD_MS - 1000).toISOString();
+    localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        currentStep: "profile",
+        completedSteps: ["account-type"],
+        skippedSteps: [],
+        isComplete: false,
+        onboardingIntent: "creator",
+        savedAt: staleDate,
+      }),
+    );
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.currentStep).toBe("account-type");
+    expect(result.current.completedSteps).toEqual([]);
+    expect(result.current.onboardingIntent).toBeNull();
+  });
+
+  it("preserves state when savedAt is within threshold", () => {
+    const recentDate = new Date(Date.now() - 1000).toISOString();
+    localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        currentStep: "profile",
+        completedSteps: ["account-type"],
+        skippedSteps: [],
+        isComplete: false,
+        onboardingIntent: "creator",
+        savedAt: recentDate,
+      }),
+    );
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.currentStep).toBe("profile");
+    expect(result.current.completedSteps).toContain("account-type");
+    expect(result.current.onboardingIntent).toBe("creator");
+  });
+
+  it("resets to fresh state when stored JSON is corrupted", () => {
+    localStorage.setItem(ONBOARDING_STORAGE_KEY, "not-valid-json{{{");
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.currentStep).toBe("account-type");
+    expect(result.current.completedSteps).toEqual([]);
+  });
+
+  it("filters out unrecognised step values from completedSteps", () => {
+    const recentDate = new Date(Date.now() - 1000).toISOString();
+    localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        currentStep: "profile",
+        completedSteps: ["account-type", "unknown-step-xyz"],
+        skippedSteps: [],
+        isComplete: false,
+        onboardingIntent: null,
+        savedAt: recentDate,
+      }),
+    );
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.completedSteps).toContain("account-type");
+    expect(result.current.completedSteps).not.toContain("unknown-step-xyz");
+  });
+
+  it("falls back to account-type when currentStep is invalid", () => {
+    const recentDate = new Date(Date.now() - 1000).toISOString();
+    localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        currentStep: "totally-invalid",
+        completedSteps: [],
+        skippedSteps: [],
+        isComplete: false,
+        onboardingIntent: null,
+        savedAt: recentDate,
+      }),
+    );
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.currentStep).toBe("account-type");
+  });
+
+  it("resets to fresh state when savedAt is an invalid date string", () => {
+    localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        currentStep: "profile",
+        completedSteps: ["account-type"],
+        skippedSteps: [],
+        isComplete: false,
+        onboardingIntent: "creator",
+        savedAt: "not-a-date",
+      }),
+    );
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.currentStep).toBe("account-type");
+    expect(result.current.completedSteps).toEqual([]);
+  });
+
+  it("ignores invalid onboardingIntent and defaults to null", () => {
+    const recentDate = new Date(Date.now() - 1000).toISOString();
+    localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        currentStep: "account-type",
+        completedSteps: [],
+        skippedSteps: [],
+        isComplete: false,
+        onboardingIntent: "hacker",
+        savedAt: recentDate,
+      }),
+    );
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.onboardingIntent).toBeNull();
   });
 });

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -6,6 +6,9 @@ import type { OnboardingIntent, OnboardingStep } from '@/lib/onboarding-types';
 export const ONBOARDING_STORAGE_KEY = 'myfans_onboarding_state';
 export const ONBOARDING_PROFILE_DRAFT_KEY = 'myfans_onboarding_profile_draft';
 
+/** Saved state older than this is considered stale and reset to a fresh start. */
+export const STALE_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
 export type { OnboardingIntent };
 
 export interface OnboardingState {
@@ -57,34 +60,61 @@ function nextCurrentStep(
   return prevStep;
 }
 
+const FRESH_STATE: OnboardingState = {
+  currentStep: 'account-type',
+  completedSteps: [],
+  skippedSteps: [],
+  isComplete: false,
+  onboardingIntent: null,
+  savedAt: null,
+};
+
+function isValidStep(value: unknown): value is OnboardingStep {
+  return typeof value === 'string' && (STEP_ORDER as string[]).includes(value);
+}
+
+function isValidIntent(value: unknown): value is OnboardingIntent {
+  return value === null || value === 'creator' || value === 'fan' || value === 'both';
+}
+
 function parseStoredState(raw: string | null): OnboardingState {
-  if (!raw) {
-    return {
-      currentStep: 'account-type',
-      completedSteps: [],
-      skippedSteps: [],
-      isComplete: false,
-      onboardingIntent: null,
-      savedAt: null,
-    };
-  }
+  if (!raw) return { ...FRESH_STATE };
   try {
     const parsed = JSON.parse(raw) as Partial<OnboardingState>;
-    const completedSteps = parsed.completedSteps ?? [];
-    const skippedSteps = parsed.skippedSteps ?? [];
+
+    // Reject stale state — savedAt older than threshold resets to fresh
+    if (parsed.savedAt) {
+      const age = Date.now() - new Date(parsed.savedAt).getTime();
+      if (!isFinite(age) || age > STALE_THRESHOLD_MS) {
+        return { ...FRESH_STATE };
+      }
+    }
+
+    // Sanitize arrays — filter out any unrecognised step values
+    const completedSteps = (parsed.completedSteps ?? []).filter(isValidStep);
+    const skippedSteps = (parsed.skippedSteps ?? []).filter(isValidStep);
+
+    const rawStep = parsed.currentStep;
+    const currentStep = isValidStep(rawStep) ? rawStep : 'account-type';
+
+    const onboardingIntent = isValidIntent(parsed.onboardingIntent)
+      ? parsed.onboardingIntent
+      : null;
+
     const isComplete =
       parsed.isComplete === true ||
       isFlowFinished(completedSteps, skippedSteps);
+
     return {
-      currentStep: parsed.currentStep ?? 'account-type',
+      currentStep,
       completedSteps,
       skippedSteps,
       isComplete,
-      onboardingIntent: parsed.onboardingIntent ?? null,
+      onboardingIntent,
       savedAt: parsed.savedAt ?? null,
     };
   } catch {
-    return parseStoredState(null);
+    return { ...FRESH_STATE };
   }
 }
 


### PR DESCRIPTION
## Summary

<!-- One or two sentences describing what this PR does and why. -->

## Changes
closes #690 

<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [ ] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [ ] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [ ] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [ ] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [ ] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [ ] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [ ] Happy path works end-to-end in a local environment
- [ ] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [ ] No regressions in closely related API or UI flows
- [ ] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [ ] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues

<!-- Closes #NNN -->

## Notes for reviewers

<!-- Anything that needs extra attention, known limitations, or follow-up work. -->
