### PR TITLE
contract/subscription: document public functions in README and add snapshot/restore tests

### DIFF
--- a/contract/contracts/subscription/README.md
+++ b/contract/contracts/subscription/README.md
@@ -1,117 +1,334 @@
 # Subscription Contract
 
-Soroban smart contract for managing subscriptions with lifecycle events.
+Soroban smart contract for managing creator subscriptions on MyFans.
+Located in `contract/contracts/subscription/`.
 
-## Events
+---
 
-### SubscriptionCreated
-Emitted when a new subscription is created.
+## Data Types
+
+### `Plan`
 
 ```rust
-pub struct SubscriptionCreated {
-    pub fan: Address,
+pub struct Plan {
     pub creator: Address,
-    pub expires_at: u64,
+    pub asset: Address,
+    pub amount: i128,
+    pub interval_days: u32,
 }
 ```
 
-**Topic:** `sub_new`
+A recurring billing plan created by a content creator.
 
-### SubscriptionCancelled
-Emitted when a subscription is cancelled.
+### `Subscription`
 
 ```rust
-pub struct SubscriptionCancelled {
+pub struct Subscription {
     pub fan: Address,
-    pub creator: Address,
+    pub plan_id: u32,  // 0 for direct (plan-less) subscriptions
+    pub expiry: u64,   // ledger sequence at which the subscription expires
 }
 ```
 
-**Topic:** `sub_cncl`
+---
 
-### SubscriptionExpired
-Emitted when a subscription expires.
+## Error Codes
+
+| Code | Variant | Description |
+|------|---------|-------------|
+| 1 | `AlreadyInitialized` | `init` was called more than once |
+| 2 | `Paused` | Contract is paused; state-changing calls are rejected |
+| 3 | `SubscriptionNotFound` | No subscription record for `(fan, creator)` |
+| 4 | `SubscriptionExpired` | Subscription exists but its expiry ledger has passed |
+| 5 | `AdminNotInitialized` | Admin key not present; contract was never initialized |
+| 6 | `InvalidFeeRecipient` | Fee recipient is the Stellar null/burn address |
+| 7 | `InvalidFeeBps` | Fee basis points exceed 10 000 (100%) |
+| 8 | `InvalidTokenAddress` | Token address is the Stellar null/burn address |
+| 9 | `InvalidPrice` | Subscription price must be strictly positive |
+
+---
+
+## Public Functions
+
+### `init`
 
 ```rust
-pub struct SubscriptionExpired {
-    pub fan: Address,
-    pub creator: Address,
-}
+pub fn init(
+    env: Env,
+    admin: Address,
+    fee_bps: u32,
+    fee_recipient: Address,
+    token: Address,
+    price: i128,
+)
 ```
 
-**Topic:** `sub_exp`
+One-time contract initialization. Stores admin, fee configuration, token address, and base subscription price.
 
-## Functions
+**Panics** with `AlreadyInitialized` if called again, `InvalidFeeBps` if `fee_bps > 10_000`,
+`InvalidTokenAddress` if `token` is the Stellar null address, or `InvalidPrice` if `price <= 0`.
 
-### create_subscription
+---
+
+### `create_plan`
+
+```rust
+pub fn create_plan(
+    env: Env,
+    creator: Address,
+    asset: Address,
+    amount: i128,
+    interval_days: u32,
+) -> u32
+```
+
+Registers a new billing plan for `creator`. Returns the assigned `plan_id` (auto-incremented from 1).
+Requires `creator` authorization. Panics with `Paused` if the contract is paused.
+
+**Event** `plan_created` — topics: `(name, creator)`, data: `plan_id`
+
+---
+
+### `subscribe`
+
+```rust
+pub fn subscribe(env: Env, fan: Address, plan_id: u32, _token: Address)
+```
+
+Subscribes `fan` to an existing plan. Transfers `plan.amount` tokens from `fan` to `plan.creator`
+(minus protocol fee) and to the fee recipient. Expiry is set to
+`current_sequence + interval_days * 17_280`.
+
+Requires `fan` authorization. Panics with `Paused` if the contract is paused.
+
+**Event** `subscribed` — topics: `(name, fan, creator)`, data: `plan_id`
+
+---
+
+### `create_subscription`
+
 ```rust
 pub fn create_subscription(
     env: Env,
     fan: Address,
     creator: Address,
-    expires_at: u64,
-) -> SubscriptionStatus
+    duration_ledgers: u32,
+)
 ```
 
