### PR TITLE
chore(backend): add Husky pre-commit lint hook with lint-staged

### DIFF
--- a/backend/.husky/pre-commit
+++ b/backend/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+cd backend
+npx lint-staged

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,8 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\" --fix",
+    "lint:check": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "prepare": "cd .. && husky backend/.husky",
     "generate:openapi": "ts-node -r tsconfig-paths/register scripts/generate-openapi.ts",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -83,7 +85,19 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.20.0"
+    "typescript-eslint": "^8.20.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.3.0"
+  },
+  "lint-staged": {
+    "src/**/*.ts": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "test/**/*.ts": [
+      "eslint --fix",
+      "prettier --write"
+    ]
   },
   "jest": {
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:backend": "npm test --prefix backend",
     "test:frontend": "npm test --prefix frontend",
     "test:contract": "npm test --prefix contract",
-    "check": "npm run lint && npm run test && npm run build"
+    "check": "npm run lint && npm run test && npm run build",
+    "prepare": "npm ci --prefix backend && cd backend && npx husky install .husky"
   }
 }


### PR DESCRIPTION
This PR closes #1217.

## Summary

- **closes #1217** — Husky v9 and lint-staged v15 added to `backend/devDependencies`; `backend/.husky/pre-commit` hook runs `npx lint-staged` on commit; `lint-staged` config in `backend/package.json` runs `eslint --fix` and `prettier --write` on staged `src/**/*.ts` and `test/**/*.ts` files; root `package.json` gains a `prepare` script to install the hook after `npm install`

## Test plan
- [ ] `npm install` in `backend/` installs Husky and lint-staged
- [ ] Staging a `.ts` file with a lint error and running `git commit` triggers the hook and blocks the commit
- [ ] Staging a clean `.ts` file passes the hook and the commit proceeds
- [ ] `npm run lint:check` in `backend/` passes on the existing codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)