### PR TITLE
feat: creator registry contract enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,11 @@ jobs:
       - name: Build wasm
         run: cargo build --release --target wasm32-unknown-unknown
         working-directory: contract
+
+      - name: Verify creator-registry wasm
+        run: |
+          wasm_path="target/wasm32-unknown-unknown/release/creator_registry.wasm"
+          test -s "$wasm_path"
+          magic="$(xxd -p -l 4 "$wasm_path" 2>/dev/null || od -A n -N 4 -t x1 "$wasm_path" | tr -d ' ')"
+          test "$magic" = "0061736d"
+        working-directory: contract

--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
 name = "creator-registry"
 version = "0.1.1"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 

--- a/contract/contracts/creator-registry/Cargo.toml
+++ b/contract/contracts/creator-registry/Cargo.toml
@@ -16,6 +16,7 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = { workspace = true }
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/contract/contracts/creator-registry/src/lib.rs
+++ b/contract/contracts/creator-registry/src/lib.rs
@@ -195,3 +195,6 @@ impl CreatorRegistryContract {
 
 #[cfg(test)]
 mod test;
+
+#[cfg(test)]
+mod property_tests;

--- a/contract/contracts/creator-registry/src/property_tests.rs
+++ b/contract/contracts/creator-registry/src/property_tests.rs
@@ -1,0 +1,90 @@
+//! Property-based tests for creator-registry invariants.
+//!
+//! Run with: `cargo test -p creator-registry prop_`
+
+#[cfg(test)]
+mod props {
+    extern crate std;
+
+    use crate::{
+        CreatorRegistryContract, CreatorRegistryContractClient, Error, DEFAULT_RATE_LIMIT,
+    };
+    use proptest::prelude::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Env, Error as SorobanError,
+    };
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        /// Registrations by distinct creators must preserve each creator's exact
+        /// ID without changing any previously written mapping.
+        #[test]
+        fn prop_self_registrations_are_isolated_and_exact(
+            creator_ids in prop::collection::vec(any::<u64>(), 1..16),
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let contract_id = env.register_contract(None, CreatorRegistryContract);
+            let client = CreatorRegistryContractClient::new(&env, &contract_id);
+            let admin = Address::generate(&env);
+            client.initialize(&admin);
+
+            let mut registered = std::vec::Vec::new();
+            for creator_id in creator_ids {
+                let creator = Address::generate(&env);
+                client.register_creator(&creator, &creator, &creator_id);
+                registered.push((creator, creator_id));
+
+                for (registered_creator, registered_id) in &registered {
+                    prop_assert_eq!(
+                        client.get_creator_id(registered_creator),
+                        Some(*registered_id),
+                        "a new registration must not alter an existing creator mapping"
+                    );
+                }
+            }
+        }
+
+        /// The rate-limit boundary is exact for every generated pair of IDs:
+        /// before the window the write is rejected without partial state; at
+        /// and after the window it succeeds with the requested ID.
+        #[test]
+        fn prop_rate_limit_preserves_state_and_allows_only_at_boundary(
+            first_id in any::<u64>(),
+            second_id in any::<u64>(),
+            elapsed_ledgers in 0u32..=(DEFAULT_RATE_LIMIT * 2),
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let contract_id = env.register_contract(None, CreatorRegistryContract);
+            let client = CreatorRegistryContractClient::new(&env, &contract_id);
+            let admin = Address::generate(&env);
+            let first_creator = Address::generate(&env);
+            let second_creator = Address::generate(&env);
+            client.initialize(&admin);
+
+            env.ledger().with_mut(|ledger| ledger.sequence_number = 100);
+            client.register_creator(&admin, &first_creator, &first_id);
+            env.ledger()
+                .with_mut(|ledger| ledger.sequence_number = 100 + elapsed_ledgers);
+
+            let result = client.try_register_creator(&admin, &second_creator, &second_id);
+            if elapsed_ledgers < DEFAULT_RATE_LIMIT {
+                prop_assert_eq!(
+                    result,
+                    Err(Ok(SorobanError::from_contract_error(Error::RateLimited as u32)))
+                );
+                prop_assert_eq!(client.get_creator_id(&second_creator), None);
+            } else {
+                prop_assert_eq!(result, Ok(Ok(())));
+                prop_assert_eq!(client.get_creator_id(&second_creator), Some(second_id));
+            }
+
+            prop_assert_eq!(client.get_creator_id(&first_creator), Some(first_id));
+        }
+    }
+}

--- a/contract/contracts/earnings/src/test.rs
+++ b/contract/contracts/earnings/src/test.rs
@@ -41,6 +41,43 @@ fn test_init_second_time_fails() {
     );
 }
 
