### PR TITLE
fix(auth): return consistent error shape on failure

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpException,
   HttpStatus,
   Post,
+  UseFilters,
   UseInterceptors,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
@@ -18,8 +19,10 @@ import { RequestChallengeDto, VerifyChallengeDto } from './wallet-auth.dto';
 import { Deprecated, DeprecationInterceptor } from '../common/deprecation';
 import { PublicGuard } from '../auth-module/guards/public.guard';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
+import { AuthExceptionFilter } from './filters/auth-exception.filter';
 
 @ApiTags('auth')
+@UseFilters(new AuthExceptionFilter())
 @Controller({ path: 'auth', version: '1' })
 export class AuthController {
   private readonly serverNetwork = process.env.STELLAR_NETWORK ?? 'testnet';

--- a/backend/src/auth/filters/auth-exception.filter.spec.ts
+++ b/backend/src/auth/filters/auth-exception.filter.spec.ts
@@ -1,0 +1,178 @@
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  AuthExceptionFilter,
+  AuthErrorResponse,
+} from './auth-exception.filter';
+
+describe('AuthExceptionFilter', () => {
+  let filter: AuthExceptionFilter;
+  let mockJson: jest.Mock;
+  let mockStatus: jest.Mock;
+  let mockHost: any;
+
+  beforeEach(() => {
+    filter = new AuthExceptionFilter();
+    mockJson = jest.fn();
+    mockStatus = jest.fn().mockReturnValue({ json: mockJson });
+    mockHost = {
+      switchToHttp: () => ({
+        getResponse: () => ({ status: mockStatus }),
+        getRequest: () => ({ url: '/v1/auth/login', method: 'POST' }),
+      }),
+    };
+  });
+
+  function getBody(): AuthErrorResponse {
+    return mockJson.mock.calls[0][0];
+  }
+
+  it('returns consistent shape for BadRequestException', () => {
+    filter.catch(new BadRequestException('Invalid Stellar address'), mockHost);
+
+    const body = getBody();
+    expect(mockStatus).toHaveBeenCalledWith(400);
+    expect(body).toEqual({
+      statusCode: 400,
+      error: 'BAD_REQUEST',
+      message: 'Invalid Stellar address',
+      timestamp: expect.any(String),
+      path: '/v1/auth/login',
+    });
+  });
+
+  it('returns consistent shape for UnauthorizedException', () => {
+    filter.catch(new UnauthorizedException('Challenge expired'), mockHost);
+
+    const body = getBody();
+    expect(mockStatus).toHaveBeenCalledWith(401);
+    expect(body.statusCode).toBe(401);
+    expect(body.error).toBe('UNAUTHORIZED');
+    expect(body.message).toBe('Challenge expired');
+    expect(body.path).toBe('/v1/auth/login');
+  });
+
+  it('returns consistent shape for NotFoundException', () => {
+    filter.catch(new NotFoundException('Resource not found'), mockHost);
+
+    const body = getBody();
+    expect(body.statusCode).toBe(404);
+    expect(body.error).toBe('NOT_FOUND');
+    expect(body.message).toBe('Resource not found');
+  });
+
+  it('extracts error and message from HttpException with object response', () => {
+    filter.catch(
+      new HttpException(
+        {
+          error: 'NETWORK_MISMATCH',
+          message: 'Wallet network does not match server network',
+          expectedNetwork: 'testnet',
+          currentNetwork: 'mainnet',
+        },
+        HttpStatus.BAD_REQUEST,
+      ),
+      mockHost,
+    );
+
+    const body = getBody();
+    expect(body.statusCode).toBe(400);
+    expect(body.error).toBe('NETWORK_MISMATCH');
+    expect(body.message).toBe('Wallet network does not match server network');
+  });
+
+  it('returns consistent shape for HttpException with string response', () => {
+    filter.catch(
+      new HttpException('Something went wrong', HttpStatus.FORBIDDEN),
+      mockHost,
+    );
+
+    const body = getBody();
+    expect(body.statusCode).toBe(403);
+    expect(body.error).toBe('FORBIDDEN');
+    expect(body.message).toBe('Something went wrong');
+  });
+
+  it('returns 500 for unknown errors', () => {
+    filter.catch(new Error('unexpected crash'), mockHost);
+
+    const body = getBody();
+    expect(mockStatus).toHaveBeenCalledWith(500);
+    expect(body.statusCode).toBe(500);
+    expect(body.error).toBe('INTERNAL_ERROR');
+    expect(body.message).toBe('unexpected crash');
+  });
+
+  it('returns 500 for non-Error thrown values', () => {
+    filter.catch('string error', mockHost);
+
+    const body = getBody();
+    expect(body.statusCode).toBe(500);
+    expect(body.error).toBe('INTERNAL_ERROR');
+    expect(body.message).toBe('Internal server error');
+  });
+
+  it('joins array messages into a single string', () => {
+    filter.catch(
+      new HttpException(
+        { message: ['field1 is required', 'field2 must be a string'], error: 'Bad Request' },
+        HttpStatus.BAD_REQUEST,
+      ),
+      mockHost,
+    );
+
+    const body = getBody();
+    expect(body.message).toBe('field1 is required; field2 must be a string');
+    expect(body.error).toBe('BAD_REQUEST');
+  });
+
+  it('returns 429 for rate-limit errors', () => {
+    filter.catch(
+      new HttpException('Too many requests', HttpStatus.TOO_MANY_REQUESTS),
+      mockHost,
+    );
+
+    const body = getBody();
+    expect(body.statusCode).toBe(429);
+    expect(body.error).toBe('TOO_MANY_REQUESTS');
+  });
+
+  it('includes a valid ISO timestamp', () => {
+    filter.catch(new BadRequestException('test'), mockHost);
+
+    const body = getBody();
+    expect(() => new Date(body.timestamp)).not.toThrow();
+    expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
+  });
+
+  it('includes the request path', () => {
+    filter.catch(new BadRequestException('test'), mockHost);
+
+    expect(getBody().path).toBe('/v1/auth/login');
+  });
+
+  it('all error responses have exactly the same keys', () => {
+    const exceptions = [
+      new BadRequestException('bad'),
+      new UnauthorizedException('unauth'),
+      new NotFoundException('missing'),
+      new HttpException('forbidden', 403),
+      new Error('crash'),
+    ];
+
+    const expectedKeys = ['statusCode', 'error', 'message', 'timestamp', 'path'];
+
+    for (const exception of exceptions) {
+      mockJson.mockClear();
+      mockStatus.mockClear().mockReturnValue({ json: mockJson });
+      filter.catch(exception, mockHost);
+      const body = getBody();
+      expect(Object.keys(body).sort()).toEqual(expectedKeys.sort());
+    }
+  });
+});

