### PR TITLE
feat(test-consumer): add initialize and admin functions with unit tests

### DIFF
--- a/contract/contracts/test-consumer/src/lib.rs
+++ b/contract/contracts/test-consumer/src/lib.rs
@@ -1,12 +1,56 @@
 #![no_std]
 use myfans_lib::{ContentType, MyfansError, SubscriptionStatus};
-use soroban_sdk::{contract, contractimpl, Env};
+use soroban_sdk::{contract, contractimpl, Env, Address, Symbol};
+
+/// Data keys for contract storage
+#[derive(Clone, Copy)]
+pub enum DataKey {
+    Admin = 0,
+}
+
+impl DataKey {
+    pub fn to_symbol(&self) -> Symbol {
+        match self {
+            DataKey::Admin => Symbol::short("admin"),
+        }
+    }
+}
 
 #[contract]
 pub struct TestConsumer;
 
 #[contractimpl]
 impl TestConsumer {
+    /// Initialize the contract with an admin address.
+    /// 
+    /// Must be called once per contract instance to set up admin privileges.
+    /// Can only be called once; subsequent calls will fail with AlreadyInitialized.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), MyfansError> {
+        let storage = env.storage().instance();
+        
+        // Check if already initialized
+        if storage.has(&DataKey::Admin.to_symbol()) {
+            return Err(MyfansError::AlreadyInitialized);
+        }
+        
+        // Set the admin
+        storage.set(&DataKey::Admin.to_symbol(), &admin);
+        
+        Ok(())
+    }
+
+    /// Get the current admin address.
+    /// 
+    /// Returns the admin address set during initialization.
+    /// Fails with NotInitialized if initialize was not called first.
+    pub fn admin(env: Env) -> Result<Address, MyfansError> {
+        let storage = env.storage().instance();
+        
+        storage
+            .get::<_, Address>(&DataKey::Admin.to_symbol())
+            .ok_or(MyfansError::NotInitialized)
+    }
+
     /// Returns true only when `status` is `Active`.
     pub fn is_active(_env: Env, status: SubscriptionStatus) -> bool {
         status == SubscriptionStatus::Active
@@ -27,7 +71,95 @@ impl TestConsumer {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::Env;
+    use soroban_sdk::{Env, Address};
+
+    // ── Initialize and Admin Tests ────────────────────────────────────────
+
+    #[test]
+    fn test_initialize_sets_admin() {
+        let env = Env::default();
+        let id = env.register_contract(None, TestConsumer);
+        let client = TestConsumerClient::new(&env, &id);
+        
+        let admin = Address::generate(&env);
+        
+        // Initialize should succeed
+        let result = client.initialize(&admin);
+        assert_eq!(result, Ok(()));
+        
+        // Admin should return the set admin
+        let stored_admin = client.admin();
+        assert_eq!(stored_admin, Ok(admin));
+    }
+
+    #[test]
+    fn test_initialize_idempotency_check() {
+        let env = Env::default();
+        let id = env.register_contract(None, TestConsumer);
+        let client = TestConsumerClient::new(&env, &id);
+        
+        let admin1 = Address::generate(&env);
+        let admin2 = Address::generate(&env);
+        
+        // First initialize should succeed
+        let result1 = client.initialize(&admin1);
+        assert_eq!(result1, Ok(()));
+        
+        // Second initialize with different admin should fail with AlreadyInitialized
+        let result2 = client.try_initialize(&admin2);
+        assert_eq!(
+            result2,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                MyfansError::AlreadyInitialized as u32
+            )))
+        );
+        
+        // Admin should still be the first one
+        let stored_admin = client.admin();
+        assert_eq!(stored_admin, Ok(admin1));
+    }
+
+    #[test]
+    fn test_admin_not_initialized() {
+        let env = Env::default();
+        let id = env.register_contract(None, TestConsumer);
+        let client = TestConsumerClient::new(&env, &id);
+        
+        // Calling admin without initialize should fail with NotInitialized
+        let result = client.try_admin();
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                MyfansError::NotInitialized as u32
+            )))
+        );
+    }
+
+    #[test]
+    fn test_initialize_different_admins() {
+        let env = Env::default();
+        
+        // Deploy two instances
+        let id1 = env.register_contract(None, TestConsumer);
+        let client1 = TestConsumerClient::new(&env, &id1);
+        
+        let id2 = env.register_contract(None, TestConsumer);
+        let client2 = TestConsumerClient::new(&env, &id2);
+        
+        let admin1 = Address::generate(&env);
+        let admin2 = Address::generate(&env);
+        
+        // Initialize each with different admin
+        let result1 = client1.initialize(&admin1);
+        assert_eq!(result1, Ok(()));
+        
+        let result2 = client2.initialize(&admin2);
+        assert_eq!(result2, Ok(()));
+        
+        // Each should return their respective admin
+        assert_eq!(client1.admin(), Ok(admin1));
+        assert_eq!(client2.admin(), Ok(admin2));
+    }
 
     // ── SubscriptionStatus ────────────────────────────────────────────────
 


### PR DESCRIPTION
- Add initialize(admin) function to set contract admin
  - Validates admin is not already set (prevents reinitialization)
  - Returns AlreadyInitialized error if called twice
- Add admin() function to retrieve current admin
  - Returns NotInitialized if contract not yet initialized
- Add DataKey enum with Admin key for storage
- Add comprehensive unit tests for initialize path:
  - test_initialize_sets_admin: verifies admin is correctly stored
  - test_initialize_idempotency_check: verifies second initialize fails
  - test_admin_not_initialized: verifies error when not initialized
  - test_initialize_different_admins: verifies instance isolation

Closes #980

## Summary

<!-- One or two sentences describing what this PR does and why. -->

## Changes

<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [ ] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [ ] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [ ] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [ ] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [ ] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [ ] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [ ] Happy path works end-to-end in a local environment
- [ ] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [ ] No regressions in closely related API or UI flows
- [ ] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [ ] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues

<!-- Closes #NNN -->

## Notes for reviewers

<!-- Anything that needs extra attention, known limitations, or follow-up work. -->
