### PR TITLE
Fix/conversations error shape swagger throttle likes tests

### DIFF
--- a/backend/src/conversations/conversations.controller.spec.ts
+++ b/backend/src/conversations/conversations.controller.spec.ts
@@ -1,0 +1,140 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { ConversationsController } from './conversations.controller';
+import { ConversationsService } from './conversations.service';
+import { ConversationDto, MessageDto } from './dto';
+import { PaginatedResponseDto } from '../common/dto';
+import { ThrottlerModule } from '@nestjs/throttler';
+
+const mockConversation: ConversationDto = {
+  id: 'conv-1',
+  participant1Id: 'temp-user-id',
+  participant2Id: 'user-2',
+  lastMessageId: null,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+};
+
+const mockMessage: MessageDto = {
+  id: 'msg-1',
+  conversationId: 'conv-1',
+  senderId: 'temp-user-id',
+  content: 'Hello!',
+  isRead: false,
+  createdAt: new Date('2024-01-01'),
+};
+
+describe('ConversationsController', () => {
+  let controller: ConversationsController;
+  let service: jest.Mocked<
+    Pick<
+      ConversationsService,
+      'create' | 'findAll' | 'findOne' | 'getMessages' | 'sendMessage' | 'remove'
+    >
+  >;
+
+  beforeEach(async () => {
+    service = {
+      create: jest.fn().mockResolvedValue(mockConversation),
+      findAll: jest.fn().mockResolvedValue(
+        new PaginatedResponseDto([mockConversation], 20, null, false),
+      ),
+      findOne: jest.fn().mockResolvedValue(mockConversation),
+      getMessages: jest.fn().mockResolvedValue(
+        new PaginatedResponseDto([mockMessage], 20, null, false),
+      ),
+      sendMessage: jest.fn().mockResolvedValue(mockMessage),
+      remove: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ThrottlerModule.forRoot([{ name: 'default', ttl: 60000, limit: 100 }])],
+      controllers: [ConversationsController],
+      providers: [{ provide: ConversationsService, useValue: service }],
+    }).compile();
+
+    controller = module.get(ConversationsController);
+  });
+
+  describe('create', () => {
+    it('delegates to service and returns conversation dto', async () => {
+      const result = await controller.create({ participant2Id: 'user-2' });
+
+      expect(service.create).toHaveBeenCalledWith('temp-user-id', { participant2Id: 'user-2' });
+      expect(result).toEqual(mockConversation);
+    });
+  });
+
+  describe('findAll', () => {
+    it('delegates to service with pagination and returns paginated list', async () => {
+      const pagination = { limit: 10 };
+      const result = await controller.findAll(pagination);
+
+      expect(service.findAll).toHaveBeenCalledWith('temp-user-id', pagination);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toEqual(mockConversation);
+    });
+  });
+
+  describe('findOne', () => {
+    it('delegates to service and returns conversation dto', async () => {
+      const result = await controller.findOne('conv-1');
+
+      expect(service.findOne).toHaveBeenCalledWith('temp-user-id', 'conv-1');
+      expect(result).toEqual(mockConversation);
+    });
+
+    it('propagates NotFoundException from service', async () => {
+      service.findOne.mockRejectedValue(new NotFoundException('Conversation with id "missing" not found'));
+
+      await expect(controller.findOne('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getMessages', () => {
+    it('delegates to service with conversation id and pagination', async () => {
+      const pagination = { limit: 5 };
+      const result = await controller.getMessages('conv-1', pagination);
+
+      expect(service.getMessages).toHaveBeenCalledWith('temp-user-id', 'conv-1', pagination);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toEqual(mockMessage);
+    });
+
+    it('propagates NotFoundException when conversation does not exist', async () => {
+      service.getMessages.mockRejectedValue(new NotFoundException('Conversation with id "bad" not found'));
+
+      await expect(controller.getMessages('bad', {})).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('delegates to service and returns message dto', async () => {
+      const result = await controller.sendMessage('conv-1', { content: 'Hello!' });
+
+      expect(service.sendMessage).toHaveBeenCalledWith('temp-user-id', 'conv-1', { content: 'Hello!' });
+      expect(result).toEqual(mockMessage);
+    });
+
+    it('propagates NotFoundException when conversation does not exist', async () => {
+      service.sendMessage.mockRejectedValue(new NotFoundException('Conversation with id "bad" not found'));
+
+      await expect(controller.sendMessage('bad', { content: 'Hi' })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('delegates to service and returns void', async () => {
+      const result = await controller.remove('conv-1');
+
+      expect(service.remove).toHaveBeenCalledWith('temp-user-id', 'conv-1');
+      expect(result).toBeUndefined();
+    });
+
+    it('propagates NotFoundException when conversation does not exist', async () => {
+      service.remove.mockRejectedValue(new NotFoundException('Conversation with id "bad" not found'));
+
+      await expect(controller.remove('bad')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/conversations/conversations.controller.ts
+++ b/backend/src/conversations/conversations.controller.ts
@@ -8,21 +8,40 @@ import {
   Query,
   UseInterceptors,
   ClassSerializerInterceptor,
+  UseFilters,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiParam,
+  ApiBody,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import { ConversationsService } from './conversations.service';
 import { ConversationDto, MessageDto, CreateConversationDto, SendMessageDto } from './dto';
 import { PaginationDto, PaginatedResponseDto } from '../common/dto';
+import { ConversationsExceptionFilter } from './filters/conversations-exception.filter';
 
 @ApiTags('conversations')
+@UseFilters(new ConversationsExceptionFilter())
+@UseGuards(ThrottlerGuard)
 @Controller({ path: 'conversations', version: '1' })
 @UseInterceptors(ClassSerializerInterceptor)
 export class ConversationsController {
   constructor(private readonly conversationsService: ConversationsService) {}
 
   @Post()
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Create a new conversation' })
+  @ApiBody({ type: CreateConversationDto })
   @ApiResponse({ status: 201, description: 'Conversation created successfully', type: ConversationDto })
+  @ApiResponse({ status: 400, description: 'Bad request – validation error' })
+  @ApiResponse({ status: 429, description: 'Too many requests – rate limit exceeded' })
   async create(@Body() dto: CreateConversationDto): Promise<ConversationDto> {
     // TODO: Get user ID from auth token/session
     const userId = 'temp-user-id';
@@ -31,7 +50,10 @@ export class ConversationsController {
 
   @Get()
   @ApiOperation({ summary: 'List user conversations (paginated)' })
-  @ApiResponse({ status: 200, description: 'Paginated conversations list' })
+  @ApiQuery({ name: 'cursor', required: false, description: 'Pagination cursor (last conversation ID)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Number of items per page (default 20)' })
+  @ApiResponse({ status: 200, description: 'Paginated conversations list', type: PaginatedResponseDto })
+  @ApiResponse({ status: 400, description: 'Bad request – invalid pagination parameters' })
   async findAll(@Query() pagination: PaginationDto): Promise<PaginatedResponseDto<ConversationDto>> {
     // TODO: Get user ID from auth token/session
     const userId = 'temp-user-id';
@@ -40,7 +62,9 @@ export class ConversationsController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get a conversation by ID' })
+  @ApiParam({ name: 'id', description: 'Conversation UUID' })
   @ApiResponse({ status: 200, description: 'Conversation details', type: ConversationDto })
+  @ApiResponse({ status: 404, description: 'Conversation not found' })
   async findOne(@Param('id') id: string): Promise<ConversationDto> {
     // TODO: Get user ID from auth token/session
     const userId = 'temp-user-id';
@@ -49,7 +73,11 @@ export class ConversationsController {
 
   @Get(':id/messages')
   @ApiOperation({ summary: 'List messages in a conversation (paginated)' })
-  @ApiResponse({ status: 200, description: 'Paginated messages list' })
+  @ApiParam({ name: 'id', description: 'Conversation UUID' })
+  @ApiQuery({ name: 'cursor', required: false, description: 'Pagination cursor (last message ID)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Number of items per page (default 20)' })
+  @ApiResponse({ status: 200, description: 'Paginated messages list', type: PaginatedResponseDto })
+  @ApiResponse({ status: 404, description: 'Conversation not found' })
   async getMessages(
     @Param('id') id: string,
     @Query() pagination: PaginationDto,
@@ -60,8 +88,13 @@ export class ConversationsController {
   }
 
   @Post(':id/messages')
+  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiOperation({ summary: 'Send a message in a conversation' })
+  @ApiParam({ name: 'id', description: 'Conversation UUID' })
+  @ApiBody({ type: SendMessageDto })
   @ApiResponse({ status: 201, description: 'Message sent successfully', type: MessageDto })
+  @ApiResponse({ status: 404, description: 'Conversation not found' })
+  @ApiResponse({ status: 429, description: 'Too many requests – rate limit exceeded' })
   async sendMessage(@Param('id') id: string, @Body() dto: SendMessageDto): Promise<MessageDto> {
     // TODO: Get user ID from auth token/session
     const userId = 'temp-user-id';
@@ -69,8 +102,13 @@ export class ConversationsController {
   }
 
   @Delete(':id')
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a conversation' })
+  @ApiParam({ name: 'id', description: 'Conversation UUID' })
   @ApiResponse({ status: 204, description: 'Conversation deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Conversation not found' })
+  @ApiResponse({ status: 429, description: 'Too many requests – rate limit exceeded' })
   async remove(@Param('id') id: string): Promise<void> {
     // TODO: Get user ID from auth token/session
     const userId = 'temp-user-id';

--- a/backend/src/conversations/conversations.swagger.spec.ts
+++ b/backend/src/conversations/conversations.swagger.spec.ts
@@ -1,0 +1,58 @@
+import { ConversationsController } from './conversations.controller';
+
+describe('ConversationsController – Swagger/OpenAPI documentation', () => {
+  const proto = ConversationsController.prototype;
+
+  const endpoints = [
+    'create',
+    'findAll',
+    'findOne',
+    'getMessages',
+    'sendMessage',
+    'remove',
+  ];
+
+  it.each(endpoints)('%s has ApiOperation metadata', (method) => {
+    const metadata = Reflect.getMetadata('swagger/apiOperation', proto[method]);
+    expect(metadata).toBeDefined();
+    expect(typeof metadata.summary).toBe('string');
+    expect(metadata.summary.length).toBeGreaterThan(0);
+  });
+
+  it.each(endpoints)('%s has at least one ApiResponse metadata', (method) => {
+    const metadata = Reflect.getMetadata('swagger/apiResponse', proto[method]);
+    expect(metadata).toBeDefined();
+    expect(Object.keys(metadata).length).toBeGreaterThan(0);
+  });
+
+  it('controller class has ApiTags metadata', () => {
+    const tags = Reflect.getMetadata('swagger/apiUseTags', ConversationsController);
+    expect(tags).toContain('conversations');
+  });
+
+  const writeEndpoints = ['create', 'sendMessage', 'remove'];
+
+  it.each(writeEndpoints)('%s documents 429 rate-limit response', (method) => {
+    const metadata = Reflect.getMetadata('swagger/apiResponse', proto[method]);
+    expect(metadata?.['429']).toBeDefined();
+    expect(metadata['429'].description).toMatch(/too many requests/i);
+  });
+
+  const paramEndpoints = ['findOne', 'getMessages', 'sendMessage', 'remove'];
+
+  it.each(paramEndpoints)('%s has ApiParam metadata for conversation id', (method) => {
+    const params = Reflect.getMetadata('swagger/apiParameters', proto[method]);
+    expect(params).toBeDefined();
+    const idParam = params.find((p: { name: string }) => p.name === 'id');
+    expect(idParam).toBeDefined();
+  });
+
+  const queryEndpoints = ['findAll', 'getMessages'];
+
+  it.each(queryEndpoints)('%s documents cursor and limit query params', (method) => {
+    const queries = Reflect.getMetadata('swagger/apiParameters', proto[method]) ?? [];
+    const names = queries.map((q: { name: string }) => q.name);
+    expect(names).toContain('cursor');
+    expect(names).toContain('limit');
+  });
+});

--- a/backend/src/conversations/conversations.throttle.spec.ts
+++ b/backend/src/conversations/conversations.throttle.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConversationsController } from './conversations.controller';
+import { ConversationsService } from './conversations.service';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+
+describe('ConversationsController – rate limiting', () => {
+  let controller: ConversationsController;
+
+  const mockService = {
+    create: jest.fn().mockResolvedValue({ id: 'conv-1' }),
+    findAll: jest.fn().mockResolvedValue({ data: [], hasMore: false }),
+    findOne: jest.fn().mockResolvedValue({ id: 'conv-1' }),
+    getMessages: jest.fn().mockResolvedValue({ data: [], hasMore: false }),
+    sendMessage: jest.fn().mockResolvedValue({ id: 'msg-1' }),
+    remove: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ThrottlerModule.forRoot([{ name: 'default', ttl: 60000, limit: 100 }])],
+      controllers: [ConversationsController],
+      providers: [{ provide: ConversationsService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get(ConversationsController);
+  });
+
+  it('should have ThrottlerGuard applied at controller level', () => {
+    const guards = Reflect.getMetadata('__guards__', ConversationsController);
+    expect(guards).toBeDefined();
+    expect(guards).toContain(ThrottlerGuard);
+  });
+
+  it('should have throttle metadata on create', () => {
+    const metadata = Reflect.getMetadata(
+      'THROTTLER:LIMIT',
+      ConversationsController.prototype.create,
+    );
+    expect(metadata).toBeDefined();
+  });
+
+  it('should have throttle metadata on sendMessage', () => {
+    const metadata = Reflect.getMetadata(
+      'THROTTLER:LIMIT',
+      ConversationsController.prototype.sendMessage,
+    );
+    expect(metadata).toBeDefined();
+  });
+
+  it('should have throttle metadata on remove', () => {
+    const metadata = Reflect.getMetadata(
+      'THROTTLER:LIMIT',
+      ConversationsController.prototype.remove,
+    );
+    expect(metadata).toBeDefined();
+  });
+
+  it('read endpoints do not have explicit throttle overrides', () => {
+    for (const method of ['findAll', 'findOne', 'getMessages'] as const) {
+      const metadata = Reflect.getMetadata(
+        'THROTTLER:LIMIT',
+        ConversationsController.prototype[method],
+      );
+      expect(metadata).toBeUndefined();
+    }
+  });
+
+  it('write endpoints still delegate to service when within rate limit', async () => {
+    await controller.create({ participant2Id: 'user-2' });
+    expect(mockService.create).toHaveBeenCalled();
+
+    await controller.sendMessage('conv-1', { content: 'hi' });
+    expect(mockService.sendMessage).toHaveBeenCalled();
+
+    await controller.remove('conv-1');
+    expect(mockService.remove).toHaveBeenCalled();
+  });
+});

--- a/backend/src/conversations/filters/conversations-exception.filter.spec.ts
+++ b/backend/src/conversations/filters/conversations-exception.filter.spec.ts
@@ -1,0 +1,155 @@
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  ConversationsExceptionFilter,
+  ConversationErrorResponse,
+} from './conversations-exception.filter';
+
+describe('ConversationsExceptionFilter', () => {
+  let filter: ConversationsExceptionFilter;
+  let mockJson: jest.Mock;
+  let mockStatus: jest.Mock;
+  let mockHost: any;
+
+  beforeEach(() => {
+    filter = new ConversationsExceptionFilter();
+    mockJson = jest.fn();
+    mockStatus = jest.fn().mockReturnValue({ json: mockJson });
+    mockHost = {
+      switchToHttp: () => ({
+        getResponse: () => ({ status: mockStatus }),
+        getRequest: () => ({ url: '/v1/conversations', method: 'POST' }),
+      }),
+    };
+  });
+
+  function getResponseBody(): ConversationErrorResponse {
+    return mockJson.mock.calls[0][0];
+  }
+
+  it('returns consistent shape for BadRequestException', () => {
+    filter.catch(new BadRequestException('Invalid input'), mockHost);
+
+    const body = getResponseBody();
+    expect(mockStatus).toHaveBeenCalledWith(400);
+    expect(body).toEqual({
+      statusCode: 400,
+      error: 'BAD_REQUEST',
+      message: 'Invalid input',
+      timestamp: expect.any(String),
+      path: '/v1/conversations',
+    });
+  });
+
+  it('returns consistent shape for NotFoundException', () => {
+    filter.catch(new NotFoundException('Conversation not found'), mockHost);
+
+    const body = getResponseBody();
+    expect(mockStatus).toHaveBeenCalledWith(404);
+    expect(body.statusCode).toBe(404);
+    expect(body.error).toBe('NOT_FOUND');
+    expect(body.message).toBe('Conversation not found');
+    expect(body.path).toBe('/v1/conversations');
+  });
+
+  it('returns consistent shape for HttpException with object response', () => {
+    filter.catch(
+      new HttpException(
+        { error: 'CONFLICT', message: 'Conversation already exists' },
+        HttpStatus.CONFLICT,
+      ),
+      mockHost,
+    );
+
+    const body = getResponseBody();
+    expect(body.statusCode).toBe(409);
+    expect(body.error).toBe('CONFLICT');
+    expect(body.message).toBe('Conversation already exists');
+  });
+
+  it('returns consistent shape for HttpException with string response', () => {
+    filter.catch(
+      new HttpException('Forbidden', HttpStatus.FORBIDDEN),
+      mockHost,
+    );
+
+    const body = getResponseBody();
+    expect(body.statusCode).toBe(403);
+    expect(body.error).toBe('FORBIDDEN');
+    expect(body.message).toBe('Forbidden');
+  });
+
+  it('returns 500 for unknown errors', () => {
+    filter.catch(new Error('unexpected crash'), mockHost);
+
+    const body = getResponseBody();
+    expect(mockStatus).toHaveBeenCalledWith(500);
+    expect(body.statusCode).toBe(500);
+    expect(body.error).toBe('INTERNAL_ERROR');
+    expect(body.message).toBe('unexpected crash');
+  });
+
+  it('returns 500 for non-Error thrown values', () => {
+    filter.catch('string error', mockHost);
+
+    const body = getResponseBody();
+    expect(body.statusCode).toBe(500);
+    expect(body.error).toBe('INTERNAL_ERROR');
+    expect(body.message).toBe('Internal server error');
+  });
+
+  it('joins array messages into single string', () => {
+    filter.catch(
+      new HttpException(
+        { message: ['content must not be empty', 'content must be a string'], error: 'Bad Request' },
+        HttpStatus.BAD_REQUEST,
+      ),
+      mockHost,
+    );
+
+    const body = getResponseBody();
+    expect(body.message).toBe('content must not be empty; content must be a string');
+  });
+
+  it('handles 429 Too Many Requests', () => {
+    filter.catch(
+      new HttpException('Too many requests', HttpStatus.TOO_MANY_REQUESTS),
+      mockHost,
+    );
+
+    const body = getResponseBody();
+    expect(body.statusCode).toBe(429);
+    expect(body.error).toBe('TOO_MANY_REQUESTS');
+  });
+
+  it('includes timestamp in ISO format', () => {
+    filter.catch(new BadRequestException('test'), mockHost);
+
+    const body = getResponseBody();
+    expect(() => new Date(body.timestamp)).not.toThrow();
+    expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
+  });
+
+  it('all error responses have exactly the same keys', () => {
+    const exceptions = [
+      new BadRequestException('bad'),
+      new NotFoundException('missing'),
+      new HttpException('forbidden', 403),
+      new Error('crash'),
+    ];
+
+    const expectedKeys = ['statusCode', 'error', 'message', 'timestamp', 'path'];
+
+    for (const exception of exceptions) {
+      mockJson.mockClear();
+      mockStatus.mockClear().mockReturnValue({ json: mockJson });
+      filter.catch(exception, mockHost);
+      const body = getResponseBody();
+      expect(Object.keys(body).sort()).toEqual(expectedKeys.sort());
+    }
+  });
+});

--- a/backend/src/conversations/filters/conversations-exception.filter.ts
+++ b/backend/src/conversations/filters/conversations-exception.filter.ts
@@ -1,0 +1,89 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+export interface ConversationErrorResponse {
+  statusCode: number;
+  error: string;
+  message: string;
+  timestamp: string;
+  path: string;
+}
+
+@Catch()
+export class ConversationsExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(ConversationsExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const res = ctx.getResponse<Response>();
+    const req = ctx.getRequest<Request>();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const exceptionResponse =
+      exception instanceof HttpException ? exception.getResponse() : null;
+
+    let message = 'Internal server error';
+    let error = 'INTERNAL_ERROR';
+
+    if (exception instanceof HttpException) {
+      if (typeof exceptionResponse === 'string') {
+        message = exceptionResponse;
+      } else if (
+        typeof exceptionResponse === 'object' &&
+        exceptionResponse !== null
+      ) {
+        const resp = exceptionResponse as Record<string, unknown>;
+        message =
+          typeof resp.message === 'string'
+            ? resp.message
+            : Array.isArray(resp.message)
+              ? resp.message.join('; ')
+              : exception.message;
+        error = typeof resp.error === 'string' ? resp.error : this.statusToError(status);
+      }
+    } else if (exception instanceof Error) {
+      message = exception.message;
+    }
+
+    if (!error || error === message) {
+      error = this.statusToError(status);
+    }
+
+    const body: ConversationErrorResponse = {
+      statusCode: status,
+      error,
+      message,
+      timestamp: new Date().toISOString(),
+      path: req.url,
+    };
+
+    this.logger.warn(`${req.method} ${req.url} ${status} – ${message}`);
+
+    res.status(status).json(body);
+  }
+
+  private statusToError(status: number): string {
+    const map: Record<number, string> = {
+      400: 'BAD_REQUEST',
+      401: 'UNAUTHORIZED',
+      403: 'FORBIDDEN',
+      404: 'NOT_FOUND',
+      409: 'CONFLICT',
+      422: 'UNPROCESSABLE_ENTITY',
+      429: 'TOO_MANY_REQUESTS',
+      500: 'INTERNAL_ERROR',
+    };
+    return map[status] ?? 'UNKNOWN_ERROR';
+  }
+}

--- a/backend/src/likes/likes.controller.spec.ts
+++ b/backend/src/likes/likes.controller.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { LikesController } from './likes.controller';
+import { LikesService } from './likes.service';
+import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
+import { Reflector } from '@nestjs/core';
+
+const mockUser = { userId: 'user-1' };
+
+describe('LikesController', () => {
+  let controller: LikesController;
+  let service: jest.Mocked<
+    Pick<LikesService, 'addLike' | 'removeLike' | 'getLikesCount' | 'hasUserLiked'>
+  >;
+
+  beforeEach(async () => {
+    service = {
+      addLike: jest.fn().mockResolvedValue({ status: 201, message: 'Like added successfully' }),
+      removeLike: jest.fn().mockResolvedValue(undefined),
+      getLikesCount: jest.fn().mockResolvedValue(42),
+      hasUserLiked: jest.fn().mockResolvedValue(true),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LikesController],
+      providers: [
+        { provide: LikesService, useValue: service },
+        Reflector,
+        { provide: JwtAuthGuard, useValue: { canActivate: jest.fn().mockReturnValue(true) } },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn().mockReturnValue(true) })
+      .compile();
+
+    controller = module.get(LikesController);
+  });
+
+  describe('likePost', () => {
+    it('delegates to service and returns like response', async () => {
+      const result = await controller.likePost('post-1', mockUser);
+
+      expect(service.addLike).toHaveBeenCalledWith('post-1', 'user-1');
+      expect(result).toEqual({
+        message: 'Like added successfully',
+        postId: 'post-1',
+        liked: true,
+      });
+    });
+
+    it('returns idempotent response when post already liked', async () => {
+      service.addLike.mockResolvedValue({ status: 200, message: 'Post already liked' });
+
+      const result = await controller.likePost('post-1', mockUser);
+
+      expect(result).toEqual({
+        message: 'Post already liked',
+        postId: 'post-1',
+        liked: true,
+      });
+    });
+
+    it('propagates NotFoundException when post does not exist', async () => {
+      service.addLike.mockRejectedValue(new NotFoundException('Post not found'));
+
+      await expect(controller.likePost('bad-post', mockUser)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('unlikePost', () => {
+    it('delegates to service and returns void', async () => {
+      const result = await controller.unlikePost('post-1', mockUser);
+
+      expect(service.removeLike).toHaveBeenCalledWith('post-1', 'user-1');
+      expect(result).toBeUndefined();
+    });
+
+    it('propagates NotFoundException when like does not exist', async () => {
+      service.removeLike.mockRejectedValue(new NotFoundException('Like not found'));
+
+      await expect(controller.unlikePost('post-1', mockUser)).rejects.toThrow(NotFoundException);
+    });
+
+    it('propagates NotFoundException when post does not exist', async () => {
+      service.removeLike.mockRejectedValue(new NotFoundException('Post not found'));
+
+      await expect(controller.unlikePost('bad-post', mockUser)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getLikesCount', () => {
+    it('delegates to service and returns count', async () => {
+      const result = await controller.getLikesCount('post-1');
+
+      expect(service.getLikesCount).toHaveBeenCalledWith('post-1');
+      expect(result).toEqual({ count: 42 });
+    });
+
+    it('returns zero count when post has no likes', async () => {
+      service.getLikesCount.mockResolvedValue(0);
+
+      const result = await controller.getLikesCount('post-1');
+
+      expect(result).toEqual({ count: 0 });
+    });
+  });
+
+  describe('getLikeStatus', () => {
+    it('returns liked true when user has liked the post', async () => {
+      const result = await controller.getLikeStatus('post-1', mockUser);
+
+      expect(service.hasUserLiked).toHaveBeenCalledWith('post-1', 'user-1');
+      expect(result).toEqual({ liked: true });
+    });
+
+    it('returns liked false when user has not liked the post', async () => {
+      service.hasUserLiked.mockResolvedValue(false);
+
+      const result = await controller.getLikeStatus('post-1', mockUser);
+
+      expect(result).toEqual({ liked: false });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
closes #1019 
closes #1020 
closes #1021 
closes #1022
<!-- One or two sentences describing what this PR does and why. -->

## Changes

---
FILES CHANGED:
- backend/src/conversations/filters/conversations-exception.filter.ts (new)
- backend/src/conversations/filters/conversations-exception.filter.spec.ts (new)
- backend/src/conversations/conversations.controller.ts (modified)
- backend/src/conversations/conversations.controller.spec.ts (new)
- backend/src/conversations/conversations.swagger.spec.ts (new)
- backend/src/conversations/conversations.throttle.spec.ts (new)
- backend/src/likes/likes.controller.spec.ts (new)

---
Issue 1 — Consistent error shape on failure:
Created ConversationsExceptionFilter (mirrors SubscriptionsExceptionFilter) that catches all exceptions and normalizes them to { statusCode, error, message, timestamp, path }. Applied via @UseFilters(new ConversationsExceptionFilter()) on the controller. Filter spec covers all error types including array messages, unknown errors, and shape consistency.

Issue 2 — Swagger/OpenAPI documentation:
Added @ApiParam, @ApiBody, @ApiQuery (cursor + limit on paginated endpoints), and full @ApiResponse annotations covering 200/201/204/400/404/429 on every endpoint. A swagger spec (conversations.swagger.spec.ts) asserts ApiOperation, ApiResponse, ApiParam, ApiQuery metadata are present on every method.

Issue 3 — Rate limiting on write endpoints:
Added @UseGuards(ThrottlerGuard) at controller level and @Throttle overrides on the three write endpoints: create (10/min), sendMessage (30/min), remove (10/min). Read endpoints inherit the global limit. A throttle spec asserts guard metadata and per-endpoint THROTTLER:LIMIT metadata.

Issue 4 — Likes controller unit tests with mocked service:
Created likes.controller.spec.ts with a fully mocked LikesService covering all four controller methods (likePost, unlikePost, getLikesCount, getLikeStatus), including idempotency behavior, delegation assertions, and NotFoundException propagation.
<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [ ] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [ ] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [ ] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [ ] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [ ] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [ ] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [ ] Happy path works end-to-end in a local environment
- [ ] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [ ] No regressions in closely related API or UI flows
- [ ] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [ ] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues

<!-- Closes #NNN -->

## Notes for reviewers

<!-- Anything that needs extra attention, known limitations, or follow-up work. -->
