### PR TITLE
Fix/likes tests and pagination

### DIFF
--- a/backend/src/likes/dto/get-likes-query.dto.ts
+++ b/backend/src/likes/dto/get-likes-query.dto.ts
@@ -1,0 +1,29 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetLikesQueryDto {
+  @ApiPropertyOptional({
+    description: 'Page number (1-based)',
+    default: 1,
+    minimum: 1,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number = 20;
+}

--- a/backend/src/likes/likes.controller.ts
+++ b/backend/src/likes/likes.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Param,
+  Query,
   UseGuards,
   HttpCode,
   HttpStatus,
@@ -18,6 +19,7 @@ import {
 import { LikesService } from './likes.service';
 import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth-module/decorators/current-user.decorator';
+import { GetLikesQueryDto } from './dto/get-likes-query.dto';
 
 @ApiTags('likes')
 @Controller({ path: 'posts', version: '1' })
@@ -57,6 +59,16 @@ export class LikesController {
     @CurrentUser() user: { userId: string },
   ) {
     await this.likesService.removeLike(postId, user.userId);
+  }
+
+  @Get(':id/likes')
+  @ApiOperation({ summary: 'Get paginated likes for a post' })
+  @ApiResponse({ status: 200, description: 'Paginated likes list' })
+  async getLikesByPost(
+    @Param('id') postId: string,
+    @Query() query: GetLikesQueryDto,
+  ) {
+    return this.likesService.getLikesByPost(postId, query.page, query.limit);
   }
 
   @Get(':id/likes/count')

--- a/backend/src/likes/likes.dto.spec.ts
+++ b/backend/src/likes/likes.dto.spec.ts
@@ -1,0 +1,74 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { GetLikesQueryDto } from './dto/get-likes-query.dto';
+
+describe('GetLikesQueryDto – DTO validation for invalid input', () => {
+  async function validateDto(plain: object) {
+    const dto = plainToInstance(GetLikesQueryDto, plain);
+    return validate(dto);
+  }
+
+  it('passes with an empty object (all fields optional)', async () => {
+    const errors = await validateDto({});
+    expect(errors).toHaveLength(0);
+  });
+
+  it('passes with valid page and limit', async () => {
+    const errors = await validateDto({ page: 1, limit: 20 });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('passes with maximum allowed limit of 100', async () => {
+    const errors = await validateDto({ limit: 100 });
+    expect(errors.filter((e) => e.property === 'limit')).toHaveLength(0);
+  });
+
+  it('fails when page is 0 (below minimum of 1)', async () => {
+    const errors = await validateDto({ page: 0 });
+    const pageErrors = errors.filter((e) => e.property === 'page');
+    expect(pageErrors.length).toBeGreaterThan(0);
+    const constraints = Object.values(pageErrors[0].constraints ?? {});
+    expect(constraints.some((c) => c.includes('1'))).toBe(true);
+  });
+
+  it('fails when page is negative', async () => {
+    const errors = await validateDto({ page: -5 });
+    const pageErrors = errors.filter((e) => e.property === 'page');
+    expect(pageErrors.length).toBeGreaterThan(0);
+  });
+
+  it('fails when limit is 0 (below minimum of 1)', async () => {
+    const errors = await validateDto({ limit: 0 });
+    const limitErrors = errors.filter((e) => e.property === 'limit');
+    expect(limitErrors.length).toBeGreaterThan(0);
+  });
+
+  it('fails when limit exceeds maximum of 100', async () => {
+    const errors = await validateDto({ limit: 101 });
+    const limitErrors = errors.filter((e) => e.property === 'limit');
+    expect(limitErrors.length).toBeGreaterThan(0);
+  });
+
+  it('fails when limit is a very large number', async () => {
+    const errors = await validateDto({ limit: 9999 });
+    const limitErrors = errors.filter((e) => e.property === 'limit');
+    expect(limitErrors.length).toBeGreaterThan(0);
+  });
+
+  it('fails when page is a non-numeric string', async () => {
+    const errors = await validateDto({ page: 'abc' });
+    const pageErrors = errors.filter((e) => e.property === 'page');
+    expect(pageErrors.length).toBeGreaterThan(0);
+  });
+
+  it('fails when limit is a non-numeric string', async () => {
+    const errors = await validateDto({ limit: 'many' });
+    const limitErrors = errors.filter((e) => e.property === 'limit');
+    expect(limitErrors.length).toBeGreaterThan(0);
+  });
+
+  it('coerces string numbers to integers via @Type(() => Number)', async () => {
+    const errors = await validateDto({ page: '2', limit: '10' });
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/backend/src/likes/likes.service.spec.ts
+++ b/backend/src/likes/likes.service.spec.ts
@@ -1,0 +1,242 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { LikesService } from './likes.service';
+import { Like } from './entities/like.entity';
+import { PostsService } from '../posts/posts.service';
+
+const mockPost = {
+  id: 'post-1',
+  authorId: 'author-1',
+  isPremium: false,
+  title: 'Test Post',
+  content: 'Test content',
+  isPublished: true,
+  likesCount: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  deletedAt: null,
+};
+
+function makeLike(overrides: Partial<Like> = {}): Like {
+  return {
+    id: 'like-1',
+    userId: 'user-1',
+    postId: 'post-1',
+    createdAt: new Date(),
+    user: undefined as never,
+    post: undefined as never,
+    ...overrides,
+  };
+}
+
+describe('LikesService – happy path', () => {
+  let service: LikesService;
+  let likes: Like[];
+
+  const mockRepo = {
+    findOne: jest.fn(async ({ where }: { where: Partial<Like> }) =>
+      likes.find(
+        (l) =>
+          (!where.userId || l.userId === where.userId) &&
+          (!where.postId || l.postId === where.postId),
+      ) ?? null,
+    ),
+    create: jest.fn((data: Partial<Like>) => makeLike(data)),
+    save: jest.fn(async (like: Like) => {
+      likes.push(like);
+      return like;
+    }),
+    remove: jest.fn(async (like: Like) => {
+      likes = likes.filter((l) => l.id !== like.id);
+    }),
+    count: jest.fn(async ({ where }: { where: Partial<Like> }) =>
+      likes.filter((l) => !where.postId || l.postId === where.postId).length,
+    ),
+    findAndCount: jest.fn(
+      async ({
+        where,
+        skip = 0,
+        take = likes.length,
+      }: {
+        where?: Partial<Like>;
+        skip?: number;
+        take?: number;
+      }) => {
+        const filtered = likes.filter(
+          (l) => !where?.postId || l.postId === where.postId,
+        );
+        return [filtered.slice(skip, skip + take), filtered.length];
+      },
+    ),
+  };
+
+  const mockPostsService = {
+    findOne: jest.fn(async () => mockPost),
+  };
+
+  beforeEach(async () => {
+    likes = [];
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LikesService,
+        { provide: getRepositoryToken(Like), useValue: mockRepo },
+        { provide: PostsService, useValue: mockPostsService },
+      ],
+    }).compile();
+
+    service = module.get(LikesService);
+  });
+
+  describe('addLike', () => {
+    it('creates a new like and returns status 201', async () => {
+      const result = await service.addLike('post-1', 'user-1');
+
+      expect(result.status).toBe(201);
+      expect(result.message).toBe('Like added successfully');
+      expect(mockRepo.create).toHaveBeenCalledWith({ userId: 'user-1', postId: 'post-1' });
+      expect(mockRepo.save).toHaveBeenCalled();
+    });
+
+    it('returns status 200 when user has already liked the post (idempotent)', async () => {
+      likes.push(makeLike({ userId: 'user-1', postId: 'post-1' }));
+
+      const result = await service.addLike('post-1', 'user-1');
+
+      expect(result.status).toBe(200);
+      expect(result.message).toBe('Post already liked');
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('verifies the post exists before liking', async () => {
+      await service.addLike('post-1', 'user-1');
+
+      expect(mockPostsService.findOne).toHaveBeenCalledWith('post-1');
+    });
+
+    it('throws NotFoundException when post does not exist', async () => {
+      mockPostsService.findOne.mockRejectedValueOnce(
+        new NotFoundException('Post with ID nonexistent not found'),
+      );
+
+      await expect(service.addLike('nonexistent', 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('removeLike', () => {
+    it('removes an existing like', async () => {
+      likes.push(makeLike({ userId: 'user-1', postId: 'post-1' }));
+
+      await service.removeLike('post-1', 'user-1');
+
+      expect(mockRepo.remove).toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when like does not exist', async () => {
+      await expect(service.removeLike('post-1', 'user-no-like')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('verifies the post exists before removing', async () => {
+      likes.push(makeLike({ userId: 'user-1', postId: 'post-1' }));
+      await service.removeLike('post-1', 'user-1');
+
+      expect(mockPostsService.findOne).toHaveBeenCalledWith('post-1');
+    });
+  });
+
+  describe('getLikesCount', () => {
+    it('returns 0 when no likes exist', async () => {
+      const count = await service.getLikesCount('post-1');
+      expect(count).toBe(0);
+    });
+
+    it('returns the correct count of likes', async () => {
+      likes.push(
+        makeLike({ id: 'like-1', userId: 'user-1', postId: 'post-1' }),
+        makeLike({ id: 'like-2', userId: 'user-2', postId: 'post-1' }),
+      );
+
+      const count = await service.getLikesCount('post-1');
+      expect(count).toBe(2);
+    });
+
+    it('counts only likes for the given post', async () => {
+      likes.push(
+        makeLike({ id: 'like-1', userId: 'user-1', postId: 'post-1' }),
+        makeLike({ id: 'like-2', userId: 'user-2', postId: 'post-2' }),
+      );
+
+      const count = await service.getLikesCount('post-1');
+      expect(count).toBe(1);
+    });
+  });
+
+  describe('hasUserLiked', () => {
+    it('returns true when user has liked the post', async () => {
+      likes.push(makeLike({ userId: 'user-1', postId: 'post-1' }));
+
+      const result = await service.hasUserLiked('post-1', 'user-1');
+      expect(result).toBe(true);
+    });
+
+    it('returns false when user has not liked the post', async () => {
+      const result = await service.hasUserLiked('post-1', 'user-1');
+      expect(result).toBe(false);
+    });
+
+    it('returns false for a different user', async () => {
+      likes.push(makeLike({ userId: 'user-2', postId: 'post-1' }));
+
+      const result = await service.hasUserLiked('post-1', 'user-1');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getLikesByPost', () => {
+    it('returns empty result when no likes exist', async () => {
+      const result = await service.getLikesByPost('post-1');
+
+      expect(result.data).toHaveLength(0);
+      expect(result.total).toBe(0);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('returns paginated likes for a post', async () => {
+      for (let i = 1; i <= 3; i++) {
+        likes.push(makeLike({ id: `like-${i}`, userId: `user-${i}`, postId: 'post-1' }));
+      }
+
+      const result = await service.getLikesByPost('post-1', 1, 2);
+
+      expect(result.data).toHaveLength(2);
+      expect(result.total).toBe(3);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(2);
+      expect(result.hasMore).toBe(true);
+    });
+
+    it('returns last page with hasMore=false', async () => {
+      for (let i = 1; i <= 3; i++) {
+        likes.push(makeLike({ id: `like-${i}`, userId: `user-${i}`, postId: 'post-1' }));
+      }
+
+      const result = await service.getLikesByPost('post-1', 2, 2);
+
+      expect(result.data).toHaveLength(1);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('uses default page=1 and limit=20', async () => {
+      const result = await service.getLikesByPost('post-1');
+
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+    });
+  });
+});

--- a/backend/src/likes/likes.service.ts
+++ b/backend/src/likes/likes.service.ts
@@ -8,6 +8,14 @@ import { Repository } from 'typeorm';
 import { Like } from './entities/like.entity';
 import { PostsService } from '../posts/posts.service';
 
+export interface PaginatedLikesResult {
+  data: Like[];
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+}
+
 @Injectable()
 export class LikesService {
   constructor(
@@ -74,6 +82,24 @@ export class LikesService {
    */
   async getLikesCount(postId: string): Promise<number> {
     return this.likesRepository.count({ where: { postId } });
+  }
+
+  /**
+   * Get paginated list of likes for a post
+   */
+  async getLikesByPost(
+    postId: string,
+    page = 1,
+    limit = 20,
+  ): Promise<PaginatedLikesResult> {
+    const skip = (page - 1) * limit;
+    const [data, total] = await this.likesRepository.findAndCount({
+      where: { postId },
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+    return { data, total, page, limit, hasMore: page * limit < total };
   }
 
   /**

--- a/backend/test/likes.e2e-spec.ts
+++ b/backend/test/likes.e2e-spec.ts
@@ -8,7 +8,8 @@ import {
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import request from 'supertest';
-import { LikesModule } from '../src/likes/likes.module';
+import { LikesController } from '../src/likes/likes.controller';
+import { LikesService } from '../src/likes/likes.service';
 import { Like } from '../src/likes/entities/like.entity';
 import { JwtAuthGuard } from '../src/auth-module/guards/jwt-auth.guard';
 import { PostsService } from '../src/posts/posts.service';
@@ -31,7 +32,7 @@ const mockPost = {
 
 function makeLike(overrides: Partial<Like> = {}): Like {
   return {
-    id: `like-${Date.now()}`,
+    id: `like-${Date.now()}-${Math.random()}`,
     userId: TEST_USER_ID,
     postId: TEST_POST_ID,
     createdAt: new Date(),
@@ -89,7 +90,9 @@ describe('LikesController (e2e) – primary endpoints', () => {
 
   const mockJwtAuthGuard = {
     canActivate: (context: ExecutionContext) => {
-      const req = context.switchToHttp().getRequest<{ user: { userId: string } }>();
+      const req = context
+        .switchToHttp()
+        .getRequest<{ user: { userId: string } }>();
       req.user = { userId: TEST_USER_ID };
       return true;
     },
@@ -100,12 +103,13 @@ describe('LikesController (e2e) – primary endpoints', () => {
     jest.clearAllMocks();
 
     const moduleRef: TestingModule = await Test.createTestingModule({
-      imports: [LikesModule],
+      controllers: [LikesController],
+      providers: [
+        LikesService,
+        { provide: getRepositoryToken(Like), useValue: mockLikeRepo },
+        { provide: PostsService, useValue: mockPostsService },
+      ],
     })
-      .overrideProvider(getRepositoryToken(Like))
-      .useValue(mockLikeRepo)
-      .overrideProvider(PostsService)
-      .useValue(mockPostsService)
       .overrideGuard(JwtAuthGuard)
       .useValue(mockJwtAuthGuard)
       .compile();
@@ -204,7 +208,11 @@ describe('LikesController (e2e) – primary endpoints', () => {
     it('respects limit query parameter', async () => {
       for (let i = 0; i < 5; i++) {
         storedLikes.push(
-          makeLike({ id: `like-${i}`, userId: `user-${i}`, postId: TEST_POST_ID }),
+          makeLike({
+            id: `like-${i}`,
+            userId: `user-${i}`,
+            postId: TEST_POST_ID,
+          }),
         );
       }
 
@@ -244,7 +252,7 @@ describe('LikesController (e2e) – primary endpoints', () => {
       expect(res.body).toHaveProperty('count', 0);
     });
 
-    it('returns the correct count after liking', async () => {
+    it('returns the correct count after likes are added', async () => {
       storedLikes.push(
         makeLike({ id: 'like-a', userId: 'user-a', postId: TEST_POST_ID }),
         makeLike({ id: 'like-b', userId: 'user-b', postId: TEST_POST_ID }),

--- a/backend/test/likes.e2e-spec.ts
+++ b/backend/test/likes.e2e-spec.ts
@@ -1,0 +1,282 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+import {
+  ExecutionContext,
+  INestApplication,
+  ValidationPipe,
+  VersioningType,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import request from 'supertest';
+import { LikesModule } from '../src/likes/likes.module';
+import { Like } from '../src/likes/entities/like.entity';
+import { JwtAuthGuard } from '../src/auth-module/guards/jwt-auth.guard';
+import { PostsService } from '../src/posts/posts.service';
+
+const TEST_USER_ID = 'e2e-user-id';
+const TEST_POST_ID = 'e2e-post-id';
+
+const mockPost = {
+  id: TEST_POST_ID,
+  authorId: 'e2e-author-id',
+  isPremium: false,
+  title: 'E2E Test Post',
+  content: 'E2E content',
+  isPublished: true,
+  likesCount: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  deletedAt: null,
+};
+
+function makeLike(overrides: Partial<Like> = {}): Like {
+  return {
+    id: `like-${Date.now()}`,
+    userId: TEST_USER_ID,
+    postId: TEST_POST_ID,
+    createdAt: new Date(),
+    user: undefined as never,
+    post: undefined as never,
+    ...overrides,
+  };
+}
+
+describe('LikesController (e2e) – primary endpoints', () => {
+  let app: INestApplication;
+  let storedLikes: Like[];
+
+  const mockLikeRepo = {
+    findOne: jest.fn(async ({ where }: { where: Partial<Like> }) =>
+      storedLikes.find(
+        (l) =>
+          (!where.userId || l.userId === where.userId) &&
+          (!where.postId || l.postId === where.postId),
+      ) ?? null,
+    ),
+    create: jest.fn((data: Partial<Like>) => makeLike(data)),
+    save: jest.fn(async (like: Like) => {
+      storedLikes.push(like);
+      return like;
+    }),
+    remove: jest.fn(async (like: Like) => {
+      storedLikes = storedLikes.filter((l) => l.id !== like.id);
+    }),
+    count: jest.fn(async ({ where }: { where: Partial<Like> }) =>
+      storedLikes.filter((l) => !where?.postId || l.postId === where.postId)
+        .length,
+    ),
+    findAndCount: jest.fn(
+      async ({
+        where,
+        skip = 0,
+        take = 20,
+      }: {
+        where?: Partial<Like>;
+        skip?: number;
+        take?: number;
+      }) => {
+        const filtered = storedLikes.filter(
+          (l) => !where?.postId || l.postId === where.postId,
+        );
+        return [filtered.slice(skip, skip + take), filtered.length];
+      },
+    ),
+  };
+
+  const mockPostsService = {
+    findOne: jest.fn(async () => mockPost),
+  };
+
+  const mockJwtAuthGuard = {
+    canActivate: (context: ExecutionContext) => {
+      const req = context.switchToHttp().getRequest<{ user: { userId: string } }>();
+      req.user = { userId: TEST_USER_ID };
+      return true;
+    },
+  };
+
+  beforeEach(async () => {
+    storedLikes = [];
+    jest.clearAllMocks();
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [LikesModule],
+    })
+      .overrideProvider(getRepositoryToken(Like))
+      .useValue(mockLikeRepo)
+      .overrideProvider(PostsService)
+      .useValue(mockPostsService)
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtAuthGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  // ── POST /v1/posts/:id/like (primary endpoint) ──────────────────────────────
+
+  describe('POST /v1/posts/:id/like', () => {
+    it('returns 201 and liked=true when a new like is created', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/v1/posts/${TEST_POST_ID}/like`)
+        .expect(201);
+
+      expect(res.body.liked).toBe(true);
+      expect(res.body.postId).toBe(TEST_POST_ID);
+      expect(res.body.message).toBe('Like added successfully');
+    });
+
+    it('returns 200 when the user has already liked the post (idempotent)', async () => {
+      await request(app.getHttpServer())
+        .post(`/v1/posts/${TEST_POST_ID}/like`)
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .post(`/v1/posts/${TEST_POST_ID}/like`)
+        .expect(200);
+
+      expect(res.body.liked).toBe(true);
+      expect(res.body.message).toBe('Post already liked');
+    });
+
+    it('returns 404 when the post does not exist', async () => {
+      mockPostsService.findOne.mockRejectedValueOnce(
+        Object.assign(new Error('Post not found'), { status: 404 }),
+      );
+
+      await request(app.getHttpServer())
+        .post('/v1/posts/nonexistent/like')
+        .expect(404);
+    });
+  });
+
+  // ── DELETE /v1/posts/:id/like ────────────────────────────────────────────────
+
+  describe('DELETE /v1/posts/:id/like', () => {
+    it('returns 204 after successfully removing a like', async () => {
+      storedLikes.push(makeLike({ userId: TEST_USER_ID, postId: TEST_POST_ID }));
+
+      await request(app.getHttpServer())
+        .delete(`/v1/posts/${TEST_POST_ID}/like`)
+        .expect(204);
+    });
+
+    it('returns 404 when trying to remove a like that does not exist', async () => {
+      await request(app.getHttpServer())
+        .delete(`/v1/posts/${TEST_POST_ID}/like`)
+        .expect(404);
+    });
+  });
+
+  // ── GET /v1/posts/:id/likes (paginated) ─────────────────────────────────────
+
+  describe('GET /v1/posts/:id/likes', () => {
+    it('returns 200 with paginated response shape', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/v1/posts/${TEST_POST_ID}/likes`)
+        .expect(200);
+
+      expect(res.body).toHaveProperty('data');
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body).toHaveProperty('total');
+      expect(res.body).toHaveProperty('page');
+      expect(res.body).toHaveProperty('limit');
+      expect(res.body).toHaveProperty('hasMore');
+    });
+
+    it('returns empty data when no likes exist', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/v1/posts/${TEST_POST_ID}/likes`)
+        .expect(200);
+
+      expect(res.body.data).toHaveLength(0);
+      expect(res.body.total).toBe(0);
+      expect(res.body.hasMore).toBe(false);
+    });
+
+    it('respects limit query parameter', async () => {
+      for (let i = 0; i < 5; i++) {
+        storedLikes.push(
+          makeLike({ id: `like-${i}`, userId: `user-${i}`, postId: TEST_POST_ID }),
+        );
+      }
+
+      const res = await request(app.getHttpServer())
+        .get(`/v1/posts/${TEST_POST_ID}/likes`)
+        .query({ limit: 3 })
+        .expect(200);
+
+      expect(res.body.data).toHaveLength(3);
+      expect(res.body.limit).toBe(3);
+      expect(res.body.hasMore).toBe(true);
+    });
+
+    it('returns 400 when limit exceeds 100', async () => {
+      await request(app.getHttpServer())
+        .get(`/v1/posts/${TEST_POST_ID}/likes`)
+        .query({ limit: 101 })
+        .expect(400);
+    });
+
+    it('returns 400 when page is less than 1', async () => {
+      await request(app.getHttpServer())
+        .get(`/v1/posts/${TEST_POST_ID}/likes`)
+        .query({ page: 0 })
+        .expect(400);
+    });
+  });
+
+  // ── GET /v1/posts/:id/likes/count ────────────────────────────────────────────
+
+  describe('GET /v1/posts/:id/likes/count', () => {
+    it('returns 200 with count=0 when no likes exist', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/v1/posts/${TEST_POST_ID}/likes/count`)
+        .expect(200);
+
+      expect(res.body).toHaveProperty('count', 0);
+    });
+
+    it('returns the correct count after liking', async () => {
+      storedLikes.push(
+        makeLike({ id: 'like-a', userId: 'user-a', postId: TEST_POST_ID }),
+        makeLike({ id: 'like-b', userId: 'user-b', postId: TEST_POST_ID }),
+      );
+
+      const res = await request(app.getHttpServer())
+        .get(`/v1/posts/${TEST_POST_ID}/likes/count`)
+        .expect(200);
+
+      expect(res.body.count).toBe(2);
+    });
+  });
+
+  // ── GET /v1/posts/:id/like/status ────────────────────────────────────────────
+
+  describe('GET /v1/posts/:id/like/status', () => {
+    it('returns liked=false when user has not liked the post', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/v1/posts/${TEST_POST_ID}/like/status`)
+        .expect(200);
+
+      expect(res.body).toHaveProperty('liked', false);
+    });
+
+    it('returns liked=true when user has liked the post', async () => {
+      storedLikes.push(makeLike({ userId: TEST_USER_ID, postId: TEST_POST_ID }));
+
+      const res = await request(app.getHttpServer())
+        .get(`/v1/posts/${TEST_POST_ID}/like/status`)
+        .expect(200);
+
+      expect(res.body.liked).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

<!-- One or two sentences describing what this PR does and why. -->

closes #1023 
closes #1024 
closes #1025 
closes #1026



Issue 1 – Service unit tests for happy path (likes.service.spec.ts)

Created backend/src/likes/likes.service.spec.ts with full happy-path coverage for every LikesService method. The spec mocks the TypeORM Like repository and PostsService.findOne, drives an in-memory likes[] array, and asserts:

- addLike creates a new record and returns { status: 201 }
- addLike is idempotent — returns { status: 200 } if the like already exists, and does not call save again
- addLike delegates to postsService.findOne and re-throws NotFoundException when the post doesn't exist
- removeLike calls remove and resolves cleanly
- removeLike throws NotFoundException when there is no matching like
- getLikesCount returns 0 on empty state, counts correctly, and filters by postId
- hasUserLiked returns true/false based on repository state
- getLikesByPost (new) returns the right slice, hasMore, and default page/limit

---
Issue 2 – DTO validation tests for invalid input (likes.dto.spec.ts)

Created backend/src/likes/dto/get-likes-query.dto.ts — a GetLikesQueryDto with page (min 1) and limit (min 1, max 100) using class-validator + @Type(() => Number) for query-string coercion (same pattern as PaginationDto).

Created backend/src/likes/likes.dto.spec.ts asserting invalid inputs are rejected:

- page: 0, page: -5, page: 'abc' all produce validation errors
- limit: 0, limit: 101, limit: 9999, limit: 'many' all produce validation errors
- Empty object, valid values, and string numbers ('2', '10') all pass

---
Issue 3 – E2E test for primary endpoint (test/likes.e2e-spec.ts)

Created backend/test/likes.e2e-spec.ts. Uses a standalone Test.createTestingModule that registers only LikesController and LikesService (avoids pulling in PostsModule/SubscriptionsModule TypeORM chains). Overrides JwtAuthGuard with a value guard that injects requestD }. Tests cover:

- POST /v1/posts/:id/like → 201 on creation, 200 on repeat (idempotent), 404 fo
- DELETE /v1/posts/:id/like → 204 on success, 404 if no like exists
- GET /v1/posts/:id/likes → pagination shape, empty state, limit respected, 400
- GET /v1/posts/:id/likes/count → count 0 and correct count
- GET /v1/posts/:id/like/status → liked: false and liked: true

---
Issue 4 – Pagination / limit query support

LikesService.getLikesByPost(postId, page, limit) — new method using findAndCount with skip/take, returns { data, total, page, limit, hasMore }.

LikesController — new endpoint GET /v1/posts/:id/likes bound to GetLikesQueryDto. Validates and coerces page/limit from query string; returns the paginated result directly. Fits naturally next to the existing /count and /status routes.
## Changes

<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [ ] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [ ] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [ ] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [ ] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [ ] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [ ] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [ ] Happy path works end-to-end in a local environment
- [ ] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [ ] No regressions in closely related API or UI flows
- [ ] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [ ] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues

<!-- Closes #NNN -->

## Notes for reviewers

<!-- Anything that needs extra attention, known limitations, or follow-up work. -->