+/// Initialization stores the supplied admin, which is then exposed through
+/// the public admin view used by downstream callers.
+#[test]
+fn test_init_stores_and_returns_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Earnings);
+    let client = EarningsClient::new(&env, &contract_id);
+
+    client.init(&admin);
+
+    assert_eq!(client.admin(), admin);
+}
+
+/// Initialization is admin-authorized and a rejected attempt leaves the
+/// contract uninitialized, allowing a later valid initialization.
+#[test]
+fn test_init_requires_admin_auth_without_persisting_state() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Earnings);
+    let client = EarningsClient::new(&env, &contract_id);
+
+    let empty: &[SorobanAuthorizationEntry] = &[];
+    env.set_auths(empty);
+    assert!(
+        client.try_init(&admin).is_err(),
+        "init must require admin auth"
+    );
+
+    env.mock_all_auths();
+    client.init(&admin);
+    assert_eq!(client.admin(), admin);
+}
+
 // ── #319 – non-admin record reverts ──────────────────────────────────────────
 
 /// Non-admin caller (no admin auth) must not be able to record earnings.
@@ -56,6 +93,11 @@ fn test_non_admin_record_reverts() {
 
     let result = client.try_record(&creator, &500);
     assert!(result.is_err(), "expected non-admin record to revert");
+    assert_eq!(
+        client.get_earnings(&creator),
+        0,
+        "a rejected admin path must not change earnings"
+    );
 }
 
 // ── #319 – admin record success + totals ─────────────────────────────────────

--- a/contract/contracts/test-consumer/src/lib.rs
+++ b/contract/contracts/test-consumer/src/lib.rs
@@ -922,4 +922,66 @@ mod test {
             assert_eq!(token_client.balance(&treasury_id), 1_300_000);
         }
     }
+
+    // ── creator-registry integration (Issue #957) ─────────────────────────
+    //
+    // Exercise creator-registry only through its public client, matching the
+    // boundary an external contract or service uses in production.
+    mod creator_registry_integration {
+        use creator_registry::{CreatorRegistryContract, CreatorRegistryContractClient, Error};
+        use soroban_sdk::{
+            testutils::{Address as _, Ledger},
+            Address, Env, Error as SorobanError,
+        };
+
+        fn deploy_registry<'a>(env: &'a Env, admin: &Address) -> CreatorRegistryContractClient<'a> {
+            let id = env.register_contract(None, CreatorRegistryContract);
+            let client = CreatorRegistryContractClient::new(env, &id);
+            client.initialize(admin);
+            client
+        }
+
+        /// An external consumer can register a creator, read its ID, and see
+        /// the mapping disappear after the admin unregisters it.
+        #[test]
+        fn creator_registry_register_lookup_and_unregister_flow() {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let admin = Address::generate(&env);
+            let creator = Address::generate(&env);
+            let registry = deploy_registry(&env, &admin);
+
+            registry.register_creator(&creator, &creator, &42u64);
+            assert_eq!(registry.get_creator_id(&creator), Some(42u64));
+
+            registry.unregister_creator(&creator);
+            assert_eq!(registry.get_creator_id(&creator), None);
+        }
+
+        /// A consumer receives the typed rate-limit failure and no partially
+        /// registered creator when an admin submits too quickly.
+        #[test]
+        fn creator_registry_rate_limit_keeps_rejected_creator_unregistered() {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let admin = Address::generate(&env);
+            let first_creator = Address::generate(&env);
+            let rejected_creator = Address::generate(&env);
+            let registry = deploy_registry(&env, &admin);
+
+            env.ledger().with_mut(|ledger| ledger.sequence_number = 100);
+            registry.register_creator(&admin, &first_creator, &1u64);
+
+            assert_eq!(
+                registry.try_register_creator(&admin, &rejected_creator, &2u64),
+                Err(Ok(SorobanError::from_contract_error(
+                    Error::RateLimited as u32
+                )))
+            );
+            assert_eq!(registry.get_creator_id(&first_creator), Some(1u64));
+            assert_eq!(registry.get_creator_id(&rejected_creator), None);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds creator-registry integration/property coverage, verifies its WASM artifact in CI, and expands earnings initialization/admin-path tests.

Closes #957
Closes #958
Closes #959
Closes #960 

## Changes

- Added creator-registry integration tests via `test-consumer`.
- Added property tests for registration isolation and rate-limit state invariants.
- Added CI validation for non-empty, valid `creator_registry.wasm`.
- Added earnings initialization and rejected-admin-path state tests.

## Test Plan

### Automated tests added or updated

- [x] **Contract tests** (`contract/`) — registry integration, property invariants, and earnings init/admin paths.

### How to run the tests locally

```bash
cd contract
cargo test -p creator-registry -p test-consumer -p earnings
cargo build --release --target wasm32-unknown-unknown -p creator-registry

Closes #957
Closes #958
Closes #959
Closes #960  