### PR TITLE
feat: Api versioning

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { APP_GUARD } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { AppController } from './app.controller';
@@ -25,6 +25,8 @@ import { FeatureFlagsModule } from './feature-flags/feature-flags.module';
 import { ReferralModule } from './referral/referral.module';
 import { CsrfModule } from './csrf/csrf.module';
 import { CsrfMiddleware } from './common/middleware/csrf.middleware';
+import { CorrelationExceptionFilter } from './common/filters/correlation-exception.filter';
+import { RequestContextService } from './common/services/request-context.service';
 
 /** Routes where idempotency protection is enforced. */
 const IDEMPOTENCY_ROUTES = [
@@ -66,6 +68,11 @@ const IDEMPOTENCY_ROUTES = [
     { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: RolesGuard },
     { provide: APP_GUARD, useClass: PublicGuard },
+    RequestContextService,
+    {
+      provide: APP_FILTER,
+      useClass: CorrelationExceptionFilter,
+    },
   ],
 })
 export class AppModule {

--- a/backend/src/common/logger/logger.config.ts
+++ b/backend/src/common/logger/logger.config.ts
@@ -1,5 +1,38 @@
 import * as winston from 'winston';
 import { utilities as nestWinstonModuleUtilities } from 'nest-winston';
+import { AsyncLocalStorage } from 'async_hooks';
+import type { RequestContext } from '../services/request-context.service';
+
+// Re-use the same module-level storage instance exported by RequestContextService.
+// We import the type only; the actual storage is accessed via a lazy getter so
+// there is no circular-dependency issue at module load time.
+let _storage: AsyncLocalStorage<RequestContext> | undefined;
+
+function getStorage(): AsyncLocalStorage<RequestContext> | undefined {
+  if (!_storage) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require('../services/request-context.service') as {
+        getRequestContextStorage?: () => AsyncLocalStorage<RequestContext>;
+      };
+      _storage = mod.getRequestContextStorage?.();
+    } catch {
+      // not available yet – skip
+    }
+  }
+  return _storage;
+}
+
+/** Winston format that injects correlationId / requestId from AsyncLocalStorage. */
+const requestContextFormat = winston.format((info) => {
+  const store = getStorage()?.getStore();
+  if (store) {
+    info['correlationId'] = store.correlationId;
+    info['requestId'] = store.requestId;
+    if (store.userId) info['userId'] = store.userId;
+  }
+  return info;
+});
 
 export const loggerConfig = {
     transports: [
@@ -8,6 +41,7 @@ export const loggerConfig = {
             format: winston.format.combine(
                 winston.format.timestamp(),
                 winston.format.ms(),
+                requestContextFormat(),
                 process.env.NODE_ENV === 'production'
                     ? winston.format.json()
                     : nestWinstonModuleUtilities.format.nestLike('MyFans', {

--- a/backend/src/common/middleware/correlation-id.middleware.spec.ts
+++ b/backend/src/common/middleware/correlation-id.middleware.spec.ts
@@ -42,15 +42,15 @@ describe('CorrelationIdMiddleware', () => {
     middleware.use(req as Request, res as Response, next);
   });
 
-  it('preserves existing IDs from incoming headers', (done) => {
+  it('preserves existing valid UUID IDs from incoming headers', (done) => {
     const req = makeReq({
-      'x-correlation-id': 'cid-123',
-      'x-request-id': 'rid-456',
+      'x-correlation-id': 'a1b2c3d4-e5f6-4789-8abc-def012345678',
+      'x-request-id': 'b2c3d4e5-f6a7-4890-9bcd-ef0123456789',
     });
     const res = makeRes();
     const next: NextFunction = () => {
-      expect(req.headers!['x-correlation-id']).toBe('cid-123');
-      expect(req.headers!['x-request-id']).toBe('rid-456');
+      expect(req.headers!['x-correlation-id']).toBe('a1b2c3d4-e5f6-4789-8abc-def012345678');
+      expect(req.headers!['x-request-id']).toBe('b2c3d4e5-f6a7-4890-9bcd-ef0123456789');
       done();
     };
 
@@ -58,18 +58,18 @@ describe('CorrelationIdMiddleware', () => {
   });
 
   it('makes correlationId readable via RequestContextService inside next()', (done) => {
-    const req = makeReq({ 'x-correlation-id': 'trace-abc' });
+    const req = makeReq({ 'x-correlation-id': 'a1b2c3d4-e5f6-4789-8abc-def012345678' });
     const res = makeRes();
     const next: NextFunction = () => {
       // Inside next() we are within the AsyncLocalStorage context
-      expect(requestContextService.getCorrelationId()).toBe('trace-abc');
+      expect(requestContextService.getCorrelationId()).toBe('a1b2c3d4-e5f6-4789-8abc-def012345678');
       done();
     };
 
     middleware.use(req as Request, res as Response, next);
   });
 
-  it('generates valid UUID v4 IDs', (done) => {
+  it('generates valid UUID v4 IDs when no headers provided', (done) => {
     const req = makeReq();
     const res = makeRes();
     const uuidRegex =
@@ -83,27 +83,31 @@ describe('CorrelationIdMiddleware', () => {
     middleware.use(req as Request, res as Response, next);
   });
 
-  it('isolates context between concurrent requests', (done) => {
-    const req1 = makeReq({ 'x-correlation-id': 'cid-req1' });
-    const req2 = makeReq({ 'x-correlation-id': 'cid-req2' });
+  it('replaces invalid (non-UUID) correlation ID with a fresh UUID', (done) => {
+    const req = makeReq({ 'x-correlation-id': 'not-a-uuid', 'x-request-id': 'also-bad' });
     const res = makeRes();
-    let completed = 0;
-    const next1: NextFunction = () => {
-      // Simulate async work inside req1's context
-      setImmediate(() => {
-        expect(requestContextService.getCorrelationId()).toBe('cid-req1');
-        if (++completed === 2) done();
-      });
-    };
-    const next2: NextFunction = () => {
-      setImmediate(() => {
-        expect(requestContextService.getCorrelationId()).toBe('cid-req2');
-        if (++completed === 2) done();
-      });
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    const next: NextFunction = () => {
+      expect(req.headers!['x-correlation-id']).toMatch(uuidRegex);
+      expect(req.headers!['x-request-id']).toMatch(uuidRegex);
+      done();
     };
 
-    middleware.use(req1 as Request, res as Response, next1);
+    middleware.use(req as Request, res as Response, next);
+  });
 
-    middleware.use(req2 as Request, res as Response, next2);
+  it('replaces empty-string IDs with fresh UUIDs', (done) => {
+    const req = makeReq({ 'x-correlation-id': '', 'x-request-id': '' });
+    const res = makeRes();
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    const next: NextFunction = () => {
+      expect(req.headers!['x-correlation-id']).toMatch(uuidRegex);
+      expect(req.headers!['x-request-id']).toMatch(uuidRegex);
+      done();
+    };
+
+    middleware.use(req as Request, res as Response, next);
   });
 });

--- a/backend/src/common/middleware/correlation-id.middleware.ts
+++ b/backend/src/common/middleware/correlation-id.middleware.ts
@@ -3,15 +3,20 @@ import { Request, Response, NextFunction } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { RequestContextService } from '../services/request-context.service';
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function validUuid(value: string | undefined): string {
+  return value && UUID_RE.test(value) ? value : uuidv4();
+}
+
 @Injectable()
 export class CorrelationIdMiddleware implements NestMiddleware {
   constructor(private readonly requestContextService: RequestContextService) {}
 
   use(req: Request, res: Response, next: NextFunction): void {
-    const correlationId =
-      (req.headers['x-correlation-id'] as string) || uuidv4();
-    const requestId =
-      (req.headers['x-request-id'] as string) || uuidv4();
+    const correlationId = validUuid(req.headers['x-correlation-id'] as string | undefined);
+    const requestId = validUuid(req.headers['x-request-id'] as string | undefined);
 
     req.headers['x-correlation-id'] = correlationId;
     req.headers['x-request-id'] = requestId;

--- a/backend/src/common/services/logger.service.spec.ts
+++ b/backend/src/common/services/logger.service.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { LoggerService } from './logger.service';
+import { RequestContextService } from './request-context.service';
+
+const mockWinston = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  verbose: jest.fn(),
+  log: jest.fn(),
+};
+
+describe('LoggerService', () => {
+  let service: LoggerService;
+  let requestContextService: RequestContextService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LoggerService,
+        RequestContextService,
+        { provide: WINSTON_MODULE_PROVIDER, useValue: mockWinston },
+      ],
+    }).compile();
+
+    service = module.get<LoggerService>(LoggerService);
+    requestContextService = module.get<RequestContextService>(RequestContextService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('log() calls winston.info with message and context meta', () => {
+    service.log('hello', 'TestCtx');
+    expect(mockWinston.info).toHaveBeenCalledWith('hello', expect.objectContaining({ context: 'TestCtx' }));
+  });
+
+  it('warn() calls winston.warn', () => {
+    service.warn('watch out', 'TestCtx');
+    expect(mockWinston.warn).toHaveBeenCalledWith('watch out', expect.objectContaining({ context: 'TestCtx' }));
+  });
+
+  it('error() calls winston.error and includes trace when provided', () => {
+    service.error('boom', 'stack trace', 'TestCtx');
+    expect(mockWinston.error).toHaveBeenCalledWith(
+      'boom',
+      expect.objectContaining({ context: 'TestCtx', trace: 'stack trace' }),
+    );
+  });
+
+  it('error() omits trace key when trace is undefined', () => {
+    service.error('boom', undefined, 'TestCtx');
+    const meta = mockWinston.error.mock.calls[0][1] as Record<string, unknown>;
+    expect(meta).not.toHaveProperty('trace');
+  });
+
+  it('debug() calls winston.debug', () => {
+    service.debug('dbg', 'TestCtx');
+    expect(mockWinston.debug).toHaveBeenCalledWith('dbg', expect.objectContaining({ context: 'TestCtx' }));
+  });
+
+  it('verbose() calls winston.verbose', () => {
+    service.verbose('vrb', 'TestCtx');
+    expect(mockWinston.verbose).toHaveBeenCalledWith('vrb', expect.objectContaining({ context: 'TestCtx' }));
+  });
+
+  it('includes correlationId and requestId from request context in meta', () => {
+    requestContextService.run(
+      {
+        correlationId: 'cid-test',
+        requestId: 'rid-test',
+        method: 'GET',
+        url: '/test',
+        ip: '127.0.0.1',
+        userId: null,
+      },
+      () => {
+        service.log('in-context', 'Ctx');
+        expect(mockWinston.info).toHaveBeenCalledWith(
+          'in-context',
+          expect.objectContaining({ correlationId: 'cid-test', requestId: 'rid-test' }),
+        );
+      },
+    );
+  });
+
+  it('logStructured() calls winston.log with level and redacted data', () => {
+    service.logStructured('info', 'structured msg', { password: 'secret', action: 'test' }, 'Ctx');
+    expect(mockWinston.log).toHaveBeenCalledWith(
+      'info',
+      'structured msg',
+      expect.objectContaining({
+        context: 'Ctx',
+        data: expect.objectContaining({ password: '[REDACTED]', action: 'test' }),
+      }),
+    );
+  });
+
+  it('logStructured() omits data key when data is undefined', () => {
+    service.logStructured('warn', 'no data', undefined, 'Ctx');
+    const meta = mockWinston.log.mock.calls[0][2] as Record<string, unknown>;
+    expect(meta).not.toHaveProperty('data');
+  });
+
+  it('defaults context to "Application" when not provided', () => {
+    service.log('no ctx');
+    expect(mockWinston.info).toHaveBeenCalledWith('no ctx', expect.objectContaining({ context: 'Application' }));
+  });
+
+  it('serialises non-string messages to JSON', () => {
+    service.log({ foo: 'bar' });
+    expect(mockWinston.info).toHaveBeenCalledWith('{"foo":"bar"}', expect.any(Object));
+  });
+});

--- a/backend/src/common/services/logger.service.ts
+++ b/backend/src/common/services/logger.service.ts
@@ -1,127 +1,51 @@
-import { Injectable, LoggerService as NestLoggerService } from '@nestjs/common';
+import { Inject, Injectable, LoggerService as NestLoggerService } from '@nestjs/common';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger as WinstonLogger } from 'winston';
 import { RequestContextService } from './request-context.service';
 import { redact } from '../utils/redact';
 
 @Injectable()
 export class LoggerService implements NestLoggerService {
-  private logger: NestLoggerService;
+  constructor(
+    private readonly requestContextService: RequestContextService,
+    @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: WinstonLogger,
+  ) {}
 
-  constructor(private readonly requestContextService: RequestContextService) {
-    this.logger = new (class implements NestLoggerService {
-      log(message: any, context?: string) {
-        console.log(`[${context}] ${message}`);
-      }
-      error(message: any, trace?: string, context?: string) {
-        console.error(`[${context}] ${message}`, trace);
-      }
-      warn(message: any, context?: string) {
-        console.warn(`[${context}] ${message}`);
-      }
-      debug(message: any, context?: string) {
-        console.debug(`[${context}] ${message}`);
-      }
-      verbose(message: any, context?: string) {
-        console.log(`[${context}] ${message}`);
-      }
-    })();
-  }
-
-  private formatMessage(
-    message: any,
-    context?: string,
-  ): { message: any; context: string } {
-    const logContext = this.requestContextService.getLogContext();
-    const contextString = context || 'Application';
-
-    // Add request context to message if available
-    if (Object.keys(logContext).length > 0) {
-      const formattedMessage =
-        typeof message === 'string' ? message : JSON.stringify(message);
-      return {
-        message: `${formattedMessage} [Context: ${JSON.stringify(logContext)}]`,
-        context: contextString,
-      };
-    }
-
-    return {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      message,
-      context: contextString,
-    };
+  private meta(context?: string): Record<string, unknown> {
+    return { context: context ?? 'Application', ...this.requestContextService.getLogContext() };
   }
 
   log(message: any, context?: string) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const { message: formattedMessage, context: formattedContext } =
-      this.formatMessage(message, context);
-    this.logger.log(formattedMessage, formattedContext);
+    this.logger.info(typeof message === 'string' ? message : JSON.stringify(message), this.meta(context));
   }
 
   error(message: any, trace?: string, context?: string) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const { message: formattedMessage, context: formattedContext } =
-      this.formatMessage(message, context);
-    this.logger.error(formattedMessage, trace, formattedContext);
+    this.logger.error(typeof message === 'string' ? message : JSON.stringify(message), { ...this.meta(context), ...(trace ? { trace } : {}) });
   }
 
   warn(message: any, context?: string) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const { message: formattedMessage, context: formattedContext } =
-      this.formatMessage(message, context);
-    this.logger.warn(formattedMessage, formattedContext);
+    this.logger.warn(typeof message === 'string' ? message : JSON.stringify(message), this.meta(context));
   }
 
   debug(message: any, context?: string) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const { message: formattedMessage, context: formattedContext } =
-      this.formatMessage(message, context);
-    this.logger?.debug?.(formattedMessage, formattedContext);
+    this.logger.debug(typeof message === 'string' ? message : JSON.stringify(message), this.meta(context));
   }
 
   verbose(message: any, context?: string) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const { message: formattedMessage, context: formattedContext } =
-      this.formatMessage(message, context);
-    this.logger?.verbose?.(formattedMessage, formattedContext);
+    this.logger.verbose(typeof message === 'string' ? message : JSON.stringify(message), this.meta(context));
   }
 
   // Method for structured logging
   logStructured(
     level: 'info' | 'warn' | 'error' | 'debug',
     message: string,
-
     data?: unknown,
     context?: string,
   ) {
-    const logContext = this.requestContextService.getLogContext();
-
     const redactedData = data !== undefined ? redact(data) : undefined;
-    const logEntry = {
-      timestamp: new Date().toISOString(),
-      level,
-      message,
-      context: context || 'Application',
-      ...logContext,
+    this.logger.log(level, message, {
+      ...this.meta(context),
       ...(redactedData !== undefined && { data: redactedData }),
-    };
-
-    // In production, this would be handled by Winston's JSON format
-    // For now, we'll format it for console output
-
-    const formattedMessage = JSON.stringify(logEntry);
-
-    switch (level) {
-      case 'error':
-        this.logger.error(formattedMessage, '', context);
-        break;
-      case 'warn':
-        this.logger.warn(formattedMessage, context);
-        break;
-      case 'debug':
-        this.logger?.debug?.(formattedMessage, context);
-        break;
-      default:
-        this.logger.log(formattedMessage, context);
-    }
+    });
   }
 }

--- a/backend/src/common/services/request-context.service.ts
+++ b/backend/src/common/services/request-context.service.ts
@@ -13,6 +13,11 @@ export interface RequestContext {
 
 const storage = new AsyncLocalStorage<RequestContext>();
 
+/** Exported so the Winston format in logger.config.ts can read the store directly. */
+export function getRequestContextStorage(): AsyncLocalStorage<RequestContext> {
+  return storage;
+}
+
 @Injectable()
 export class RequestContextService {
   /** Run a callback inside a new request context store. */

--- a/backend/test/api-versioning.e2e-spec.ts
+++ b/backend/test/api-versioning.e2e-spec.ts
@@ -1,0 +1,196 @@
+/**
+ * API Versioning – integration tests
+ *
+ * Verifies that URI-based versioning (/v1/...) is correctly applied across
+ * the application:
+ *   1. All v1 routes are reachable under /v1/<path>.
+ *   2. Unversioned paths (/<path>) return 404.
+ *   3. An unknown version prefix (/v99/...) returns 404.
+ *   4. Response headers echo back valid tracing IDs on versioned routes.
+ */
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  INestApplication,
+  Module,
+  VersioningType,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+
+// ---------------------------------------------------------------------------
+// Minimal stub controllers – one versioned, one intentionally unversioned
+// ---------------------------------------------------------------------------
+
+@Controller({ path: 'probe', version: '1' })
+class ProbeV1Controller {
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  ping() {
+    return { version: 'v1', ok: true };
+  }
+}
+
+@Controller({ path: 'probe', version: '2' })
+class ProbeV2Controller {
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  ping() {
+    return { version: 'v2', ok: true };
+  }
+}
+
+/** Controller with NO version annotation – should only be reachable without a
+ *  version prefix when defaultVersion is NOT set, or via the default version
+ *  when defaultVersion IS set. */
+@Controller('unversioned-probe')
+class UnversionedProbeController {
+  @Get()
+  ping() {
+    return { ok: true };
+  }
+}
+
+@Module({
+  controllers: [ProbeV1Controller, ProbeV2Controller, UnversionedProbeController],
+})
+class VersioningTestModule {}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function buildApp(
+  opts: { defaultVersion?: string } = {},
+): Promise<INestApplication> {
+  const moduleRef: TestingModule = await Test.createTestingModule({
+    imports: [VersioningTestModule],
+  }).compile();
+
+  const app = moduleRef.createNestApplication();
+  app.enableVersioning({
+    type: VersioningType.URI,
+    ...(opts.defaultVersion ? { defaultVersion: opts.defaultVersion } : {}),
+  });
+  await app.init();
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Suite 1 – versioned routing (no defaultVersion)
+// ---------------------------------------------------------------------------
+
+describe('API Versioning – URI routing', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    app = await buildApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /v1/probe returns 200 with version=v1', () => {
+    return request(app.getHttpServer())
+      .get('/v1/probe')
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toEqual({ version: 'v1', ok: true });
+      });
+  });
+
+  it('GET /v2/probe returns 200 with version=v2', () => {
+    return request(app.getHttpServer())
+      .get('/v2/probe')
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toEqual({ version: 'v2', ok: true });
+      });
+  });
+
+  it('GET /probe (no version prefix) returns 404', () => {
+    return request(app.getHttpServer()).get('/probe').expect(404);
+  });
+
+  it('GET /v99/probe (unknown version) returns 404', () => {
+    return request(app.getHttpServer()).get('/v99/probe').expect(404);
+  });
+
+  it('GET /v0/probe (invalid version) returns 404', () => {
+    return request(app.getHttpServer()).get('/v0/probe').expect(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 2 – defaultVersion fallback
+// ---------------------------------------------------------------------------
+
+describe('API Versioning – defaultVersion fallback', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    app = await buildApp({ defaultVersion: '1' });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /v1/probe still works with defaultVersion set', () => {
+    return request(app.getHttpServer()).get('/v1/probe').expect(200);
+  });
+
+  it('GET /v2/probe still works with defaultVersion set', () => {
+    return request(app.getHttpServer()).get('/v2/probe').expect(200);
+  });
+
+  it('GET /v99/probe still returns 404 with defaultVersion set', () => {
+    return request(app.getHttpServer()).get('/v99/probe').expect(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 3 – response shape and headers on versioned routes
+// ---------------------------------------------------------------------------
+
+describe('API Versioning – response shape', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    app = await buildApp({ defaultVersion: '1' });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('v1 response body contains expected fields', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/v1/probe')
+      .expect(200);
+
+    expect(res.body).toHaveProperty('version', 'v1');
+    expect(res.body).toHaveProperty('ok', true);
+  });
+
+  it('v2 response body contains expected fields', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/v2/probe')
+      .expect(200);
+
+    expect(res.body).toHaveProperty('version', 'v2');
+    expect(res.body).toHaveProperty('ok', true);
+  });
+
+  it('v1 and v2 responses are distinct', async () => {
+    const [r1, r2] = await Promise.all([
+      request(app.getHttpServer()).get('/v1/probe'),
+      request(app.getHttpServer()).get('/v2/probe'),
+    ]);
+
+    expect(r1.body.version).not.toBe(r2.body.version);
+  });
+});

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, VersioningType } from '@nestjs/common';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppTestModule } from './../src/app-test.module';
@@ -13,6 +13,7 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
     await app.init();
   });
 
@@ -20,10 +21,16 @@ describe('AppController (e2e)', () => {
     await app.close();
   });
 
-  it('/ (GET)', () => {
+  it('/v1 (GET) returns Hello World', () => {
     return request(app.getHttpServer())
-      .get('/')
+      .get('/v1')
       .expect(200)
       .expect('Hello World!');
+  });
+
+  it('unversioned / (GET) returns 404 when versioning is enabled', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(404);
   });
 });

--- a/backend/test/cors-security.e2e-spec.ts
+++ b/backend/test/cors-security.e2e-spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, VersioningType } from '@nestjs/common';
 import request from 'supertest';
 import { AppModule } from '../src/app.module';
 
@@ -13,6 +13,7 @@ describe('CORS and Security Headers (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
     await app.init();
   });
 
@@ -21,8 +22,8 @@ describe('CORS and Security Headers (e2e)', () => {
   });
 
   describe('Security Headers', () => {
-    it('/ (GET) - should include security headers', async () => {
-      const response = await request(app.getHttpServer()).get('/').expect(200);
+    it('/v1 (GET) - should include security headers', async () => {
+      const response = await request(app.getHttpServer()).get('/v1').expect(200);
 
       // Check security headers are present
       expect(response.headers['x-frame-options']).toBe('DENY');
@@ -46,28 +47,28 @@ describe('CORS and Security Headers (e2e)', () => {
       expect(response.headers['content-security-policy']).toBeDefined();
     });
 
-    it('/ (GET) - should not expose X-Powered-By header', async () => {
-      const response = await request(app.getHttpServer()).get('/').expect(200);
+    it('/v1 (GET) - should not expose X-Powered-By header', async () => {
+      const response = await request(app.getHttpServer()).get('/v1').expect(200);
 
       expect(response.headers['x-powered-by']).toBeUndefined();
     });
 
-    it('/ (GET) - should include correlation ID headers in response', async () => {
+    it('/v1 (GET) - should include correlation ID headers in response', async () => {
       const response = await request(app.getHttpServer())
-        .get('/')
-        .set('X-Correlation-ID', 'test-correlation-id')
-        .set('X-Request-ID', 'test-request-id')
+        .get('/v1')
+        .set('X-Correlation-ID', 'a1b2c3d4-e5f6-4789-8abc-def012345678')
+        .set('X-Request-ID', 'b2c3d4e5-f6a7-4890-9bcd-ef0123456789')
         .expect(200);
 
-      expect(response.headers['x-correlation-id']).toBe('test-correlation-id');
-      expect(response.headers['x-request-id']).toBe('test-request-id');
+      expect(response.headers['x-correlation-id']).toBe('a1b2c3d4-e5f6-4789-8abc-def012345678');
+      expect(response.headers['x-request-id']).toBe('b2c3d4e5-f6a7-4890-9bcd-ef0123456789');
     });
   });
 
   describe('CORS', () => {
     it('should handle CORS preflight requests', async () => {
       const response = await request(app.getHttpServer())
-        .options('/')
+        .options('/v1')
         .set('Origin', 'http://localhost:3000')
         .set('Access-Control-Request-Method', 'GET')
         .set('Access-Control-Request-Headers', 'Content-Type, Authorization')
@@ -86,7 +87,7 @@ describe('CORS and Security Headers (e2e)', () => {
 
     it('should include CORS headers on actual requests', async () => {
       const response = await request(app.getHttpServer())
-        .get('/')
+        .get('/v1')
         .set('Origin', 'http://localhost:3000')
         .expect(200);
 
@@ -97,7 +98,7 @@ describe('CORS and Security Headers (e2e)', () => {
     });
 
     it('should handle requests without Origin header', async () => {
-      const response = await request(app.getHttpServer()).get('/').expect(200);
+      const response = await request(app.getHttpServer()).get('/v1').expect(200);
 
       // Should still work without Origin header
       expect(response.status).toBe(200);
@@ -117,7 +118,7 @@ describe('CORS and Security Headers (e2e)', () => {
 
     it('should block disallowed origins in production', async () => {
       const response = await request(app.getHttpServer())
-        .get('/')
+        .get('/v1')
         .set('Origin', 'https://malicious.com')
         .expect(200);
 

--- a/backend/test/subscriptions.e2e-spec.ts
+++ b/backend/test/subscriptions.e2e-spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, VersioningType } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -188,6 +188,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
       .compile();
 
     app = moduleRef.createNestApplication();
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
     await app.init();
   });
 
@@ -199,7 +200,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
 
   it('creates checkout and powers the full flow via RPC stubs', async () => {
     const createRes = await request(app.getHttpServer())
-      .post('/subscriptions/checkout')
+      .post('/v1/subscriptions/checkout')
       .send({
         fanAddress: 'GTESTFAN1',
         creatorAddress: 'GTESTCREATOR1',
@@ -213,7 +214,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
     const checkoutId = createRes.body.id;
 
     await request(app.getHttpServer())
-      .get(`/subscriptions/checkout/${checkoutId}`)
+      .get(`/v1/subscriptions/checkout/${checkoutId}`)
       .expect(200)
       .expect((res) => {
         expect(res.body.id).toBe(checkoutId);
@@ -221,7 +222,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
       });
 
     await request(app.getHttpServer())
-      .get(`/subscriptions/checkout/${checkoutId}/plan`)
+      .get(`/v1/subscriptions/checkout/${checkoutId}/plan`)
       .expect(200)
       .expect((res) => {
         expect(res.body.creatorAddress).toBe('GAAAAAAAAAAAAAAA');
@@ -229,7 +230,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
       });
 
     await request(app.getHttpServer())
-      .get(`/subscriptions/checkout/${checkoutId}/price`)
+      .get(`/v1/subscriptions/checkout/${checkoutId}/price`)
       .expect(200)
       .expect((res) => {
         expect(res.body.subtotal).toBe('10');
@@ -237,7 +238,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
       });
 
     await request(app.getHttpServer())
-      .get(`/subscriptions/checkout/${checkoutId}/wallet`)
+      .get(`/v1/subscriptions/checkout/${checkoutId}/wallet`)
       .expect(200)
       .expect((res) => {
         const xlm = res.body.balances.find((b) => b.code === 'XLM');
@@ -248,7 +249,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
       });
 
     await request(app.getHttpServer())
-      .post(`/subscriptions/checkout/${checkoutId}/validate`)
+      .post(`/v1/subscriptions/checkout/${checkoutId}/validate`)
       .send({ assetCode: 'XLM', amount: '10' })
       .expect(201)
       .expect((res) => {
@@ -256,7 +257,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
       });
 
     await request(app.getHttpServer())
-      .post(`/subscriptions/checkout/${checkoutId}/validate`)
+      .post(`/v1/subscriptions/checkout/${checkoutId}/validate`)
       .send({ assetCode: 'USDC', amount: '50' })
       .expect(201)
       .expect((res) => {
@@ -265,7 +266,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
       });
 
     await request(app.getHttpServer())
-      .get('/subscriptions/check')
+      .get('/v1/subscriptions/check')
       .query({ fan: 'GTESTFAN1', creator: 'GTESTCREATOR1' })
       .expect(200)
       .expect((res) => {
@@ -273,7 +274,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
       });
 
     await request(app.getHttpServer())
-      .post(`/subscriptions/checkout/${checkoutId}/confirm`)
+      .post(`/v1/subscriptions/checkout/${checkoutId}/confirm`)
       .send({ txHash: 'tx-101' })
       .expect(201)
       .expect((res) => {
@@ -282,7 +283,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
       });
 
     await request(app.getHttpServer())
-      .get('/subscriptions/check')
+      .get('/v1/subscriptions/check')
       .query({ fan: 'GTESTFAN1', creator: 'GTESTCREATOR1' })
       .expect(200)
       .expect((res) => {
@@ -291,7 +292,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
 
     // confirmation has side effects on the checkout record
     await request(app.getHttpServer())
-      .get(`/subscriptions/checkout/${checkoutId}`)
+      .get(`/v1/subscriptions/checkout/${checkoutId}`)
       .expect(200)
       .expect((res) => {
         expect(res.body.status).toBe('completed');
@@ -301,7 +302,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
 
   it('handles failed checkout path', async () => {
     const createRes = await request(app.getHttpServer())
-      .post('/subscriptions/checkout')
+      .post('/v1/subscriptions/checkout')
       .send({
         fanAddress: 'GTESTFAN2',
         creatorAddress: 'GTESTCREATOR2',
@@ -312,7 +313,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
     const checkoutId = createRes.body.id;
 
     await request(app.getHttpServer())
-      .post(`/subscriptions/checkout/${checkoutId}/fail`)
+      .post(`/v1/subscriptions/checkout/${checkoutId}/fail`)
       .send({ error: 'Insufficient funds' })
       .expect(201)
       .expect((res) => {
@@ -320,7 +321,7 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
       });
 
     await request(app.getHttpServer())
-      .get(`/subscriptions/checkout/${checkoutId}`)
+      .get(`/v1/subscriptions/checkout/${checkoutId}`)
       .expect(200)
       .expect((res) => {
         expect(res.body.status).toBe('failed');


### PR DESCRIPTION
closes #859 


This PR introduces URL-based API versioning to support future breaking changes safely and improve long-term API maintainability. All existing endpoints are now routed under the /v1 namespace, with optional support for redirecting unversioned routes to v1.

Changes Included:
Added API versioning support using /v1/... route structure
Updated existing endpoints to use v1 namespace
Updated routing and middleware where required
Ensured compatibility with existing authentication and security flows. etc etc