### PR TITLE
 Title: feat(health, users): Swagger docs, consistent error shape, rate limiting, and controller unit tests

### DIFF
--- a/backend/src/auth/throttler.guard.ts
+++ b/backend/src/auth/throttler.guard.ts
@@ -17,10 +17,8 @@ export class ThrottlerGuard extends NestThrottlerGuard implements CanActivate {
   }
 
   private isHealthCheckRoute(url: string): boolean {
-    return (
-      url === '/health' ||
-      url.startsWith('/health/') ||
-      url.startsWith('/v1/health')
-    );
+    // Only exempt the basic liveness probe — expensive sub-checks are throttled
+    // to prevent resource exhaustion from scanning probes.
+    return url === '/health' || url === '/v1/health';
   }
 }

--- a/backend/src/health/dto/health-response.dto.ts
+++ b/backend/src/health/dto/health-response.dto.ts
@@ -1,0 +1,111 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class HealthStatusDto {
+  @ApiProperty({ enum: ['up', 'down', 'degraded'] })
+  status: 'up' | 'down' | 'degraded';
+
+  @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
+  timestamp: string;
+}
+
+export class SubsystemStatusDto {
+  @ApiProperty({ enum: ['up', 'down', 'degraded'] })
+  status: 'up' | 'down' | 'degraded';
+
+  @ApiProperty({ required: false, example: 5 })
+  latencyMs?: number;
+
+  @ApiProperty({ required: false, example: 'Connection refused' })
+  error?: string;
+}
+
+export class SorobanStatusDto {
+  @ApiProperty({ enum: ['up', 'down', 'degraded'] })
+  status: 'up' | 'down' | 'degraded';
+
+  @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
+  timestamp: string;
+
+  @ApiProperty({ required: false })
+  rpcUrl?: string;
+
+  @ApiProperty({ required: false })
+  ledger?: number;
+
+  @ApiProperty({ required: false })
+  responseTime?: number;
+
+  @ApiProperty({ required: false })
+  error?: string;
+}
+
+export class DetailedHealthChecksDto {
+  @ApiProperty({ type: SubsystemStatusDto })
+  database: SubsystemStatusDto;
+
+  @ApiProperty({ type: SorobanStatusDto, required: false })
+  sorobanRpc?: SorobanStatusDto;
+
+  @ApiProperty({ type: SorobanStatusDto, required: false })
+  sorobanContract?: SorobanStatusDto;
+}
+
+export class DetailedHealthStatusDto extends HealthStatusDto {
+  @ApiProperty({ type: DetailedHealthChecksDto, required: false })
+  checks?: DetailedHealthChecksDto;
+}
+
+export class HealthSummaryDto {
+  @ApiProperty({ example: 4 })
+  total: number;
+
+  @ApiProperty({ example: 3 })
+  up: number;
+
+  @ApiProperty({ example: 0 })
+  degraded: number;
+
+  @ApiProperty({ example: 1 })
+  down: number;
+}
+
+export class AggregatedSubsystemsDto {
+  @ApiProperty({ type: SubsystemStatusDto })
+  database: SubsystemStatusDto;
+
+  @ApiProperty({ type: SubsystemStatusDto })
+  redis: SubsystemStatusDto;
+
+  @ApiProperty({ type: SorobanStatusDto })
+  sorobanRpc: SorobanStatusDto;
+
+  @ApiProperty({ type: SorobanStatusDto })
+  sorobanContract: SorobanStatusDto;
+}
+
+export class AggregatedHealthDto extends HealthStatusDto {
+  @ApiProperty({ example: 3600 })
+  uptime: number;
+
+  @ApiProperty({ example: '1.0.0' })
+  version: string;
+
+  @ApiProperty({ type: AggregatedSubsystemsDto })
+  subsystems: AggregatedSubsystemsDto;
+
+  @ApiProperty({ type: HealthSummaryDto })
+  summary: HealthSummaryDto;
+}
+
+export class QueueSnapshotDto {
+  @ApiProperty({ type: Object, additionalProperties: { type: 'number' } })
+  [key: string]: unknown;
+}
+
+export class QueueMetricsDto {
+  @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
+  timestamp: string;
+
+  @ApiProperty({ type: QueueSnapshotDto })
+  queues: QueueSnapshotDto;
+}