-Creates a new subscription and emits `SubscriptionCreated` event.
+Direct (plan-less) subscription. Charges the global `price` stored at `init` and sets expiry to
+`current_sequence + duration_ledgers`. Increments `CreatorSubscriptionCount` for `creator`.
 
-### cancel_subscription
+Requires `fan` authorization. Panics with `Paused` if the contract is paused.
+
+**Event** `subscribed` — topics: `(name, fan, creator)`, data: `0u32` (no plan)
+
+---
+
+### `extend_subscription`
+
 ```rust
-pub fn cancel_subscription(env: Env, fan: Address, creator: Address)
+pub fn extend_subscription(
+    env: Env,
+    fan: Address,
+    creator: Address,
+    extra_ledgers: u32,
+    token: Address,
+)
 ```
 
-Cancels an existing subscription and emits `SubscriptionCancelled` event.
+Extends an active subscription by `extra_ledgers`. Charges `plan.amount` again.
+Panics with `SubscriptionNotFound`, `SubscriptionExpired`, or `Paused` as applicable.
 
-### expire_subscription
+Requires `fan` authorization.
+
+**Event** `extended` — topics: `(name, fan, creator)`, data: `plan_id`
+
+---
+
+### `cancel`
+
 ```rust
-pub fn expire_subscription(env: Env, fan: Address, creator: Address)
+pub fn cancel(env: Env, fan: Address, creator: Address, reason: u32)
 ```
 
-Expires a subscription and emits `SubscriptionExpired` event.
+Cancels `fan`'s subscription to `creator` and removes the storage entry.
 
-### get_expiry
+`reason` codes (convention — not enforced on-chain):
+
+| Code | Meaning |
+|------|---------|
+| 0 | User-initiated |
+| 1 | Too expensive |
+| 2 | Content quality |
+| 3 | Switching creator |
+| 4 | Other |
+
+Requires `fan` authorization. Panics with `Paused` if the contract is paused.
+
+**Event** `cancelled` — topics: `(name, fan, creator)`, data: `(true, reason)`
+
+---
+
+### `pause`
+
 ```rust
-pub fn get_expiry(env: Env, fan: Address, creator: Address) -> Option<u64>
+pub fn pause(env: Env)
 ```
 
-Returns the expiry timestamp for a subscription, or None if not found.
+Pauses the contract. All state-changing operations (`create_plan`, `subscribe`,
+`create_subscription`, `extend_subscription`, `cancel`) will fail while paused.
+View functions remain available.
 
-## Tests
+Requires admin authorization.
 