--- a/backend/src/auth/filters/auth-exception.filter.ts
+++ b/backend/src/auth/filters/auth-exception.filter.ts
@@ -1,0 +1,92 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+export interface AuthErrorResponse {
+  statusCode: number;
+  error: string;
+  message: string;
+  timestamp: string;
+  path: string;
+}
+
+@Catch()
+export class AuthExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(AuthExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const res = ctx.getResponse<Response>();
+    const req = ctx.getRequest<Request>();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const exceptionResponse =
+      exception instanceof HttpException ? exception.getResponse() : null;
+
+    let message = 'Internal server error';
+    let error = 'INTERNAL_ERROR';
+
+    if (exception instanceof HttpException) {
+      if (typeof exceptionResponse === 'string') {
+        message = exceptionResponse;
+        error = this.statusToError(status);
+      } else if (
+        typeof exceptionResponse === 'object' &&
+        exceptionResponse !== null
+      ) {
+        const resp = exceptionResponse as Record<string, unknown>;
+        message =
+          typeof resp.message === 'string'
+            ? resp.message
+            : Array.isArray(resp.message)
+              ? resp.message.join('; ')
+              : exception.message;
+        // Use a custom error code only if it follows screaming-snake convention
+        // (e.g. NETWORK_MISMATCH). NestJS defaults like "Bad Request" fall back
+        // to the status-derived code so the shape stays consistent.
+        const rawError = typeof resp.error === 'string' ? resp.error : '';
+        error = /^[A-Z][A-Z0-9_]+$/.test(rawError)
+          ? rawError
+          : this.statusToError(status);
+      }
+    } else if (exception instanceof Error) {
+      message = exception.message;
+    }
+
+    const body: AuthErrorResponse = {
+      statusCode: status,
+      error,
+      message,
+      timestamp: new Date().toISOString(),
+      path: req.url,
+    };
+
+    this.logger.warn(`${req.method} ${req.url} ${status} – ${message}`);
+
+    res.status(status).json(body);
+  }
+
+  private statusToError(status: number): string {
+    const map: Record<number, string> = {
+      400: 'BAD_REQUEST',
+      401: 'UNAUTHORIZED',
+      403: 'FORBIDDEN',
+      404: 'NOT_FOUND',
+      409: 'CONFLICT',
+      422: 'UNPROCESSABLE_ENTITY',
+      429: 'TOO_MANY_REQUESTS',
+      500: 'INTERNAL_ERROR',
+    };
+    return map[status] ?? 'UNKNOWN_ERROR';
+  }
+}


### PR DESCRIPTION
Add AuthExceptionFilter to normalise all auth error responses to the same five-field envelope { statusCode, error, message, timestamp, path } regardless of whether the exception originates from a standard NestJS exception, a custom HttpException, or an unexpected runtime error.

Apply the filter at the AuthController class level so every endpoint (/login, /register, /challenge, /challenge/verify) is covered.

Closes #1051

## Summary

<!-- One or two sentences describing what this PR does and why. -->

## Changes

<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [ ] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [ ] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [ ] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [ ] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [ ] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [ ] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [ ] Happy path works end-to-end in a local environment
- [ ] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [ ] No regressions in closely related API or UI flows
- [ ] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [ ] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues

<!-- Closes #NNN -->

## Notes for reviewers

<!-- Anything that needs extra attention, known limitations, or follow-up work. -->