--- a/backend/src/health/health.controller.spec.ts
+++ b/backend/src/health/health.controller.spec.ts
@@ -49,15 +49,15 @@ describe('HealthController', () => {
     describe('getHealth', () => {
         it('should return health status', () => {
             const result = controller.getHealth();
-            expect(result.status).toBe('ok');
+            expect(result.status).toBe('up');
             expect(result.timestamp).toBeDefined();
         });
 
         // Validates: docker-compose dev profile — health endpoint used by Docker
         // healthcheck and CI smoke test must return 200 with correct body shape.
-        it('should return status "ok" with a valid ISO 8601 timestamp', () => {
+        it('should return status "up" with a valid ISO 8601 timestamp', () => {
             const result = controller.getHealth();
-            expect(result.status).toBe('ok');
+            expect(result.status).toBe('up');
             // ISO 8601 pattern: YYYY-MM-DDTHH:mm:ss.sssZ
             expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
             expect(() => new Date(result.timestamp)).not.toThrow();

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,115 +1,129 @@
 import { Controller, Get, Res } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import type { Response } from 'express';
 import { HealthService } from './health.service';
+import {
+  HealthStatusDto,
+  DetailedHealthStatusDto,
+  AggregatedHealthDto,
+  SubsystemStatusDto,
+  QueueMetricsDto,
+} from './dto/health-response.dto';
 
 @ApiTags('health')
 @Controller({ path: 'health', version: '1' })
 export class HealthController {
-    constructor(private readonly healthService: HealthService) { }
+  constructor(private readonly healthService: HealthService) {}
 
-    @Get()
-    @ApiOperation({ summary: 'Basic health check' })
-    @ApiResponse({ status: 200, description: 'Service is healthy' })
-    getHealth() {
-        return this.healthService.getHealth();
-    }
+  @Get()
+  @ApiOperation({ summary: 'Basic health check' })
+  @ApiResponse({ status: 200, description: 'Service is healthy', type: HealthStatusDto })
+  getHealth() {
+    return this.healthService.getHealth();
+  }
 
-    @Get('detailed')
-    @ApiOperation({ summary: 'Detailed health check (all subsystems)' })
-    @ApiResponse({ status: 200, description: 'Health status for all subsystems' })
-    @ApiResponse({ status: 503, description: 'One or more subsystems are down' })
-    async getDetailedHealth(@Res() res: Response) {
-        const health = await this.healthService.getDetailedHealth();
-        if (health.status === 'down') {
-            return res.status(503).json(health);
-        } else if (health.status === 'degraded') {
-            return res.status(200).json(health);
-        }
-        return res.status(200).json(health);
-    }
+  @Get('detailed')
+  @Throttle({ medium: { limit: 50, ttl: 60000 } })
+  @ApiOperation({ summary: 'Detailed health check (all subsystems)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Health status for all subsystems (up or degraded)',
+    type: DetailedHealthStatusDto,
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'One or more subsystems are down',
+    type: DetailedHealthStatusDto,
+  })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
+  async getDetailedHealth(@Res() res: Response) {
+    const health = await this.healthService.getDetailedHealth();
+    const httpStatus = health.status === 'down' ? 503 : 200;
+    return res.status(httpStatus).json(health);
+  }
 
-    @Get('aggregate')
-    @ApiOperation({
-        summary: 'Aggregated health check with per-subsystem summary',
-        description:
-            'Runs all subsystem checks in parallel and returns a structured ' +
-            'summary including per-subsystem latency, uptime, version, and a ' +
-            'numeric breakdown (total/up/degraded/down). ' +
-            'Returns 200 for "up" and "degraded", 503 for "down".',
-    })
-    @ApiResponse({
-        status: 200,
-        description: 'Service is up or degraded — includes subsystem breakdown',
-    })
-    @ApiResponse({
-        status: 503,
-        description: 'Service is down — database or critical subsystem unreachable',
-    })
-    async getAggregatedHealth(@Res() res: Response) {
-        const health = await this.healthService.getAggregatedHealth();
-        const httpStatus = health.status === 'down' ? 503 : 200;
-        return res.status(httpStatus).json(health);
-    }
+  @Get('aggregate')
+  @Throttle({ medium: { limit: 50, ttl: 60000 } })
+  @ApiOperation({
+    summary: 'Aggregated health check with per-subsystem summary',
+    description:
+      'Runs all subsystem checks in parallel and returns a structured ' +
+      'summary including per-subsystem latency, uptime, version, and a ' +
+      'numeric breakdown (total/up/degraded/down). ' +
+      'Returns 200 for "up" and "degraded", 503 for "down".',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Service is up or degraded — includes subsystem breakdown',
+    type: AggregatedHealthDto,
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Service is down — database or critical subsystem unreachable',
+    type: AggregatedHealthDto,
+  })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
+  async getAggregatedHealth(@Res() res: Response) {
+    const health = await this.healthService.getAggregatedHealth();
+    const httpStatus = health.status === 'down' ? 503 : 200;
+    return res.status(httpStatus).json(health);
+  }
 
-    @Get('db')
-    @ApiOperation({ summary: 'Database health check' })
-    @ApiResponse({ status: 200, description: 'Database is healthy' })
-    @ApiResponse({ status: 503, description: 'Database is down' })
-    async getDbHealth(@Res() res: Response) {
-        const health = await this.healthService.checkDatabase();
-        if (health.status === 'down') {
-            return res.status(503).json(health);
-        } else if (health.status === 'degraded') {
-            return res.status(200).json(health);
-        }
-        return res.status(200).json(health);
-    }
+  @Get('db')
+  @Throttle({ medium: { limit: 50, ttl: 60000 } })
+  @ApiOperation({ summary: 'Database health check' })
+  @ApiResponse({ status: 200, description: 'Database is healthy', type: SubsystemStatusDto })
+  @ApiResponse({ status: 503, description: 'Database is down', type: SubsystemStatusDto })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
+  async getDbHealth(@Res() res: Response) {
+    const health = await this.healthService.checkDatabase();
+    const httpStatus = health.status === 'down' ? 503 : 200;
+    return res.status(httpStatus).json(health);
+  }
 
-    @Get('redis')
-    @ApiOperation({ summary: 'Redis health check' })
-    @ApiResponse({ status: 200, description: 'Redis is healthy' })
-    @ApiResponse({ status: 503, description: 'Redis is down' })
-    async getRedisHealth(@Res() res: Response) {
-        const health = await this.healthService.checkRedis();
-        if (health.status === 'down') {
-            return res.status(503).json(health);
-        }
-        return res.status(200).json(health);
-    }
+  @Get('redis')
+  @Throttle({ medium: { limit: 50, ttl: 60000 } })
+  @ApiOperation({ summary: 'Redis health check' })
+  @ApiResponse({ status: 200, description: 'Redis is healthy', type: SubsystemStatusDto })
+  @ApiResponse({ status: 503, description: 'Redis is down', type: SubsystemStatusDto })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
+  async getRedisHealth(@Res() res: Response) {
+    const health = await this.healthService.checkRedis();
+    const httpStatus = health.status === 'down' ? 503 : 200;
+    return res.status(httpStatus).json(health);
+  }
 
-    @Get('soroban')
-    @ApiOperation({ summary: 'Soroban RPC health check' })
-    @ApiResponse({ status: 200, description: 'Soroban RPC is healthy' })
-    @ApiResponse({ status: 503, description: 'Soroban RPC is down' })
-    async getSorobanHealth(@Res() res: Response) {
-        const health = await this.healthService.checkSorobanRpc();
-        if (health.status === 'down') {
-            return res.status(503).json(health);
-        } else if (health.status === 'degraded') {
-            return res.status(200).json(health);
-        }
-        return res.status(200).json(health);
-    }
+  @Get('soroban')
+  @Throttle({ medium: { limit: 50, ttl: 60000 } })
+  @ApiOperation({ summary: 'Soroban RPC health check' })
+  @ApiResponse({ status: 200, description: 'Soroban RPC is healthy or degraded', type: DetailedHealthStatusDto })
+  @ApiResponse({ status: 503, description: 'Soroban RPC is down', type: DetailedHealthStatusDto })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
+  async getSorobanHealth(@Res() res: Response) {
+    const health = await this.healthService.checkSorobanRpc();
+    const httpStatus = health.status === 'down' ? 503 : 200;
+    return res.status(httpStatus).json(health);
+  }
 
-    @Get('soroban-contract')
-    @ApiOperation({ summary: 'Soroban contract health check' })
-    @ApiResponse({ status: 200, description: 'Soroban contract is healthy' })
-    @ApiResponse({ status: 503, description: 'Soroban contract is down' })
-    async getSorobanContractHealth(@Res() res: Response) {
-        const health = await this.healthService.checkSorobanContract();
-        if (health.status === 'down') {
-            return res.status(503).json(health);
-        } else if (health.status === 'degraded') {
-            return res.status(200).json(health);
-        }
-        return res.status(200).json(health);
-    }
+  @Get('soroban-contract')
+  @Throttle({ medium: { limit: 50, ttl: 60000 } })
+  @ApiOperation({ summary: 'Soroban contract health check' })
+  @ApiResponse({ status: 200, description: 'Soroban contract is healthy or degraded', type: DetailedHealthStatusDto })
+  @ApiResponse({ status: 503, description: 'Soroban contract is down', type: DetailedHealthStatusDto })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
+  async getSorobanContractHealth(@Res() res: Response) {
+    const health = await this.healthService.checkSorobanContract();
+    const httpStatus = health.status === 'down' ? 503 : 200;
+    return res.status(httpStatus).json(health);
+  }
 
-    @Get('queue-metrics')
-    @ApiOperation({ summary: 'Worker queue performance metrics' })
-    @ApiResponse({ status: 200, description: 'Queue metrics snapshot' })
-    getQueueMetrics() {
-        return this.healthService.getQueueMetrics();
-    }
+  @Get('queue-metrics')
+  @Throttle({ medium: { limit: 50, ttl: 60000 } })
+  @ApiOperation({ summary: 'Worker queue performance metrics' })
+  @ApiResponse({ status: 200, description: 'Queue metrics snapshot', type: QueueMetricsDto })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
+  getQueueMetrics() {
+    return this.healthService.getQueueMetrics();
+  }
 }

--- a/backend/src/health/health.service.spec.ts
+++ b/backend/src/health/health.service.spec.ts
@@ -39,7 +39,7 @@ describe('HealthService', () => {
     describe('getHealth', () => {
         it('should return basic health status', () => {
             const result = service.getHealth();
-            expect(result.status).toBe('ok');
+            expect(result.status).toBe('up');
             expect(result.timestamp).toBeDefined();
         });
     });

--- a/backend/src/health/health.service.ts
+++ b/backend/src/health/health.service.ts
@@ -47,7 +47,7 @@ export class HealthService {
 
   getHealth(): DetailedHealthCheckResult {
     return {
-      status: 'ok' as any, // Legacy compatibility
+      status: 'up',
       timestamp: new Date().toISOString(),
     };
   }
@@ -145,7 +145,8 @@ export class HealthService {
       await this.dataSource.query('SELECT 1');
       return { status: 'up' };
     } catch (error) {
-      return { status: 'down', error: error.message };
+      const msg = error instanceof Error ? error.message : String(error);
+      return { status: 'down', error: msg };
     }
   }
 
@@ -159,7 +160,8 @@ export class HealthService {
       await this.dataSource.query('SELECT 1');
       return { status: 'up', latencyMs: Date.now() - start };
     } catch (error) {
-      return { status: 'down', latencyMs: Date.now() - start, error: error.message };
+      const msg = error instanceof Error ? error.message : String(error);
+      return { status: 'down', latencyMs: Date.now() - start, error: msg };
     }
   }
 

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -1,104 +1,225 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { JwtService } from '@nestjs/jwt';
-import { UnauthorizedException } from '@nestjs/common';
+import { UserProfileDto } from './dto/user-profile.dto';
+
+const makeUser = (overrides: Record<string, unknown> = {}) => ({
+  id: 'user-1',
+  username: 'testuser',
+  display_name: 'Test User',
+  avatar_url: null,
+  is_creator: false,
+  onboarding_state: null,
+  created_at: new Date('2024-01-01'),
+  email_notifications: true,
+  push_notifications: false,
+  marketing_emails: false,
+  ...overrides,
+});
 
 describe('UsersController', () => {
-    let controller: UsersController;
-    let service: any;
+  let controller: UsersController;
+  let service: jest.Mocked<
+    Pick<
+      UsersService,
+      | 'findOne'
+      | 'update'
+      | 'updateOnboarding'
+      | 'updateNotificationPreferences'
+      | 'validatePassword'
+      | 'remove'
+    >
+  >;
 
-    const mockUsersService = {
-        findOne: jest.fn(),
-        updateOnboarding: jest.fn(),
-        validatePassword: jest.fn(),
-        remove: jest.fn(),
+  beforeEach(async () => {
+    service = {
+      findOne: jest.fn(),
+      update: jest.fn(),
+      updateOnboarding: jest.fn(),
+      updateNotificationPreferences: jest.fn(),
+      validatePassword: jest.fn(),
+      remove: jest.fn(),
     };
 
-    const mockJwtService = {
-        verifyAsync: jest.fn(),
-    };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        { provide: UsersService, useValue: service },
+        { provide: JwtService, useValue: { verifyAsync: jest.fn() } },
+      ],
+    }).compile();
 
-    beforeEach(async () => {
-        const module: TestingModule = await Test.createTestingModule({
-            controllers: [UsersController],
-            providers: [
-                {
-                    provide: UsersService,
-                    useValue: mockUsersService,
-                },
-                {
-                    provide: JwtService,
-                    useValue: mockJwtService,
-                },
-            ],
-        }).compile();
+    controller = module.get<UsersController>(UsersController);
+  });
 
-        controller = module.get<UsersController>(UsersController);
-        service = module.get<UsersService>(UsersService);
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getMe', () => {
+    it('returns a UserProfileDto for the authenticated user', async () => {
+      const user = makeUser();
+      service.findOne.mockResolvedValue(user as any);
+      const req = { user: { id: 'user-1' } };
+
+      const result = await controller.getMe(req);
+
+      expect(service.findOne).toHaveBeenCalledWith('user-1');
+      expect(result).toBeInstanceOf(UserProfileDto);
+      expect(result.id).toBe('user-1');
+      expect(result.username).toBe('testuser');
     });
 
-    it('should be defined', () => {
-        expect(controller).toBeDefined();
+    it('throws when service.findOne rejects', async () => {
+      service.findOne.mockRejectedValue(new Error('User not found'));
+      const req = { user: { id: 'missing-user' } };
+
+      await expect(controller.getMe(req)).rejects.toThrow('User not found');
+    });
+  });
+
+  describe('updateMe', () => {
+    it('calls service.update with the temp user id and dto', async () => {
+      const updated = makeUser({ display_name: 'New Name' });
+      service.update.mockResolvedValue(updated as any);
+      const dto = { display_name: 'New Name' };
+
+      const result = await controller.updateMe(dto as any);
+
+      expect(service.update).toHaveBeenCalledWith('temp-user-id', dto);
+      expect(result).toBeInstanceOf(UserProfileDto);
+      expect(result.display_name).toBe('New Name');
     });
 
-    describe('removeMe', () => {
-        it('should call service.remove if password is valid', async () => {
-            const req = { user: { id: 'user-id' } };
-            const dto = { password: 'correct_password' };
-            service.validatePassword.mockResolvedValue(true);
-            service.remove.mockResolvedValue(undefined);
+    it('propagates service errors', async () => {
+      service.update.mockRejectedValue(new Error('DB error'));
 
-            await controller.removeMe(req, dto);
+      await expect(controller.updateMe({} as any)).rejects.toThrow('DB error');
+    });
+  });
 
-            expect(service.validatePassword).toHaveBeenCalledWith('user-id', 'correct_password');
-            expect(service.remove).toHaveBeenCalledWith('user-id');
-        });
+  describe('updateOnboarding', () => {
+    it('calls service.updateOnboarding with req.user.id and dto fields', async () => {
+      const dto = {
+        currentStep: 'profile',
+        completedSteps: ['account-type'],
+        skippedSteps: [] as string[],
+        intent: 'creator',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+      const updated = makeUser({
+        onboarding_state: {
+          currentStep: dto.currentStep,
+          completedSteps: dto.completedSteps,
+          skippedSteps: dto.skippedSteps,
+          intent: dto.intent,
+          updatedAt: dto.updatedAt,
+        },
+      });
+      service.updateOnboarding.mockResolvedValue(updated as any);
+      const req = { user: { id: 'user-1' } };
 
-        it('should throw UnauthorizedException if password is invalid', async () => {
-            const req = { user: { id: 'user-id' } };
-            const dto = { password: 'wrong_password' };
-            service.validatePassword.mockResolvedValue(false);
+      const result = await controller.updateOnboarding(req as any, dto as any);
 
-            await expect(controller.removeMe(req, dto)).rejects.toThrow(UnauthorizedException);
-        });
+      expect(service.updateOnboarding).toHaveBeenCalledWith('user-1', {
+        currentStep: 'profile',
+        completedSteps: ['account-type'],
+        skippedSteps: [],
+        intent: 'creator',
+        updatedAt: dto.updatedAt,
+      });
+      expect(result).toHaveProperty('onboarding_state');
     });
 
-    describe('updateOnboarding', () => {
-        it('should call service.updateOnboarding with req.user.id and dto', async () => {
-            const req = { user: { id: 'user-id' } };
-            const dto = {
-                currentStep: 'profile',
-                completedSteps: ['account-type'],
-                skippedSteps: [],
-                intent: 'creator',
-                updatedAt: new Date().toISOString(),
-            };
-            mockUsersService.updateOnboarding.mockResolvedValue({
-                id: 'user-id',
-                username: 'u',
-                display_name: 'd',
-                avatar_url: null,
-                is_creator: false,
-                onboarding_state: {
-                    currentStep: dto.currentStep,
-                    completedSteps: dto.completedSteps,
-                    skippedSteps: dto.skippedSteps,
-                    intent: dto.intent,
-                    updatedAt: dto.updatedAt,
-                },
-            });
+    it('defaults intent to null when omitted', async () => {
+      const dto = {
+        currentStep: 'profile',
+        completedSteps: [],
+        skippedSteps: [],
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+      service.updateOnboarding.mockResolvedValue(makeUser() as any);
+      const req = { user: { id: 'user-1' } };
 
-            const result = await controller.updateOnboarding(req as any, dto as any);
+      await controller.updateOnboarding(req as any, dto as any);
 
-            expect(mockUsersService.updateOnboarding).toHaveBeenCalledWith('user-id', {
-                currentStep: 'profile',
-                completedSteps: ['account-type'],
-                skippedSteps: [],
-                intent: 'creator',
-                updatedAt: dto.updatedAt,
-            });
-            expect(result).toHaveProperty('onboarding_state');
-        });
+      expect(service.updateOnboarding).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ intent: null }),
+      );
     });
+
+    it('propagates service errors', async () => {
+      service.updateOnboarding.mockRejectedValue(new Error('Not found'));
+      const req = { user: { id: 'user-1' } };
+
+      await expect(
+        controller.updateOnboarding(req as any, {} as any),
+      ).rejects.toThrow('Not found');
+    });
+  });
+
+  describe('updateNotifications', () => {
+    it('delegates to service.updateNotificationPreferences and returns result', async () => {
+      const dto = { email_notifications: true, push_notifications: false };
+      const serviceResult = {
+        message: 'Notification preferences updated successfully',
+        preferences: { email_notifications: true, push_notifications: false },
+      };
+      service.updateNotificationPreferences.mockResolvedValue(serviceResult as any);
+      const req = { user: { id: 'user-1' } };
+
+      const result = await controller.updateNotifications(req as any, dto as any);
+
+      expect(service.updateNotificationPreferences).toHaveBeenCalledWith('user-1', dto);
+      expect(result).toEqual(serviceResult);
+    });
+
+    it('propagates service errors', async () => {
+      service.updateNotificationPreferences.mockRejectedValue(new Error('DB error'));
+      const req = { user: { id: 'user-1' } };
+
+      await expect(
+        controller.updateNotifications(req as any, {} as any),
+      ).rejects.toThrow('DB error');
+    });
+  });
+
+  describe('removeMe', () => {
+    it('calls service.remove when password is valid', async () => {
+      service.validatePassword.mockResolvedValue(true);
+      service.remove.mockResolvedValue(undefined);
+      const req = { user: { id: 'user-1' } };
+
+      await controller.removeMe(req as any, { password: 'correct' });
+
+      expect(service.validatePassword).toHaveBeenCalledWith('user-1', 'correct');
+      expect(service.remove).toHaveBeenCalledWith('user-1');
+    });
+
+    it('throws UnauthorizedException when password is invalid', async () => {
+      service.validatePassword.mockResolvedValue(false);
+      const req = { user: { id: 'user-1' } };
+
+      await expect(
+        controller.removeMe(req as any, { password: 'wrong' }),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(service.remove).not.toHaveBeenCalled();
+    });
+
+    it('does not call remove when validatePassword rejects', async () => {
+      service.validatePassword.mockRejectedValue(new Error('DB error'));
+      const req = { user: { id: 'user-1' } };
+
+      await expect(
+        controller.removeMe(req as any, { password: 'any' }),
+      ).rejects.toThrow('DB error');
+      expect(service.remove).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION


## Summary

Closes #1068, #1067, #1069, #1070

closes #1068 — Swagger/OpenAPI docs (health): Added health/dto/health-response.dto.ts with fully typed response classes (HealthStatusDto, DetailedHealthStatusDto, AggregatedHealthDto, SubsystemStatusDto, QueueMetricsDto). Every @ApiResponse in the health controller now carries a type: reference so Swagger renders complete request/response schemas.

closes #1067 — Consistent error shape (health): Removed the legacy status: 'ok' as any hack from HealthService.getHealth() — it now returns status: 'up' like all other health endpoints. Also fixed two pre-existing TypeScript errors where catch (error) was accessed without an instanceof guard. Updated all affected test assertions.

closes #1069 — Rate limiting on expensive endpoints (health): Narrowed the blanket health-route exemption in ThrottlerGuard to only the basic liveness probe (GET /v1/health). All subsystem check endpoints (/detailed, /aggregate, /db, /redis, /soroban, /soroban-contract, /queue-metrics) now go through the throttler at the medium tier (50 req/min) via @Throttle({ medium: { limit: 50, ttl: 60000 } }).

closes #1070 — Users controller unit tests: Rewrote users.controller.spec.ts with 13 focused tests covering all five controller methods (getMe, updateMe, updateOnboarding, updateNotifications, removeMe). Uses a jest.Mocked<Pick<UsersService, ...>> — no real service, database, or HTTP context wired in.

## Test plan

 npx jest src/health/ --no-coverage → 57 tests pass
 npx jest src/users/ --no-coverage → 18 tests pass
 Visit /api-docs and confirm health endpoints show full request/response schemas
 Confirm GET /v1/health is still exempt from throttling (used by Docker healthcheck)
 Confirm GET /v1/health/detailed returns 429 after 50 requests in 60 s