-Run tests:
+**Event** `paused` — topics: `(name,)`, data: `admin`
+
+---
+
+### `unpause`
+
+```rust
+pub fn unpause(env: Env)
+```
+
+Resumes normal contract operation after a pause.
+
+Requires admin authorization.
+
+**Event** `unpaused` — topics: `(name,)`, data: `admin`
+
+---
+
+### `set_fee_recipient`
+
+```rust
+pub fn set_fee_recipient(env: Env, new_fee_recipient: Address)
+```
+
+Rotates the protocol fee recipient. Rejects the Stellar null/burn address.
+
+Requires admin authorization.
+
+**Event** `fee_recipient_updated` — topics: `(name, old_recipient, new_recipient)`, data: `()`
+
+---
+
+### `set_fee_bps`
+
+```rust
+pub fn set_fee_bps(env: Env, new_fee_bps: u32)
+```
+
+Updates the protocol fee in basis points. `new_fee_bps` must be ≤ 10 000.
+
+Requires admin authorization.
+
+**Event** `fee_updated` — topics: `(name,)`, data: `(old_bps, new_bps)`
+
+---
+
+### `admin`
+
+```rust
+pub fn admin(env: Env) -> Address
+```
+
+Returns the admin address. No authorization required.
+Panics with `AdminNotInitialized` if the contract was never initialized.
+
+---
+
+### `is_subscriber`
+
+```rust
+pub fn is_subscriber(env: Env, fan: Address, creator: Address) -> bool
+```
+
+Returns `true` if `fan` has an active (non-expired) subscription to `creator`.
+No authorization required.
+
+---
+
+### `is_paused`
+
+```rust
+pub fn is_paused(env: Env) -> bool
+```
+
+Returns `true` if the contract is currently paused. No authorization required.
+
+---
+
+### `get_expiry_unix`
+
+```rust
+pub fn get_expiry_unix(env: Env, fan: Address, creator: Address) -> (u64, u64)
+```
+
+Returns `(expiry_ledger_sequence, expiry_unix_timestamp)` for the subscription.
+The unix timestamp is derived from the on-chain ledger timestamp at call time,
+avoiding server-clock skew (5 seconds per ledger is used for conversion).
+
+Returns `(0, 0)` if no subscription exists. No authorization required.
+
+---
+
+### `ping`
+
+```rust
+pub fn ping(env: Env) -> u32
+```
+
+Health-check / connectivity probe. Returns the current ledger sequence number.
+A stale or non-advancing sequence indicates an RPC node problem.
+No authorization required; safe to call before `init`.
+
+Suggested HTTP mapping:
+- Successful invocation → `200 OK`
+- Invocation error / RPC unreachable → `503 Service Unavailable`
+
+---
+
+## Events Reference
+
+| Event | Topics | Data |
+|-------|--------|------|
+| `plan_created` | `(name, creator)` | `plan_id: u32` |
+| `subscribed` | `(name, fan, creator)` | `plan_id: u32` (0 for direct sub) |
+| `extended` | `(name, fan, creator)` | `plan_id: u32` |
+| `cancelled` | `(name, fan, creator)` | `(true, reason: u32)` |
+| `paused` | `(name,)` | `admin: Address` |
+| `unpaused` | `(name,)` | `admin: Address` |
+| `fee_recipient_updated` | `(name, old, new)` | `()` |
+| `fee_updated` | `(name,)` | `(old_bps: u32, new_bps: u32)` |
+
+---
+
+## Running Tests
+
 ```bash
-cargo test
+cd contract
+cargo test -p subscription --features testutils
 ```
 
 ### Test Coverage
 
-1. **test_create_subscription_emits_event** - Verifies SubscriptionCreated event
-2. **test_cancel_subscription_emits_event** - Verifies SubscriptionCancelled event
-3. **test_expire_subscription_emits_event** - Verifies SubscriptionExpired event
-4. **test_subscription_lifecycle** - Full lifecycle test
+Unit tests (`src/test.rs`):
+- Full subscribe flow with fee calculation
+- Direct subscription payment flow (`create_subscription`)
+- Extend subscription: expiry update and payment
+- Cancel subscription and storage removal
+- Snapshot/restore state consistency (subscription, protocol config, pause state)
+- Pause enforcement across all mutating functions
+- View availability while paused
+- Event field validation for all events
+- Cancel reason code propagation
+- `get_expiry_unix` for active, expired, and missing subscriptions
+- `admin()` view correctness and auth-free access
+- `ping()` health check with and without init
+- `set_fee_recipient` / `set_fee_bps` authorization and validation
 
-## Interface Docs
-
-Full method reference: [../docs/interfaces/subscription.md](../docs/interfaces/subscription.md)
-
-## Usage Example
-
-```rust
-let fan = Address::generate(&env);
-let creator = Address::generate(&env);
-let expires_at = 1000;
-
-// Create subscription (emits SubscriptionCreated)
-client.create_subscription(&fan, &creator, &expires_at);
-
-// Cancel subscription (emits SubscriptionCancelled)
-client.cancel_subscription(&fan, &creator);
-```
-
-## Event Indexing
-
-Backend can listen to these events to:
-- Update subscription database
-- Send notifications to users
-- Track subscription metrics
-- Trigger content access updates
+Integration tests (`tests/`):
+- `contract_integration.rs` — cross-contract flows
+- `auth_matrix.rs` — authorization matrix across all entry points

--- a/contract/contracts/subscription/src/test.rs
+++ b/contract/contracts/subscription/src/test.rs
@@ -420,6 +420,198 @@ fn test_subscription_state_after_snapshot_restore() {
     assert_eq!(plan_count, 1, "plan count matches after restore");
 }
 
