### PR TITLE
Add subscription unauthorized pause/unpause revert tests

### DIFF
--- a/contract/contracts/subscription/src/test.rs
+++ b/contract/contracts/subscription/src/test.rs
@@ -932,6 +932,34 @@ fn test_mutations_succeed_after_unpause() {
     assert!(client.is_subscriber(&fan, &creator));
 }
 
+#[test]
+fn test_pause_non_admin_rejected() {
+    let (env, client, admin, token, _token_admin) = setup_test();
+    let fee_recipient = Address::generate(&env);
+
+    client.init(&admin, &500, &fee_recipient, &token.address, &1000);
+    env.set_auths(&[]);
+
+    let result = client.try_pause();
+    assert!(result.is_err(), "non-admin must not pause the contract");
+    assert!(!client.is_paused(), "contract must remain unpaused after unauthorized pause attempt");
+}
+
+#[test]
+fn test_unpause_non_admin_rejected() {
+    let (env, client, admin, token, _token_admin) = setup_test();
+    let fee_recipient = Address::generate(&env);
+
+    client.init(&admin, &500, &fee_recipient, &token.address, &1000);
+    client.pause();
+    assert!(client.is_paused());
+
+    env.set_auths(&[]);
+    let result = client.try_unpause();
+    assert!(result.is_err(), "non-admin must not unpause the contract");
+    assert!(client.is_paused(), "contract must remain paused after unauthorized unpause attempt");
+}
+
 // ── set_fee_recipient (admin fee recipient rotation) ─────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

<!-- One or two sentences describing what this PR does and why. -->

## Changes

<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [ ] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [ ] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [ ] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [ ] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [ ] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [ ] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [ ] Happy path works end-to-end in a local environment
- [ ] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [ ] No regressions in closely related API or UI flows
- [ ] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [ ] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues

<!-- Closes #891 -->

## Notes for reviewers

<!-- Anything that needs extra attention, known limitations, or follow-up work. -->
