### PR TITLE
docs(treasury): document all public functions in README and lib.rs

### DIFF
--- a/contract/contracts/subscription/src/test.rs
+++ b/contract/contracts/subscription/src/test.rs
@@ -542,13 +542,7 @@ fn test_paused_state_preserved_after_snapshot_restore() {
 fn test_extend_subscription_after_snapshot_restore() {
     let (env, client, admin, token, token_admin) = setup_test();
     let fee_recipient = Address::generate(&env);
-    client.init(
-        &admin,
-        &0,
-        &fee_recipient,
-        &token.address,
-        &DUMMY_PRICE,
-    );
+    client.init(&admin, &0, &fee_recipient, &token.address, &DUMMY_PRICE);
 
     let creator = Address::generate(&env);
     let fan = Address::generate(&env);

--- a/contract/contracts/subscription/tests/contract_integration.rs
+++ b/contract/contracts/subscription/tests/contract_integration.rs
@@ -219,7 +219,11 @@ fn test_create_subscription_direct_via_test_env() {
     // 5% fee on 1000 → fee = 50, creator gets 950
     assert_eq!(token.balance(&f.fan), 4_000i128, "fan paid 1000");
     assert_eq!(token.balance(&f.creator), 950i128, "creator gets 950");
-    assert_eq!(token.balance(&f.fee_recipient), 50i128, "fee_recipient gets 50");
+    assert_eq!(
+        token.balance(&f.fee_recipient),
+        50i128,
+        "fee_recipient gets 50"
+    );
 
     assert!(
         sub.is_subscriber(&f.fan, &f.creator),
@@ -299,13 +303,19 @@ fn test_pause_blocks_writes_but_not_views_in_integration() {
     // isn't relevant since sub2 isn't paused — so use sub (the paused one)
     let _ = result; // sub2 is unpaused; test sub directly
     let result_sub = sub.try_create_subscription(&f.fan, &f.creator, &17_280u32);
-    assert!(result_sub.is_err(), "create_subscription must fail when paused");
+    assert!(
+        result_sub.is_err(),
+        "create_subscription must fail when paused"
+    );
 
     sub.unpause();
     let plan_id2 = sub.create_plan(&f.creator, &token.address, &1000i128, &1u32);
     token.mint(&f.fan, &5_000i128);
     sub.subscribe(&f.fan, &plan_id2, &token.address);
-    assert!(sub.is_subscriber(&f.fan, &f.creator), "works again after unpause");
+    assert!(
+        sub.is_subscriber(&f.fan, &f.creator),
+        "works again after unpause"
+    );
 }
 
 /// `get_expiry_unix` reflects the correct unix timestamp in an integration context.

--- a/contract/contracts/test-consumer/src/lib.rs
+++ b/contract/contracts/test-consumer/src/lib.rs
@@ -253,14 +253,32 @@ mod test {
         /// published in `myfans_lib::error_codes::subscription`.
         #[test]
         fn subscription_error_codes_match_stable_constants() {
-            assert_eq!(SubError::AlreadyInitialized as u32, sub_err::ALREADY_INITIALIZED);
+            assert_eq!(
+                SubError::AlreadyInitialized as u32,
+                sub_err::ALREADY_INITIALIZED
+            );
             assert_eq!(SubError::Paused as u32, sub_err::PAUSED);
-            assert_eq!(SubError::SubscriptionNotFound as u32, sub_err::SUBSCRIPTION_NOT_FOUND);
-            assert_eq!(SubError::SubscriptionExpired as u32, sub_err::SUBSCRIPTION_EXPIRED);
-            assert_eq!(SubError::AdminNotInitialized as u32, sub_err::ADMIN_NOT_INITIALIZED);
-            assert_eq!(SubError::InvalidFeeRecipient as u32, sub_err::INVALID_FEE_RECIPIENT);
+            assert_eq!(
+                SubError::SubscriptionNotFound as u32,
+                sub_err::SUBSCRIPTION_NOT_FOUND
+            );
+            assert_eq!(
+                SubError::SubscriptionExpired as u32,
+                sub_err::SUBSCRIPTION_EXPIRED
+            );
+            assert_eq!(
+                SubError::AdminNotInitialized as u32,
+                sub_err::ADMIN_NOT_INITIALIZED
+            );
+            assert_eq!(
+                SubError::InvalidFeeRecipient as u32,
+                sub_err::INVALID_FEE_RECIPIENT
+            );
             assert_eq!(SubError::InvalidFeeBps as u32, sub_err::INVALID_FEE_BPS);
-            assert_eq!(SubError::InvalidTokenAddress as u32, sub_err::INVALID_TOKEN_ADDRESS);
+            assert_eq!(
+                SubError::InvalidTokenAddress as u32,
+                sub_err::INVALID_TOKEN_ADDRESS
+            );
             assert_eq!(SubError::InvalidPrice as u32, sub_err::INVALID_PRICE);
             assert_eq!(SubError::PlanNotFound as u32, sub_err::PLAN_NOT_FOUND);
         }
@@ -292,7 +310,10 @@ mod test {
             assert_eq!(token.balance(&fan), 4_000i128);
             assert_eq!(token.balance(&creator), 950i128);
             assert_eq!(token.balance(&fee_recipient), 50i128);
-            assert!(sub.is_subscriber(&fan, &creator), "fan must be active subscriber");
+            assert!(
+                sub.is_subscriber(&fan, &creator),
+                "fan must be active subscriber"
+            );
         }
 
         /// `subscribe` with a non-existent plan returns `Error::PlanNotFound` (code 10).
@@ -313,7 +334,9 @@ mod test {
             let result = sub.try_subscribe(&fan, &9999u32, &token.address);
             assert_eq!(
                 result,
-                Err(Ok(SorobanError::from_contract_error(sub_err::PLAN_NOT_FOUND))),
+                Err(Ok(SorobanError::from_contract_error(
+                    sub_err::PLAN_NOT_FOUND
+                ))),
                 "subscribing to non-existent plan must return PlanNotFound (code 10)"
             );
         }
@@ -370,7 +393,10 @@ mod test {
             assert!(sub.is_subscriber(&fan, &creator));
 
             sub.cancel(&fan, &creator, &0u32);
-            assert!(!sub.is_subscriber(&fan, &creator), "cancelled sub must be inactive");
+            assert!(
+                !sub.is_subscriber(&fan, &creator),
+                "cancelled sub must be inactive"
+            );
             assert_eq!(
                 sub.get_expiry_unix(&fan, &creator),
                 (0u64, 0u64),

--- a/contract/contracts/treasury/README.md
+++ b/contract/contracts/treasury/README.md
@@ -1,57 +1,66 @@
 # Treasury Contract
 
-A simple treasury contract for holding platform funds on Stellar/Soroban.
+A Soroban contract that holds platform funds, enforces an admin-controlled minimum balance, and supports pause/unpause for emergency stops.
 
-## Features
-
-- **initialize**: Store admin and token address
-- **deposit**: Users can deposit tokens (requires authorization)
-- **withdraw**: Admin-only withdrawal with balance checks
-
-## Functions
+## Public Functions
 
 ### `initialize(env, admin, token_address)`
-Initializes the treasury with an admin and token address.
-- Requires admin authorization
-- Stores admin and token address in contract storage
+
+One-time setup. Stores the admin address and the token address, and sets defaults (`paused = false`, `min_balance = 0`).
+
+- Requires authorization from `admin`.
+- Panics with `NotInitialized` (code 5) if called a second time.
+
+### `set_paused(env, paused)`
+
+Pause (`true`) or unpause (`false`) the contract. While paused, `deposit` and `withdraw` are both rejected.
+
+- Requires authorization from the admin.
+
+### `set_min_balance(env, amount)`
+
+Set the minimum token balance the contract must retain after any withdrawal.
+
+- `amount` must be ≥ 0; negative values panic with `NegativeMinBalance` (code 1).
+- Requires authorization from the admin.
 
 ### `deposit(env, from, amount)`
-Deposits tokens into the treasury.
-- Requires authorization from the depositor
-- Transfers tokens from depositor to contract
+
+Transfer `amount` tokens from `from` into the treasury.
+
+- `amount` must be > 0 (`InvalidAmount`, code 6).
+- Contract must not be paused (`Paused`, code 2).
+- Requires authorization from `from`.
+- Emits a `deposit` event: `(from, amount, token_address)`.
 
 ### `withdraw(env, to, amount)`
-Withdraws tokens from the treasury.
-- Admin only (requires admin authorization)
-- Checks for sufficient balance
-- Reverts if balance is insufficient
 
-## Tests
+Transfer `amount` tokens from the treasury to `to`.
 
-All tests are located in `src/test.rs`:
+- `amount` must be > 0 (`InvalidAmount`, code 6).
+- Contract must not be paused (`Paused`, code 2).
+- Treasury balance must be ≥ `amount` (`InsufficientBalance`, code 3).
+- Remaining balance after withdrawal must be ≥ `min_balance` (`MinBalanceViolation`, code 4).
+- Requires authorization from the admin.
+- Emits a `withdraw` event: `(to, amount, token_address)`.
 
-1. **test_deposit_and_withdraw**: Verifies deposit and withdrawal work correctly
-2. **test_withdraw_insufficient_balance**: Verifies withdrawal reverts when balance is insufficient
-3. **test_unauthorized_withdraw_reverts**: Verifies non-admin cannot withdraw
+## Error Codes
 
-## Interface Docs
-
-Full method reference: [../docs/interfaces/treasury-contracts.md](../docs/interfaces/treasury-contracts.md)
+| Code | Variant | Meaning |
+|------|---------|---------|
+| 1 | `NegativeMinBalance` | `min_balance` must be ≥ 0 |
+| 2 | `Paused` | Contract is paused |
+| 3 | `InsufficientBalance` | Balance < requested withdrawal amount |
+| 4 | `MinBalanceViolation` | Withdrawal would leave balance below `min_balance` |
+| 5 | `NotInitialized` | Contract was never initialized (or re-init attempted) |
+| 6 | `InvalidAmount` | Deposit or withdrawal amount must be > 0 |
 
 ## Building and Testing
 
 ```bash
-# Build the contract
-cargo build --package treasury --target wasm32-unknown-unknown --release
-
 # Run tests
 cargo test --package treasury
+
+# Build wasm release
+cargo build --package treasury --target wasm32-unknown-unknown --release
 ```
-
-## Acceptance Criteria
-
-✅ Tokens can be deposited  
-✅ Admin can withdraw  
-✅ Unauthorized withdraw reverts  
-✅ Insufficient balance reverts  
-✅ All tests pass

--- a/contract/contracts/treasury/src/lib.rs
+++ b/contract/contracts/treasury/src/lib.rs
@@ -44,6 +44,11 @@ pub struct Treasury;
 
 #[contractimpl]
 impl Treasury {
+    /// One-time setup: store `admin` and `token_address` and set defaults
+    /// (`paused = false`, `min_balance = 0`).
+    ///
+    /// Panics with [`Error::NotInitialized`] if called a second time.
+    /// Requires authorization from `admin`.
     pub fn initialize(env: Env, admin: Address, token_address: Address) {
         admin.require_auth();
 
@@ -57,12 +62,21 @@ impl Treasury {
         env.storage().instance().set(&MIN_BALANCE, &0i128);
     }
 
+    /// Pause (`true`) or unpause (`false`) the contract.
+    ///
+    /// While paused, [`deposit`](Self::deposit) and [`withdraw`](Self::withdraw)
+    /// both panic with [`Error::Paused`].
+    /// Requires authorization from the admin.
     pub fn set_paused(env: Env, paused: bool) {
         let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
         admin.require_auth();
         env.storage().instance().set(&PAUSED, &paused);
     }
 
+    /// Set the minimum token balance the contract must retain after any withdrawal.
+    ///
+    /// `amount` must be ≥ 0; negative values panic with [`Error::NegativeMinBalance`].
+    /// Requires authorization from the admin.
     pub fn set_min_balance(env: Env, amount: i128) {
         let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
         admin.require_auth();
@@ -72,6 +86,13 @@ impl Treasury {
         env.storage().instance().set(&MIN_BALANCE, &amount);
     }
 
+    /// Transfer `amount` tokens from `from` into the treasury.
+    ///
+    /// - `amount` must be > 0 ([`Error::InvalidAmount`]).
+    /// - Contract must not be paused ([`Error::Paused`]).
+    /// - Requires authorization from `from`.
+    ///
+    /// Emits a `deposit` event with `(from, amount, token_address)`.
     pub fn deposit(env: Env, from: Address, amount: i128) {
         if amount <= 0 {
             panic_with_error!(&env, Error::InvalidAmount);
@@ -94,6 +115,15 @@ impl Treasury {
         );
     }
 
+    /// Transfer `amount` tokens from the treasury to `to`.
+    ///
+    /// - `amount` must be > 0 ([`Error::InvalidAmount`]).
+    /// - Contract must not be paused ([`Error::Paused`]).
+    /// - Treasury balance must be ≥ `amount` ([`Error::InsufficientBalance`]).
+    /// - Remaining balance after withdrawal must be ≥ `min_balance` ([`Error::MinBalanceViolation`]).
+    /// - Requires authorization from the admin.
+    ///
+    /// Emits a `withdraw` event with `(to, amount, token_address)`.
     pub fn withdraw(env: Env, to: Address, amount: i128) {
         if amount <= 0 {
             panic_with_error!(&env, Error::InvalidAmount);


### PR DESCRIPTION
closes #903

Description:

Documents all public functions of the treasury Soroban contract, which were either missing or 
incomplete in the README.

Changes:

- treasury/src/lib.rs — Added rustdoc comments to all 5 public functions (initialize, 
set_paused, set_min_balance, deposit, withdraw) covering auth requirements, error conditions, 
and emitted events.
- treasury/README.md — Rewrote to document all 5 public functions with a complete error code 
reference table. Previously, set_paused and set_min_balance were undocumented.
- Fixed pre-existing rustfmt violations in subscription and test-consumer crates so 
cargo fmt --all --check passes in CI.

Testing:

- All 14 treasury unit tests pass (cargo test --package treasury).
- Wasm release build succeeds (
cargo build --package treasury --target wasm32-unknown-unknown --release).
- cargo fmt --all --check passes.
- No regressions in related contracts.