+/// Protocol config (admin, fee_bps, fee_recipient) is fully preserved after snapshot/restore.
+#[test]
+fn test_protocol_config_preserved_after_snapshot_restore() {
+    let (env, client, admin, token, _token_admin) = setup_test();
+    let fee_recipient = Address::generate(&env);
+    client.init(
+        &admin,
+        &DUMMY_FEE_BPS,
+        &fee_recipient,
+        &token.address,
+        &DUMMY_PRICE,
+    );
+
+    let contract_id = client.address.clone();
+    let sc_admin: ScAddress = admin.clone().into();
+    let sc_fee_recipient: ScAddress = fee_recipient.clone().into();
+    let sc_contract: ScAddress = contract_id.clone().into();
+
+    let snapshot = env.to_snapshot();
+    let env2 = Env::from_snapshot(snapshot);
+    env2.mock_all_auths();
+
+    let contract_id2: Address = Address::try_from_val(&env2, &sc_contract).unwrap();
+    let admin2: Address = Address::try_from_val(&env2, &sc_admin).unwrap();
+    let fee_recipient2: Address = Address::try_from_val(&env2, &sc_fee_recipient).unwrap();
+
+    env2.register_contract(Some(&contract_id2), MyfansContract);
+    let client2 = MyfansContractClient::new(&env2, &contract_id2);
+
+    assert_eq!(
+        client2.admin(),
+        admin2,
+        "admin address must survive snapshot/restore"
+    );
+
+    let stored_fee_bps: u32 = env2.as_contract(&contract_id2, || {
+        env2.storage()
+            .instance()
+            .get::<DataKey, u32>(&DataKey::FeeBps)
+            .unwrap_or(0)
+    });
+    assert_eq!(
+        stored_fee_bps, DUMMY_FEE_BPS,
+        "fee_bps must survive snapshot/restore"
+    );
+
+    let stored_fee_recipient: Address = env2.as_contract(&contract_id2, || {
+        env2.storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::FeeRecipient)
+            .unwrap()
+    });
+    assert_eq!(
+        stored_fee_recipient, fee_recipient2,
+        "fee_recipient must survive snapshot/restore"
+    );
+
+    let stored_price: i128 = env2.as_contract(&contract_id2, || {
+        env2.storage()
+            .instance()
+            .get::<DataKey, i128>(&DataKey::Price)
+            .unwrap()
+    });
+    assert_eq!(
+        stored_price, DUMMY_PRICE,
+        "price must survive snapshot/restore"
+    );
+}
+
+/// Paused state (true) survives snapshot/restore and continues to block mutations.
+#[test]
+fn test_paused_state_preserved_after_snapshot_restore() {
+    let (env, client, admin, token, token_admin) = setup_test();
+    let fee_recipient = Address::generate(&env);
+    client.init(
+        &admin,
+        &DUMMY_FEE_BPS,
+        &fee_recipient,
+        &token.address,
+        &DUMMY_PRICE,
+    );
+    client.pause();
+    assert!(client.is_paused());
+
+    let creator = Address::generate(&env);
+    let fan = Address::generate(&env);
+    token_admin.mint(&fan, &DUMMY_FAN_BALANCE);
+
+    let contract_id = client.address.clone();
+    let sc_contract: ScAddress = contract_id.clone().into();
+    let sc_fan: ScAddress = fan.clone().into();
+    let sc_creator: ScAddress = creator.clone().into();
+
+    let snapshot = env.to_snapshot();
+    let env2 = Env::from_snapshot(snapshot);
+    env2.mock_all_auths();
+
+    let contract_id2: Address = Address::try_from_val(&env2, &sc_contract).unwrap();
+    let fan2: Address = Address::try_from_val(&env2, &sc_fan).unwrap();
+    let creator2: Address = Address::try_from_val(&env2, &sc_creator).unwrap();
+
+    env2.register_contract(Some(&contract_id2), MyfansContract);
+    let client2 = MyfansContractClient::new(&env2, &contract_id2);
+
+    assert!(
+        client2.is_paused(),
+        "paused state must survive snapshot/restore"
+    );
+
+    // Mutations must remain blocked after restore
+    let r = client2.try_create_subscription(&fan2, &creator2, &17280);
+    assert!(
+        r.is_err(),
+        "create_subscription must remain blocked while paused after restore"
+    );
+}
+
+/// Extend subscription works correctly after snapshot/restore, updating expiry by exact ledger count.
+#[test]
+fn test_extend_subscription_after_snapshot_restore() {
+    let (env, client, admin, token, token_admin) = setup_test();
+    let fee_recipient = Address::generate(&env);
+    client.init(
+        &admin,
+        &0,
+        &fee_recipient,
+        &token.address,
+        &DUMMY_PRICE,
+    );
+
+    let creator = Address::generate(&env);
+    let fan = Address::generate(&env);
+    token_admin.mint(&fan, &(DUMMY_FAN_BALANCE * 3));
+
+    env.ledger().with_mut(|li| li.sequence_number = 1000);
+
+    let plan_id = client.create_plan(
+        &creator,
+        &token.address,
+        &DUMMY_PLAN_AMOUNT,
+        &DUMMY_INTERVAL_DAYS,
+    );
+    client.subscribe(&fan, &plan_id, &token.address);
+
+    let expiry_before: u64 = env.as_contract(&client.address, || {
+        env.storage()
+            .instance()
+            .get::<DataKey, Subscription>(&DataKey::Sub(fan.clone(), creator.clone()))
+            .unwrap()
+            .expiry
+    });
+
+    let contract_id = client.address.clone();
+    let sc_fan: ScAddress = fan.clone().into();
+    let sc_creator: ScAddress = creator.clone().into();
+    let sc_contract: ScAddress = contract_id.clone().into();
+    let sc_token: ScAddress = token.address.clone().into();
+
+    let snapshot = env.to_snapshot();
+    let env2 = Env::from_snapshot(snapshot);
+    env2.mock_all_auths();
+
+    let contract_id2: Address = Address::try_from_val(&env2, &sc_contract).unwrap();
+    let fan2: Address = Address::try_from_val(&env2, &sc_fan).unwrap();
+    let creator2: Address = Address::try_from_val(&env2, &sc_creator).unwrap();
+    let token_addr2: Address = Address::try_from_val(&env2, &sc_token).unwrap();
+
+    env2.register_contract(Some(&contract_id2), MyfansContract);
+    let client2 = MyfansContractClient::new(&env2, &contract_id2);
+
+    const EXTRA: u32 = 7_000;
+    client2.extend_subscription(&fan2, &creator2, &EXTRA, &token_addr2);
+
+    let expiry_after: u64 = env2.as_contract(&contract_id2, || {
+        env2.storage()
+            .instance()
+            .get::<DataKey, Subscription>(&DataKey::subscription(fan2.clone(), creator2.clone()))
+            .unwrap()
+            .expiry
+    });
+
+    assert_eq!(
+        expiry_after,
+        expiry_before + EXTRA as u64,
+        "extend after restore must increment expiry by exact extra_ledgers"
+    );
+    assert!(
+        client2.is_subscriber(&fan2, &creator2),
+        "fan must still be active subscriber after extend"
+    );
+}
+
 // ── #311 – event topic standardization ───────────────────────────────────────
 
 /// Helper: find the first event whose first topic matches `name`.


### PR DESCRIPTION
 #893 — README documentation
  The existing README was completely wrong — it referenced non-existent structs, wrong
  event topics (sub_new, sub_cncl), and function signatures that don't exist in the
  contract. I rewrote it to accurately document all 15 public functions (init, create_plan,
   subscribe, create_subscription, extend_subscription, cancel, pause, unpause,
  set_fee_recipient, set_fee_bps, admin, is_subscriber, is_paused, get_expiry_unix, ping)
  with correct signatures, authorization requirements, error codes, and emitted events.

closes #893 

  #894 — Snapshot/restore consistency tests
  Two snapshot/restore tests already existed; I added three more covering gaps:
  - test_protocol_config_preserved_after_snapshot_restore — admin, fee_bps, fee_recipient,
  price all survive the round-trip
  - test_paused_state_preserved_after_snapshot_restore — paused=true persists and continues
   blocking mutations
  - test_extend_subscription_after_snapshot_restore — extend correctly updates expiry by
  the exact ledger count after restore

closes #894 