### PR TITLE
Feat/subscriptions tests and pagination

### DIFF
--- a/backend/src/subscriptions/dto/dto-validation.spec.ts
+++ b/backend/src/subscriptions/dto/dto-validation.spec.ts
@@ -1,0 +1,265 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { ListSubscriptionsQueryDto } from './list-subscriptions-query.dto';
+import { ListCreatorSubscribersQueryDto } from './list-creator-subscribers-query.dto';
+import { SubscriptionStateQueryDto } from './subscription-state-query.dto';
+import { SubscriptionIndexerEventDto } from './subscription-indexer-event.dto';
+import { SetSpendingCapDto } from './spending-cap.dto';
+import { FanDashboardQueryDto } from './fan-dashboard-query.dto';
+
+describe('ListSubscriptionsQueryDto – invalid input', () => {
+  async function validateDto(plain: object) {
+    const dto = plainToInstance(ListSubscriptionsQueryDto, plain);
+    return validate(dto);
+  }
+
+  it('fails when fan is empty string', async () => {
+    const errors = await validateDto({ fan: '' });
+    expect(errors.some((e) => e.property === 'fan')).toBe(true);
+  });
+
+  it('fails when fan is missing', async () => {
+    const errors = await validateDto({});
+    expect(errors.some((e) => e.property === 'fan')).toBe(true);
+  });
+
+  it('fails when status is an invalid string', async () => {
+    const errors = await validateDto({ fan: 'GFAN', status: 'bogus' });
+    const statusErrors = errors.filter((e) => e.property === 'status');
+    expect(statusErrors).toHaveLength(1);
+  });
+
+  it('fails when sort is an invalid string', async () => {
+    const errors = await validateDto({ fan: 'GFAN', sort: 'alphabetical' });
+    const sortErrors = errors.filter((e) => e.property === 'sort');
+    expect(sortErrors).toHaveLength(1);
+  });
+
+  it('fails when limit is zero', async () => {
+    const errors = await validateDto({ fan: 'GFAN', limit: 0 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('fails when limit is negative', async () => {
+    const errors = await validateDto({ fan: 'GFAN', limit: -5 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('fails when limit exceeds maximum', async () => {
+    const errors = await validateDto({ fan: 'GFAN', limit: 101 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('fails when page is zero', async () => {
+    const errors = await validateDto({ fan: 'GFAN', page: 0 });
+    expect(errors.some((e) => e.property === 'page')).toBe(true);
+  });
+
+  it('fails when page is negative', async () => {
+    const errors = await validateDto({ fan: 'GFAN', page: -1 });
+    expect(errors.some((e) => e.property === 'page')).toBe(true);
+  });
+});
+
+describe('ListCreatorSubscribersQueryDto – invalid input', () => {
+  async function validateDto(plain: object) {
+    const dto = plainToInstance(ListCreatorSubscribersQueryDto, plain);
+    return validate(dto);
+  }
+
+  it('fails when creator is missing', async () => {
+    const errors = await validateDto({});
+    expect(errors.some((e) => e.property === 'creator')).toBe(true);
+  });
+
+  it('fails when creator is empty string', async () => {
+    const errors = await validateDto({ creator: '' });
+    expect(errors.some((e) => e.property === 'creator')).toBe(true);
+  });
+
+  it('fails when status is not active or expired', async () => {
+    const errors = await validateDto({ creator: 'GCREATOR', status: 'pending' });
+    expect(errors.some((e) => e.property === 'status')).toBe(true);
+  });
+
+  it('fails when sort is invalid', async () => {
+    const errors = await validateDto({ creator: 'GCREATOR', sort: 'price' });
+    expect(errors.some((e) => e.property === 'sort')).toBe(true);
+  });
+
+  it('fails when limit exceeds maximum', async () => {
+    const errors = await validateDto({ creator: 'GCREATOR', limit: 200 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('fails when limit is zero', async () => {
+    const errors = await validateDto({ creator: 'GCREATOR', limit: 0 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+});
+
+describe('SubscriptionStateQueryDto – invalid input', () => {
+  async function validateDto(plain: object) {
+    const dto = plainToInstance(SubscriptionStateQueryDto, plain);
+    return validate(dto);
+  }
+
+  it('fails when creator is missing', async () => {
+    const errors = await validateDto({});
+    expect(errors.some((e) => e.property === 'creator')).toBe(true);
+  });
+
+  it('fails when creator is empty string', async () => {
+    const errors = await validateDto({ creator: '' });
+    expect(errors.some((e) => e.property === 'creator')).toBe(true);
+  });
+
+  it('fails when creator does not match G-address format', async () => {
+    const errors = await validateDto({ creator: 'not-a-stellar-address' });
+    const creatorErrors = errors.filter((e) => e.property === 'creator');
+    expect(creatorErrors.length).toBeGreaterThan(0);
+  });
+
+  it('fails when creator is lowercase g-address', async () => {
+    const errors = await validateDto({ creator: 'g' + 'A'.repeat(55) });
+    const creatorErrors = errors.filter((e) => e.property === 'creator');
+    expect(creatorErrors.length).toBeGreaterThan(0);
+  });
+
+  it('fails when creator is too short', async () => {
+    const errors = await validateDto({ creator: 'GABCDEF' });
+    const creatorErrors = errors.filter((e) => e.property === 'creator');
+    expect(creatorErrors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('SubscriptionIndexerEventDto – invalid input', () => {
+  async function validateDto(plain: object) {
+    const dto = plainToInstance(SubscriptionIndexerEventDto, plain);
+    return validate(dto);
+  }
+
+  it('fails when event is missing', async () => {
+    const errors = await validateDto({ userId: 'GFAN', creatorId: 'GCREATOR', planId: 1 });
+    expect(errors.some((e) => e.property === 'event')).toBe(true);
+  });
+
+  it('fails when event is invalid value', async () => {
+    const errors = await validateDto({ event: 'created', userId: 'GFAN', creatorId: 'GCREATOR', planId: 1 });
+    expect(errors.some((e) => e.property === 'event')).toBe(true);
+  });
+
+  it('fails when userId is missing', async () => {
+    const errors = await validateDto({ event: 'renewed', creatorId: 'GCREATOR', planId: 1 });
+    expect(errors.some((e) => e.property === 'userId')).toBe(true);
+  });
+
+  it('fails when creatorId is missing', async () => {
+    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', planId: 1 });
+    expect(errors.some((e) => e.property === 'creatorId')).toBe(true);
+  });
+
+  it('fails when planId is missing', async () => {
+    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', creatorId: 'GCREATOR' });
+    expect(errors.some((e) => e.property === 'planId')).toBe(true);
+  });
+
+  it('fails when planId is zero', async () => {
+    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', creatorId: 'GCREATOR', planId: 0 });
+    expect(errors.some((e) => e.property === 'planId')).toBe(true);
+  });
+
+  it('fails when planId is negative', async () => {
+    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', creatorId: 'GCREATOR', planId: -1 });
+    expect(errors.some((e) => e.property === 'planId')).toBe(true);
+  });
+
+  it('fails when expiry is negative', async () => {
+    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', creatorId: 'GCREATOR', planId: 1, expiry: -100 });
+    expect(errors.some((e) => e.property === 'expiry')).toBe(true);
+  });
+
+  it('fails when cancelledAt is negative', async () => {
+    const errors = await validateDto({ event: 'cancelled', userId: 'GFAN', creatorId: 'GCREATOR', planId: 1, cancelledAt: -1 });
+    expect(errors.some((e) => e.property === 'cancelledAt')).toBe(true);
+  });
+
+  it('passes for valid renewed event', async () => {
+    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', creatorId: 'GCREATOR', planId: 1, expiry: 1700000000 });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('passes for valid cancelled event', async () => {
+    const errors = await validateDto({ event: 'cancelled', userId: 'GFAN', creatorId: 'GCREATOR', planId: 1, cancelledAt: 1700000000 });
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe('SetSpendingCapDto – invalid input', () => {
+  async function validateDto(plain: object) {
+    const dto = plainToInstance(SetSpendingCapDto, plain);
+    return validate(dto);
+  }
+
+  it('fails when period is invalid', async () => {
+    const errors = await validateDto({ period: 'weekly' });
+    expect(errors.some((e) => e.property === 'period')).toBe(true);
+  });
+
+  it('fails when capAmount is negative', async () => {
+    const errors = await validateDto({ capAmount: -100, period: 'monthly' });
+    expect(errors.some((e) => e.property === 'capAmount')).toBe(true);
+  });
+
+  it('fails when capAmount is a float', async () => {
+    const errors = await validateDto({ capAmount: 10.5, period: 'monthly' });
+    expect(errors.some((e) => e.property === 'capAmount')).toBe(true);
+  });
+
+  it('passes when capAmount is zero', async () => {
+    const errors = await validateDto({ capAmount: 0, period: 'monthly' });
+    expect(errors.filter((e) => e.property === 'capAmount')).toHaveLength(0);
+  });
+
+  it('passes when capAmount is omitted', async () => {
+    const errors = await validateDto({ period: 'monthly' });
+    expect(errors.filter((e) => e.property === 'capAmount')).toHaveLength(0);
+  });
+});
+
+describe('FanDashboardQueryDto – invalid input', () => {
+  async function validateDto(plain: object) {
+    const dto = plainToInstance(FanDashboardQueryDto, plain);
+    return validate(dto);
+  }
+
+  it('fails when page is zero', async () => {
+    const errors = await validateDto({ page: 0 });
+    expect(errors.some((e) => e.property === 'page')).toBe(true);
+  });
+
+  it('fails when page is negative', async () => {
+    const errors = await validateDto({ page: -1 });
+    expect(errors.some((e) => e.property === 'page')).toBe(true);
+  });
+
+  it('fails when limit is zero', async () => {
+    const errors = await validateDto({ limit: 0 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('fails when limit exceeds maximum', async () => {
+    const errors = await validateDto({ limit: 101 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('passes with valid page and limit', async () => {
+    const errors = await validateDto({ page: 1, limit: 50 });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('passes when both are omitted', async () => {
+    const errors = await validateDto({});
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/backend/src/subscriptions/dto/fan-dashboard-query.dto.ts
+++ b/backend/src/subscriptions/dto/fan-dashboard-query.dto.ts
@@ -1,0 +1,20 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class FanDashboardQueryDto {
+  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1, minimum: 1 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ description: 'Items per page', default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number = 20;
+}

--- a/backend/src/subscriptions/subscriptions.controller.spec.ts
+++ b/backend/src/subscriptions/subscriptions.controller.spec.ts
@@ -19,7 +19,7 @@ describe('SubscriptionsController', () => {
   let service: jest.Mocked<
     Pick<
       SubscriptionsService,
-      'getFanCreatorSubscriptionState' | 'listCreatorSubscribers' | 'listSubscriptions'
+      'getFanCreatorSubscriptionState' | 'listCreatorSubscribers' | 'listSubscriptions' | 'getFanDashboardSummary'
     >
   >;
 
@@ -62,6 +62,14 @@ describe('SubscriptionsController', () => {
         hasMore: false,
         nextCursor: null,
         cursor: null,
+      }),
+      getFanDashboardSummary: jest.fn().mockResolvedValue({
+        fan,
+        totalActive: 0,
+        subscriptions: [],
+        page: 1,
+        limit: 20,
+        totalPages: 0,
       }),
     };
 
@@ -155,6 +163,20 @@ describe('SubscriptionsController', () => {
       undefined,
       20,
     );
+  });
+
+  it('getFanDashboard delegates to getFanDashboardSummary with fan from request', async () => {
+    const req = { fanAddress: fan } as RequestWithFan;
+    await controller.getFanDashboard(req, { page: 2, limit: 10 });
+
+    expect(service.getFanDashboardSummary).toHaveBeenCalledWith(fan, 2, 10);
+  });
+
+  it('getFanDashboard uses default page and limit', async () => {
+    const req = { fanAddress: fan } as RequestWithFan;
+    await controller.getFanDashboard(req, {});
+
+    expect(service.getFanDashboardSummary).toHaveBeenCalledWith(fan, undefined, undefined);
   });
 });
 

--- a/backend/src/subscriptions/subscriptions.controller.ts
+++ b/backend/src/subscriptions/subscriptions.controller.ts
@@ -15,6 +15,7 @@ import { Reflector } from '@nestjs/core';
 import { ListSubscriptionsQueryDto } from './dto/list-subscriptions-query.dto';
 import { ListCreatorSubscribersQueryDto } from './dto/list-creator-subscribers-query.dto';
 import { SubscriptionStateQueryDto } from './dto/subscription-state-query.dto';
+import { FanDashboardQueryDto } from './dto/fan-dashboard-query.dto';
 import { FanBearerGuard } from './guards/fan-bearer.guard';
 import type { RequestWithFan } from './guards/fan-bearer.guard';
 import { SubscriptionsService } from './subscriptions.service';
@@ -141,6 +142,29 @@ export class SubscriptionsController {
       query.cursor,
       query.limit,
       query.sort,
+    );
+  }
+
+  @Get('me/dashboard')
+  @UseGuards(FanBearerGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get fan dashboard summary with active subscriptions',
+    description:
+      'Offset-paginated dashboard. Pass `page` and `limit` to control pagination.',
+  })
+  @ApiQuery({ name: 'page', required: false, description: 'Page number (1-based, default 1)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Items per page (default 20, max 100)' })
+  @ApiResponse({ status: 200, description: 'Fan dashboard summary with pagination' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  getFanDashboard(
+    @Req() req: RequestWithFan,
+    @Query() query: FanDashboardQueryDto,
+  ) {
+    return this.subscriptionsService.getFanDashboardSummary(
+      req.fanAddress,
+      query.page,
+      query.limit,
     );
   }
 

--- a/backend/src/subscriptions/subscriptions.service.spec.ts
+++ b/backend/src/subscriptions/subscriptions.service.spec.ts
@@ -349,6 +349,235 @@ describe('SubscriptionsService', () => {
     );
   });
 
+  describe('happy path', () => {
+    const fan = 'GFANHAPPY1111111111111111111111111111111111111111111111111';
+    const creator = 'GAAAAAAAAAAAAAAA';
+
+    it('addSubscription creates and returns a subscription entity', async () => {
+      const expiry = Math.floor(Date.now() / 1000) + 3600;
+      const result = await service.addSubscription(fan, creator, 1, expiry);
+
+      expect(result).toMatchObject({ fan, creator, planId: 1, expiryUnix: expiry, status: SubscriptionStatus.ACTIVE });
+      expect(repo.upsertManual).toHaveBeenCalledWith(expect.objectContaining({ fan, creator, planId: 1, expiryUnix: expiry }));
+    });
+
+    it('addSubscription publishes SubscriptionCreatedEvent', async () => {
+      const handler = jest.fn();
+      eventBus.subscribe('subscription.created', handler);
+
+      await service.addSubscription(fan, creator, 1, Math.floor(Date.now() / 1000) + 3600);
+
+      expect(handler).toHaveBeenCalledWith(expect.objectContaining({ type: 'subscription.created', fan, creator }));
+    });
+
+    it('addSubscription sets status to expired when expiry is in the past', async () => {
+      const pastExpiry = Math.floor(Date.now() / 1000) - 3600;
+      const result = await service.addSubscription(fan, creator, 1, pastExpiry);
+
+      expect(result.status).toBe(SubscriptionStatus.EXPIRED);
+    });
+
+    it('renewSubscription updates expiry and returns entity', async () => {
+      await service.addSubscription(fan, creator, 1, Math.floor(Date.now() / 1000) + 60);
+      const result = await service.renewSubscription(fan, creator, 1);
+
+      expect(result).toMatchObject({ fan, creator, planId: 1, status: SubscriptionStatus.ACTIVE });
+      expect(result.expiryUnix).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    });
+
+    it('renewSubscription accepts explicit expiry', async () => {
+      const explicitExpiry = Math.floor(Date.now() / 1000) + 86400;
+      await service.addSubscription(fan, creator, 1, Math.floor(Date.now() / 1000) + 60);
+      const result = await service.renewSubscription(fan, creator, 1, explicitExpiry);
+
+      expect(result.expiryUnix).toBe(explicitExpiry);
+    });
+
+    it('renewSubscription throws when plan does not belong to creator', async () => {
+      await expect(service.renewSubscription(fan, 'GOTHER_CREATOR_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 1))
+        .rejects.toThrow('Plan does not belong to the specified creator');
+    });
+
+    it('isSubscriber returns true for active subscription', async () => {
+      await service.addSubscription(fan, creator, 1, Math.floor(Date.now() / 1000) + 3600);
+      const result = await service.isSubscriber(fan, creator);
+      expect(result).toBe(true);
+    });
+
+    it('isSubscriber returns false when no subscription exists', async () => {
+      const result = await service.isSubscriber(fan, creator);
+      expect(result).toBe(false);
+    });
+
+    it('getSubscription returns the subscription entity', async () => {
+      await service.addSubscription(fan, creator, 1, Math.floor(Date.now() / 1000) + 3600);
+      const result = await service.getSubscription(fan, creator);
+
+      expect(result).not.toBeNull();
+      expect(result!.fan).toBe(fan);
+      expect(result!.creator).toBe(creator);
+    });
+
+    it('getSubscription returns null when none exists', async () => {
+      const result = await service.getSubscription(fan, creator);
+      expect(result).toBeNull();
+    });
+
+    it('cancelSubscription returns success result', async () => {
+      await service.addSubscription(fan, creator, 1, Math.floor(Date.now() / 1000) + 3600);
+      const result = await service.cancelSubscription(fan, creator);
+
+      expect(result).toMatchObject({ success: true, fan, creator, status: SubscriptionStatus.CANCELLED });
+      expect(result.cancelledAt).toBeDefined();
+    });
+
+    it('cancelSubscription throws NotFoundException when subscription does not exist', async () => {
+      await expect(service.cancelSubscription(fan, creator)).rejects.toThrow('Subscription not found');
+    });
+
+    it('expireSubscription updates status to expired', async () => {
+      await service.addSubscription(fan, creator, 1, Math.floor(Date.now() / 1000) + 3600);
+      await service.expireSubscription(fan, creator);
+
+      expect(repo.updateStatus).toHaveBeenCalledWith(fan, creator, SubscriptionStatus.EXPIRED);
+    });
+
+    it('createCheckout creates a pending checkout session', () => {
+      const checkout = service.createCheckout(fan, creator, 1);
+
+      expect(checkout).toMatchObject({
+        fanAddress: fan,
+        creatorAddress: creator,
+        planId: 1,
+        assetCode: 'XLM',
+        status: 'pending',
+      });
+      expect(checkout.id).toBeDefined();
+      expect(parseFloat(checkout.amount)).toBeGreaterThan(0);
+      expect(parseFloat(checkout.fee)).toBeGreaterThan(0);
+    });
+
+    it('createCheckout throws when plan not found', () => {
+      expect(() => service.createCheckout(fan, creator, 999)).toThrow('Plan not found');
+    });
+
+    it('getCheckout retrieves an existing checkout', () => {
+      const checkout = service.createCheckout(fan, creator, 1);
+      const retrieved = service.getCheckout(checkout.id);
+
+      expect(retrieved.id).toBe(checkout.id);
+      expect(retrieved.fanAddress).toBe(fan);
+    });
+
+    it('getCheckout throws when checkout not found', () => {
+      expect(() => service.getCheckout('nonexistent')).toThrow('Checkout not found');
+    });
+
+    it('confirmSubscription creates new subscription and returns success', async () => {
+      const checkout = service.createCheckout(fan, creator, 1);
+      const result = await service.confirmSubscription(checkout.id, 'tx-hash-123');
+
+      expect(result).toMatchObject({ success: true, status: 'completed', txHash: 'tx-hash-123', lifecycleEvent: 'created' });
+      expect(result.subscriptionId).toBeDefined();
+    });
+
+    it('getPlanSummary returns plan details', () => {
+      const summary = service.getPlanSummary(1);
+
+      expect(summary).toMatchObject({ id: 1, creatorAddress: 'GAAAAAAAAAAAAAAA', assetCode: 'XLM' });
+      expect(summary.amount).toBe('10');
+      expect(summary.intervalDays).toBe(30);
+    });
+
+    it('getPlanSummary throws for non-existent plan', () => {
+      expect(() => service.getPlanSummary(999)).toThrow('Plan not found');
+    });
+
+    it('getPriceBreakdown returns price components', () => {
+      const checkout = service.createCheckout(fan, creator, 1);
+      const breakdown = service.getPriceBreakdown(checkout.id);
+
+      expect(breakdown).toMatchObject({ currency: 'XLM' });
+      expect(parseFloat(breakdown.subtotal)).toBeGreaterThan(0);
+      expect(parseFloat(breakdown.platformFee)).toBeGreaterThan(0);
+      expect(parseFloat(breakdown.total)).toBeGreaterThan(0);
+    });
+
+    it('validateBalance returns valid for sufficient balance', () => {
+      const result = service.validateBalance(fan, 'XLM', '10');
+      expect(result).toMatchObject({ valid: true });
+    });
+
+    it('validateBalance returns invalid with shortfall for insufficient balance', () => {
+      const result = service.validateBalance(fan, 'XLM', '2000');
+      expect(result.valid).toBe(false);
+      expect(result.shortfall).toBeDefined();
+    });
+
+    it('getWalletStatus returns balances for supported assets', () => {
+      const wallet = service.getWalletStatus(fan);
+
+      expect(wallet.address).toBe(fan);
+      expect(wallet.isConnected).toBe(true);
+      expect(wallet.balances.length).toBeGreaterThanOrEqual(2);
+      expect(wallet.balances.find((b) => b.code === 'XLM')).toBeDefined();
+    });
+
+    it('getTransactionPreview returns preview for checkout', () => {
+      const checkout = service.createCheckout(fan, creator, 1);
+      const preview = service.getTransactionPreview(checkout.id);
+
+      expect(preview).toMatchObject({ checkoutId: checkout.id, from: fan, to: creator });
+      expect(parseFloat(preview.amount)).toBeGreaterThan(0);
+    });
+
+    it('failCheckout marks checkout as failed', () => {
+      const checkout = service.createCheckout(fan, creator, 1);
+      const result = service.failCheckout(checkout.id, 'network error');
+
+      expect(result).toMatchObject({ success: false, status: 'failed', error: 'network error' });
+    });
+
+    it('failCheckout marks checkout as rejected when isRejected is true', () => {
+      const checkout = service.createCheckout(fan, creator, 1);
+      const result = service.failCheckout(checkout.id, 'user rejected', true);
+
+      expect(result).toMatchObject({ success: false, status: 'rejected' });
+    });
+
+    it('assertNetworkMatch does nothing when network is undefined', () => {
+      expect(() => service.assertNetworkMatch(undefined)).not.toThrow();
+    });
+
+    it('assertNetworkMatch throws for mismatched network', () => {
+      expect(() => service.assertNetworkMatch('mainnet')).toThrow();
+    });
+
+    it('getFanDashboardSummary returns dashboard with pagination', async () => {
+      await service.addSubscription(fan, creator, 1, Math.floor(Date.now() / 1000) + 3600);
+      const result = await service.getFanDashboardSummary(fan, 1, 20);
+
+      expect(result.fan).toBe(fan);
+      expect(result.totalActive).toBeGreaterThanOrEqual(1);
+      expect(result.subscriptions).toBeInstanceOf(Array);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+    });
+
+    it('getCompletedPayments returns completed checkouts', async () => {
+      const checkout = service.createCheckout(fan, creator, 1);
+      await service.confirmSubscription(checkout.id, 'tx-pay');
+
+      const payments = service.getCompletedPayments();
+      expect(payments.some((p) => p.txHash === 'tx-pay')).toBe(true);
+    });
+
+    it('getAllSubscriptionsInternal delegates to repository', async () => {
+      await service.getAllSubscriptionsInternal();
+      expect(repo.findAllForReconciler).toHaveBeenCalled();
+    });
+  });
+
   it('publishes a cancelled event when subscription is cancelled', async () => {
     const handler = jest.fn();
     eventBus.subscribe('subscription.cancelled', handler);

--- a/backend/test/subscriptions.e2e-spec.ts
+++ b/backend/test/subscriptions.e2e-spec.ts
@@ -300,6 +300,199 @@ describe('SubscriptionsController (integration, RPC-mocked)', () => {
       });
   });
 
+  describe('GET /v1/subscriptions/me/subscription-state', () => {
+    function bearerToken(address: string): string {
+      return `Bearer ${Buffer.from(address, 'utf8').toString('base64')}`;
+    }
+
+    it('returns subscription state for authenticated fan', async () => {
+      const fanAddr = `G${'A'.repeat(55)}`;
+
+      await request(app.getHttpServer())
+        .get('/v1/subscriptions/me/subscription-state')
+        .set('Authorization', bearerToken(fanAddr))
+        .query({ creator: `G${'B'.repeat(55)}` })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('fan', fanAddr);
+          expect(res.body).toHaveProperty('active');
+          expect(res.body).toHaveProperty('indexedStatus');
+          expect(res.body).toHaveProperty('chain');
+        });
+    });
+
+    it('returns 401 without Authorization header', async () => {
+      await request(app.getHttpServer())
+        .get('/v1/subscriptions/me/subscription-state')
+        .query({ creator: `G${'B'.repeat(55)}` })
+        .expect(401);
+    });
+
+    it('returns active state after subscription is created', async () => {
+      const fanAddr = `G${'C'.repeat(55)}`;
+      const creatorAddr = 'GAAAAAAAAAAAAAAA';
+
+      const createRes = await request(app.getHttpServer())
+        .post('/v1/subscriptions/checkout')
+        .send({ fanAddress: fanAddr, creatorAddress: creatorAddr, planId: 1 })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/v1/subscriptions/checkout/${createRes.body.id}/confirm`)
+        .send({ txHash: 'tx-e2e-state' })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .get('/v1/subscriptions/me/subscription-state')
+        .set('Authorization', bearerToken(fanAddr))
+        .query({ creator: creatorAddr })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.active).toBe(true);
+          expect(res.body.indexedStatus).toBe('active');
+          expect(res.body.indexed).not.toBeNull();
+          expect(res.body.indexed.planId).toBe(1);
+        });
+    });
+  });
+
+  describe('GET /v1/subscriptions/me/list', () => {
+    function bearerToken(address: string): string {
+      return `Bearer ${Buffer.from(address, 'utf8').toString('base64')}`;
+    }
+
+    it('returns paginated subscription list for authenticated fan', async () => {
+      const fanAddr = `G${'D'.repeat(55)}`;
+
+      await request(app.getHttpServer())
+        .get('/v1/subscriptions/me/list')
+        .set('Authorization', bearerToken(fanAddr))
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('data');
+          expect(res.body).toHaveProperty('limit');
+          expect(res.body).toHaveProperty('hasMore');
+          expect(Array.isArray(res.body.data)).toBe(true);
+        });
+    });
+
+    it('returns 401 without Authorization header', async () => {
+      await request(app.getHttpServer())
+        .get('/v1/subscriptions/me/list')
+        .expect(401);
+    });
+
+    it('respects limit query parameter', async () => {
+      const fanAddr = `G${'E'.repeat(55)}`;
+
+      await request(app.getHttpServer())
+        .get('/v1/subscriptions/me/list')
+        .set('Authorization', bearerToken(fanAddr))
+        .query({ limit: 5 })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.limit).toBe(5);
+        });
+    });
+
+    it('includes subscriptions after checkout confirmation', async () => {
+      const fanAddr = `G${'F'.repeat(55)}`;
+      const creatorAddr = 'GAAAAAAAAAAAAAAA';
+
+      const createRes = await request(app.getHttpServer())
+        .post('/v1/subscriptions/checkout')
+        .send({ fanAddress: fanAddr, creatorAddress: creatorAddr, planId: 1 })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/v1/subscriptions/checkout/${createRes.body.id}/confirm`)
+        .send({ txHash: 'tx-e2e-list' })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .get('/v1/subscriptions/me/list')
+        .set('Authorization', bearerToken(fanAddr))
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data.length).toBeGreaterThanOrEqual(1);
+          expect(res.body.data[0].creatorId).toBe(creatorAddr);
+        });
+    });
+  });
+
+  describe('POST /v1/subscriptions/cancel', () => {
+    it('cancels an existing subscription', async () => {
+      const createRes = await request(app.getHttpServer())
+        .post('/v1/subscriptions/checkout')
+        .send({ fanAddress: 'GTESTFAN_CANCEL1', creatorAddress: 'GAAAAAAAAAAAAAAA', planId: 1 })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/v1/subscriptions/checkout/${createRes.body.id}/confirm`)
+        .send({ txHash: 'tx-cancel' })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post('/v1/subscriptions/cancel')
+        .send({ fanAddress: 'GTESTFAN_CANCEL1', creatorAddress: 'GAAAAAAAAAAAAAAA' })
+        .expect(201)
+        .expect((res) => {
+          expect(res.body.success).toBe(true);
+          expect(res.body.status).toBe('cancelled');
+        });
+    });
+
+    it('returns 404 when subscription does not exist', async () => {
+      await request(app.getHttpServer())
+        .post('/v1/subscriptions/cancel')
+        .send({ fanAddress: 'GNONEXISTENT', creatorAddress: 'GNOONE' })
+        .expect(404);
+    });
+  });
+
+  describe('GET /v1/subscriptions/me/dashboard', () => {
+    function bearerToken(address: string): string {
+      return `Bearer ${Buffer.from(address, 'utf8').toString('base64')}`;
+    }
+
+    it('returns paginated dashboard for authenticated fan', async () => {
+      const fanAddr = `G${'H'.repeat(55)}`;
+
+      await request(app.getHttpServer())
+        .get('/v1/subscriptions/me/dashboard')
+        .set('Authorization', bearerToken(fanAddr))
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('fan', fanAddr);
+          expect(res.body).toHaveProperty('totalActive');
+          expect(res.body).toHaveProperty('subscriptions');
+          expect(res.body).toHaveProperty('page');
+          expect(res.body).toHaveProperty('limit');
+          expect(Array.isArray(res.body.subscriptions)).toBe(true);
+        });
+    });
+
+    it('returns 401 without Authorization header', async () => {
+      await request(app.getHttpServer())
+        .get('/v1/subscriptions/me/dashboard')
+        .expect(401);
+    });
+
+    it('respects page and limit query parameters', async () => {
+      const fanAddr = `G${'I'.repeat(55)}`;
+
+      await request(app.getHttpServer())
+        .get('/v1/subscriptions/me/dashboard')
+        .set('Authorization', bearerToken(fanAddr))
+        .query({ page: 2, limit: 5 })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.page).toBe(2);
+          expect(res.body.limit).toBe(5);
+        });
+    });
+  });
+
   it('handles failed checkout path', async () => {
     const createRes = await request(app.getHttpServer())
       .post('/v1/subscriptions/checkout')


### PR DESCRIPTION
closes #1040
closes #1039
closes #1041
closes #1042
Backend module Subscriptions (subscriptions). Add service unit tests for happy path.
Backend module Subscriptions (subscriptions). Add DTO validation tests for invalid input.
Backend module Subscriptions (subscriptions). Add e2e test for primary endpoint.

