### PR TITLE
test(subscription): add unit tests for initialize and admin paths (#890)

### DIFF
--- a/contract/contracts/subscription/src/test.rs
+++ b/contract/contracts/subscription/src/test.rs
@@ -1792,3 +1792,59 @@ fn test_cancel_paused_returns_typed_error() {
         Err(Ok(SorobanError::from_contract_error(Error::Paused as u32)))
     );
 }
+
+// ── #890 – initialize and admin path unit tests ───────────────────────────────
+
+/// init stores PlanCount as zero so the first create_plan gets id=1.
+#[test]
+fn test_init_stores_plan_count_zero() {
+    let (env, client, admin, token, _) = setup_test();
+    let fee_recipient = Address::generate(&env);
+    client.init(&admin, &500, &fee_recipient, &token.address, &1000);
+
+    let stored_count: u32 = env.as_contract(&client.address, || {
+        env.storage()
+            .instance()
+            .get::<DataKey, u32>(&DataKey::PlanCount)
+            .unwrap_or(0)
+    });
+    assert_eq!(stored_count, 0, "init must set PlanCount to 0");
+}
+
+/// init emits the "initialized" event with fee_bps as data.
+#[test]
+fn test_init_emits_initialized_event() {
+    let (env, client, admin, token, _) = setup_test();
+    let fee_recipient = Address::generate(&env);
+    let fee_bps = 300u32;
+    client.init(&admin, &fee_bps, &fee_recipient, &token.address, &1000);
+
+    let ev = find_event(&env, "initialized").expect("initialized event not emitted");
+    let d_fee_bps: u32 = ev.2.try_into_val(&env).unwrap();
+    assert_eq!(d_fee_bps, fee_bps, "event data must carry fee_bps");
+}
+
+/// admin() panics when the contract has never been initialized.
+#[test]
+#[should_panic]
+fn test_admin_panics_when_uninitialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, MyfansContract);
+    let client = MyfansContractClient::new(&env, &contract_id);
+    client.admin();
+}
+
+/// admin() returns the same address after fee configuration changes.
+#[test]
+fn test_admin_unchanged_after_fee_updates() {
+    let (env, client, admin, token, _) = setup_test();
+    let fee_recipient = Address::generate(&env);
+    let new_recipient = Address::generate(&env);
+    client.init(&admin, &500, &fee_recipient, &token.address, &1000);
+
+    client.set_fee_bps(&200u32);
+    client.set_fee_recipient(&new_recipient);
+
+    assert_eq!(client.admin(), admin, "admin must not change after fee updates");
+}


### PR DESCRIPTION
Add tests for PlanCount=0 on init, initialized event emission, admin() panic on uninitialized contract, and admin address stability across fee configuration changes.

## Summary

<!-- One or two sentences describing what this PR does and why. -->

## Changes

<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [ ] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [ ] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [ ] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [ ] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [ ] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [ ] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [ ] Happy path works end-to-end in a local environment
- [ ] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [ ] No regressions in closely related API or UI flows
- [ ] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [ ] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues

<!-- Closes #890 -->

## Notes for reviewers

<!-- Anything that needs extra attention, known limitations, or follow-up work. -->
