### PR TITLE
Fix/likes rate limit errors swagger games controller tests

### DIFF
--- a/backend/src/games/games.controller.spec.ts
+++ b/backend/src/games/games.controller.spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { GamesController } from './games.controller';
+import { GamesService } from './games.service';
+import { GameStatus } from './entities/game.entity';
+import { PaginatedResponseDto } from '../common/dto/paginated-response.dto';
+
+describe('GamesController', () => {
+  let controller: GamesController;
+
+  const mockPlayer = {
+    id: 'player-1',
+    game_id: 'game-1',
+    user_id: 'user-1',
+    balance: 1500,
+    turn_order: 1,
+  };
+
+  const mockGame = {
+    id: 'game-1',
+    status: GameStatus.PENDING,
+    number_of_players: 4,
+    players: [],
+    game_settings: { starting_cash: 1500, randomize_turn_order: false },
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+
+  const mockGamesService = {
+    findAll: jest.fn(),
+    joinGame: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GamesController],
+      providers: [{ provide: GamesService, useValue: mockGamesService }],
+    }).compile();
+
+    controller = module.get<GamesController>(GamesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('returns paginated list of games', async () => {
+      const paginated = new PaginatedResponseDto([mockGame], 1, 1, 20);
+      mockGamesService.findAll.mockResolvedValue(paginated);
+
+      const result = await controller.findAll({ page: 1, limit: 20 });
+
+      expect(result).toEqual(paginated);
+      expect(mockGamesService.findAll).toHaveBeenCalledWith({ page: 1, limit: 20 });
+    });
+
+    it('filters by status when provided', async () => {
+      const dto = { page: 1, limit: 10, status: GameStatus.PENDING };
+      const paginated = new PaginatedResponseDto([mockGame], 1, 1, 10);
+      mockGamesService.findAll.mockResolvedValue(paginated);
+
+      const result = await controller.findAll(dto);
+
+      expect(result).toEqual(paginated);
+      expect(mockGamesService.findAll).toHaveBeenCalledWith(dto);
+    });
+
+    it('returns empty page when no games match', async () => {
+      const paginated = new PaginatedResponseDto([], 0, 1, 20);
+      mockGamesService.findAll.mockResolvedValue(paginated);
+
+      const result = await controller.findAll({ page: 1, limit: 20 });
+
+      expect(result.data).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe('joinGame', () => {
+    it('returns the created player on success', async () => {
+      mockGamesService.joinGame.mockResolvedValue(mockPlayer);
+
+      const result = await controller.joinGame('game-1', { userId: 'user-1' });
+
+      expect(result).toEqual(mockPlayer);
+      expect(mockGamesService.joinGame).toHaveBeenCalledWith('game-1', 'user-1');
+    });
+
+    it('propagates NotFoundException when game does not exist', async () => {
+      mockGamesService.joinGame.mockRejectedValue(new NotFoundException('Game not found'));
+
+      await expect(controller.joinGame('missing', { userId: 'user-1' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('propagates BadRequestException when game is not PENDING', async () => {
+      mockGamesService.joinGame.mockRejectedValue(
+        new BadRequestException('Game is not in PENDING status'),
+      );
+
+      await expect(controller.joinGame('game-1', { userId: 'user-1' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('propagates BadRequestException when game is full', async () => {
+      mockGamesService.joinGame.mockRejectedValue(new BadRequestException('Game is full'));
+
+      await expect(controller.joinGame('game-1', { userId: 'user-1' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('propagates BadRequestException when player already joined', async () => {
+      mockGamesService.joinGame.mockRejectedValue(
+        new BadRequestException('Player already joined this game'),
+      );
+
+      await expect(controller.joinGame('game-1', { userId: 'user-1' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/backend/src/likes/likes.controller.ts
+++ b/backend/src/likes/likes.controller.ts
@@ -7,34 +7,55 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
-  ForbiddenException,
 } from '@nestjs/common';
 import {
   ApiOperation,
   ApiResponse,
   ApiTags,
   ApiBearerAuth,
+  ApiParam,
 } from '@nestjs/swagger';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import { LikesService } from './likes.service';
 import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth-module/decorators/current-user.decorator';
 
 @ApiTags('likes')
 @Controller({ path: 'posts', version: '1' })
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, ThrottlerGuard)
 @ApiBearerAuth()
 export class LikesController {
   constructor(private readonly likesService: LikesService) {}
 
   @Post(':id/like')
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Like a post' })
-  @ApiResponse({ status: 201, description: 'Like added successfully' })
-  @ApiResponse({ status: 200, description: 'Post already liked (idempotent)' })
+  @ApiParam({ name: 'id', description: 'Post ID' })
+  @ApiResponse({
+    status: 201,
+    description: 'Like added successfully',
+    schema: { example: { message: 'Like added successfully', postId: 'uuid', liked: true } },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Post already liked (idempotent)',
+    schema: { example: { message: 'Post already liked', postId: 'uuid', liked: true } },
+  })
   @ApiResponse({
     status: 403,
-    description: 'Forbidden - user does not have access to post',
+    description: 'Forbidden',
+    schema: { example: { statusCode: 403, message: 'Forbidden' } },
   })
-  @ApiResponse({ status: 404, description: 'Post not found' })
+  @ApiResponse({
+    status: 404,
+    description: 'Post not found',
+    schema: { example: { statusCode: 404, message: 'Post not found' } },
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Too Many Requests',
+    schema: { example: { statusCode: 429, message: 'Too Many Requests' } },
+  })
   async likePost(
     @Param('id') postId: string,
     @CurrentUser() user: { userId: string },
@@ -49,9 +70,20 @@ export class LikesController {
 
   @Delete(':id/like')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Unlike a post' })
+  @ApiParam({ name: 'id', description: 'Post ID' })
   @ApiResponse({ status: 204, description: 'Like removed successfully' })
-  @ApiResponse({ status: 404, description: 'Like not found' })
+  @ApiResponse({
+    status: 404,
+    description: 'Like not found',
+    schema: { example: { statusCode: 404, message: 'Like not found' } },
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Too Many Requests',
+    schema: { example: { statusCode: 429, message: 'Too Many Requests' } },
+  })
   async unlikePost(
     @Param('id') postId: string,
     @CurrentUser() user: { userId: string },
@@ -61,12 +93,17 @@ export class LikesController {
 
   @Get(':id/likes/count')
   @ApiOperation({ summary: 'Get likes count for a post' })
+  @ApiParam({ name: 'id', description: 'Post ID' })
   @ApiResponse({
     status: 200,
     description: 'Likes count',
     schema: { example: { count: 42 } },
   })
-  @ApiResponse({ status: 404, description: 'Post not found' })
+  @ApiResponse({
+    status: 404,
+    description: 'Post not found',
+    schema: { example: { statusCode: 404, message: 'Post not found' } },
+  })
   async getLikesCount(@Param('id') postId: string) {
     const count = await this.likesService.getLikesCount(postId);
     return { count };
@@ -74,12 +111,17 @@ export class LikesController {
 
   @Get(':id/like/status')
   @ApiOperation({ summary: 'Check if current user has liked a post' })
+  @ApiParam({ name: 'id', description: 'Post ID' })
   @ApiResponse({
     status: 200,
     description: 'Like status',
     schema: { example: { liked: true } },
   })
-  @ApiResponse({ status: 404, description: 'Post not found' })
+  @ApiResponse({
+    status: 404,
+    description: 'Post not found',
+    schema: { example: { statusCode: 404, message: 'Post not found' } },
+  })
   async getLikeStatus(
     @Param('id') postId: string,
     @CurrentUser() user: { userId: string },

--- a/backend/src/likes/likes.service.spec.ts
+++ b/backend/src/likes/likes.service.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { LikesService } from './likes.service';
+import { Like } from './entities/like.entity';
+import { PostsService } from '../posts/posts.service';
+
+describe('LikesService', () => {
+  let service: LikesService;
+
+  const mockPost = { id: 'post-1', authorId: 'author-1', isPremium: false };
+
+  const mockLikesRepository = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+    count: jest.fn(),
+  };
+
+  const mockPostsService = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LikesService,
+        { provide: getRepositoryToken(Like), useValue: mockLikesRepository },
+        { provide: PostsService, useValue: mockPostsService },
+      ],
+    }).compile();
+
+    service = module.get<LikesService>(LikesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('addLike', () => {
+    it('returns 201 message when like is new', async () => {
+      mockPostsService.findOne.mockResolvedValue(mockPost);
+      mockLikesRepository.findOne.mockResolvedValue(null);
+      mockLikesRepository.create.mockReturnValue({ userId: 'u1', postId: 'post-1' });
+      mockLikesRepository.save.mockResolvedValue({});
+
+      const result = await service.addLike('post-1', 'u1');
+
+      expect(result).toEqual({ status: 201, message: 'Like added successfully' });
+    });
+
+    it('returns 200 message when like already exists (idempotent)', async () => {
+      mockPostsService.findOne.mockResolvedValue(mockPost);
+      mockLikesRepository.findOne.mockResolvedValue({ id: 'like-1' });
+
+      const result = await service.addLike('post-1', 'u1');
+
+      expect(result).toEqual({ status: 200, message: 'Post already liked' });
+    });
+
+    it('propagates NotFoundException from PostsService (consistent error shape)', async () => {
+      mockPostsService.findOne.mockRejectedValue(new NotFoundException('Post not found'));
+
+      await expect(service.addLike('missing-post', 'u1')).rejects.toMatchObject({
+        status: 404,
+        message: 'Post not found',
+      });
+    });
+  });
+
+  describe('removeLike', () => {
+    it('removes the like successfully', async () => {
+      mockPostsService.findOne.mockResolvedValue(mockPost);
+      const like = { id: 'like-1' };
+      mockLikesRepository.findOne.mockResolvedValue(like);
+      mockLikesRepository.remove.mockResolvedValue(undefined);
+
+      await expect(service.removeLike('post-1', 'u1')).resolves.toBeUndefined();
+      expect(mockLikesRepository.remove).toHaveBeenCalledWith(like);
+    });
+
+    it('throws NotFoundException with consistent shape when like does not exist', async () => {
+      mockPostsService.findOne.mockResolvedValue(mockPost);
+      mockLikesRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.removeLike('post-1', 'u1')).rejects.toMatchObject({
+        status: 404,
+        message: 'Like not found',
+      });
+    });
+
+    it('propagates NotFoundException when post does not exist', async () => {
+      mockPostsService.findOne.mockRejectedValue(new NotFoundException('Post not found'));
+
+      await expect(service.removeLike('missing-post', 'u1')).rejects.toMatchObject({
+        status: 404,
+        message: 'Post not found',
+      });
+    });
+  });
+
+  describe('getLikesCount', () => {
+    it('returns the count from repository', async () => {
+      mockLikesRepository.count.mockResolvedValue(7);
+
+      const count = await service.getLikesCount('post-1');
+
+      expect(count).toBe(7);
+      expect(mockLikesRepository.count).toHaveBeenCalledWith({ where: { postId: 'post-1' } });
+    });
+  });
+
+  describe('hasUserLiked', () => {
+    it('returns true when like exists', async () => {
+      mockLikesRepository.findOne.mockResolvedValue({ id: 'like-1' });
+
+      expect(await service.hasUserLiked('post-1', 'u1')).toBe(true);
+    });
+
+    it('returns false when like does not exist', async () => {
+      mockLikesRepository.findOne.mockResolvedValue(null);
+
+      expect(await service.hasUserLiked('post-1', 'u1')).toBe(false);
+    });
+  });
+});

--- a/backend/src/likes/likes.throttle.spec.ts
+++ b/backend/src/likes/likes.throttle.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { Reflector } from '@nestjs/core';
+import { LikesController } from './likes.controller';
+import { LikesService } from './likes.service';
+import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
+
+describe('LikesController – rate limiting', () => {
+  let controller: LikesController;
+
+  const mockLikesService = {
+    addLike: jest.fn().mockResolvedValue({ status: 201, message: 'Like added successfully' }),
+    removeLike: jest.fn().mockResolvedValue(undefined),
+    getLikesCount: jest.fn().mockResolvedValue(0),
+    hasUserLiked: jest.fn().mockResolvedValue(false),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot([{ name: 'default', ttl: 60_000, limit: 10 }]),
+      ],
+      controllers: [LikesController],
+      providers: [
+        { provide: LikesService, useValue: mockLikesService },
+        { provide: JwtAuthGuard, useValue: { canActivate: () => true } },
+        Reflector,
+      ],
+    }).compile();
+
+    controller = module.get<LikesController>(LikesController);
+  });
+
+  it('should have ThrottlerGuard applied at controller level', () => {
+    const guards = Reflect.getMetadata('__guards__', LikesController);
+    expect(guards).toBeDefined();
+    expect(guards.some((g: unknown) => g === ThrottlerGuard)).toBe(true);
+  });
+
+  it('should have throttle metadata on likePost', () => {
+    const metadata = Reflect.getMetadata(
+      'THROTTLER:LIMIT',
+      LikesController.prototype.likePost,
+    );
+    expect(metadata).toBeDefined();
+  });
+
+  it('should have throttle metadata on unlikePost', () => {
+    const metadata = Reflect.getMetadata(
+      'THROTTLER:LIMIT',
+      LikesController.prototype.unlikePost,
+    );
+    expect(metadata).toBeDefined();
+  });
+
+  it('GET endpoints do not have per-route throttle metadata', () => {
+    const countMeta = Reflect.getMetadata(
+      'THROTTLER:LIMIT',
+      LikesController.prototype.getLikesCount,
+    );
+    const statusMeta = Reflect.getMetadata(
+      'THROTTLER:LIMIT',
+      LikesController.prototype.getLikeStatus,
+    );
+    expect(countMeta).toBeUndefined();
+    expect(statusMeta).toBeUndefined();
+  });
+
+  it('write endpoints delegate to service when within rate limit', async () => {
+    const user = { userId: 'u1' };
+    await controller.likePost('post-1', user);
+    expect(mockLikesService.addLike).toHaveBeenCalledWith('post-1', 'u1');
+
+    await controller.unlikePost('post-1', user);
+    expect(mockLikesService.removeLike).toHaveBeenCalledWith('post-1', 'u1');
+  });
+});


### PR DESCRIPTION
## Summary
closes #1027 
closes #1028 
closes #1029 
closes #1030
<!-- One or two sentences describing what this PR does and why. -->

## Changes

<!-- Bullet list of the key changes made. -->

FILES CHANGED:
- backend/src/likes/likes.controller.ts
- backend/src/likes/likes.service.spec.ts (new)
- backend/src/likes/likes.throttle.spec.ts (new)
- backend/src/games/games.controller.spec.ts (new)

---
What was done:

Issue 1 — Likes: consistent error shape on failure
LikesService already throws NestJS NotFoundException/ForbiddenException which produce the standard { statusCode, message } shape via NestJS's built-in exception layer. Added likes.service.spec.ts that verifies each failure path (addLike on missing post, removeLike on missing like/post) rejects with the correct status and message, confirming the consistent error shape contract.

Issue 2 — Likes: rate limiting on write endpoints
Updated likes.controller.ts to add ThrottlerGuard to @UseGuards at the controller level (alongside the existing JwtAuthGuard) and @Throttle({ default: { limit: 10, ttl: 60000 } }) on POST :id/like and DELETE :id/like. Read-only GET endpoints are left unthrottled. Added likes.throttle.spec.ts that verifies throttle metadata exists on write methods and not on read methods, following the same pattern as social-links and subscriptions.

Issue 3 — Likes: Swagger/OpenAPI documentation
Enriched all four endpoints in likes.controller.ts with @ApiParam for the id path parameter and explicit @ApiResponse entries with schema.example for every response code including 429 Too Many Requests.

Issue 4 — Games: controller unit tests with mocked service
Created games.controller.spec.ts with a fully mocked GamesService. Tests cover: findAll returning a paginated response, filtering by status, empty pages; joinGame success, and all four error cases (NotFoundException, BadRequestException for not-pending / full / already-joined).

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [ ] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [ ] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [ ] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [ ] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [ ] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [ ] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [ ] Happy path works end-to-end in a local environment
- [ ] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [ ] No regressions in closely related API or UI flows
- [ ] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [ ] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues

<!-- Closes #NNN -->

## Notes for reviewers

<!-- Anything that needs extra attention, known limitations, or follow-up work. -->
