### PR TITLE
Fix/auth swagger openapi docs

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -12,7 +12,13 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Throttle } from '@nestjs/throttler';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiHeader,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { WalletAuthService } from './wallet-auth.service';
 import { RequestChallengeDto, VerifyChallengeDto } from './wallet-auth.dto';
@@ -20,6 +26,21 @@ import { Deprecated, DeprecationInterceptor } from '../common/deprecation';
 import { PublicGuard } from '../auth-module/guards/public.guard';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
 import { AuthExceptionFilter } from './filters/auth-exception.filter';
+import { LoginBodyDto } from './dto/login-body.dto';
+import {
+  AuthErrorResponseDto,
+  ChallengeResponseDto,
+  SessionResponseDto,
+  TokenResponseDto,
+} from './dto/auth-responses.dto';
+
+const X_NETWORK_HEADER = {
+  name: 'x-network',
+  required: false,
+  description:
+    'Stellar network identifier (mainnet | testnet). When provided it must match the server network; mismatches are rejected with 400.',
+  schema: { type: 'string', example: 'testnet' },
+} as const;
 
 @ApiTags('auth')
 @UseFilters(new AuthExceptionFilter())
@@ -51,8 +72,11 @@ export class AuthController {
   @Post('login')
   @Throttle({ auth: { limit: 5, ttl: 60000 } })
   @ApiOperation({ summary: 'Authenticate with a Stellar wallet address' })
-  @ApiResponse({ status: 201, description: 'Session created' })
-  @ApiResponse({ status: 400, description: 'Invalid Stellar address' })
+  @ApiHeader(X_NETWORK_HEADER)
+  @ApiBody({ type: LoginBodyDto })
+  @ApiResponse({ status: 201, description: 'Session created', type: SessionResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid Stellar address or network mismatch', type: AuthErrorResponseDto })
+  @ApiResponse({ status: 429, description: 'Too many requests', type: AuthErrorResponseDto })
   async login(
     @Body() body: { address?: string },
     @Headers('x-network') requestNetwork?: string,
@@ -74,8 +98,11 @@ export class AuthController {
   })
   @UseInterceptors(new DeprecationInterceptor(new Reflector()))
   @ApiOperation({ summary: '[Deprecated] Register with a Stellar wallet address', deprecated: true })
-  @ApiResponse({ status: 201, description: 'Session created' })
-  @ApiResponse({ status: 400, description: 'Invalid Stellar address' })
+  @ApiHeader(X_NETWORK_HEADER)
+  @ApiBody({ type: LoginBodyDto })
+  @ApiResponse({ status: 201, description: 'Session created', type: SessionResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid Stellar address or network mismatch', type: AuthErrorResponseDto })
+  @ApiResponse({ status: 429, description: 'Too many requests', type: AuthErrorResponseDto })
   async register(
     @Body() body: { address?: string },
     @Headers('x-network') requestNetwork?: string,
@@ -88,15 +115,17 @@ export class AuthController {
     return this.authService.createSession(body.address!);
   }
 
-  /**
-   * POST /v1/auth/challenge
-   * Returns a one-time nonce the wallet must sign.
-   */
   @Post('challenge')
   @HttpCode(HttpStatus.OK)
   @Throttle({ auth: { limit: 5, ttl: 60000 } })
-  @ApiOperation({ summary: 'Request a sign-in challenge for a Stellar wallet' })
-  @ApiResponse({ status: 200, description: 'Nonce and expiry returned' })
+  @ApiOperation({
+    summary: 'Request a sign-in challenge for a Stellar wallet',
+    description: 'Returns a one-time nonce the wallet must sign. The challenge expires after 5 minutes.',
+  })
+  @ApiHeader(X_NETWORK_HEADER)
+  @ApiResponse({ status: 200, description: 'Nonce and expiry returned', type: ChallengeResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid Stellar address or network mismatch', type: AuthErrorResponseDto })
+  @ApiResponse({ status: 429, description: 'Too many requests', type: AuthErrorResponseDto })
   async requestChallenge(
     @Body() dto: RequestChallengeDto,
     @Headers('x-network') requestNetwork?: string,
@@ -108,17 +137,18 @@ export class AuthController {
     return this.walletAuthService.createChallenge(dto.address);
   }
 
-  /**
-   * POST /v1/auth/challenge/verify
-   * Verifies the signed nonce and issues a JWT on success.
-   */
   @Post('challenge/verify')
   @HttpCode(HttpStatus.OK)
   @Throttle({ auth: { limit: 5, ttl: 60000 } })
-  @ApiOperation({ summary: 'Verify wallet signature and receive JWT' })
-  @ApiResponse({ status: 200, description: 'JWT access token' })
-  @ApiResponse({ status: 400, description: 'Invalid signature' })
-  @ApiResponse({ status: 401, description: 'Expired or replayed challenge' })
+  @ApiOperation({
+    summary: 'Verify wallet signature and receive JWT',
+    description: 'Validates the Ed25519 signature against the previously issued nonce and returns a Bearer token on success.',
+  })
+  @ApiHeader(X_NETWORK_HEADER)
+  @ApiResponse({ status: 200, description: 'JWT access token', type: TokenResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid Stellar address or signature', type: AuthErrorResponseDto })
+  @ApiResponse({ status: 401, description: 'Expired or replayed challenge', type: AuthErrorResponseDto })
+  @ApiResponse({ status: 429, description: 'Too many requests', type: AuthErrorResponseDto })
   async verifyChallenge(
     @Body() dto: VerifyChallengeDto,
     @Headers('x-network') requestNetwork?: string,

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpException,
   HttpStatus,
   Post,
+  UseFilters,
   UseInterceptors,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
@@ -18,8 +19,10 @@ import { RequestChallengeDto, VerifyChallengeDto } from './wallet-auth.dto';
 import { Deprecated, DeprecationInterceptor } from '../common/deprecation';
 import { PublicGuard } from '../auth-module/guards/public.guard';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
+import { AuthExceptionFilter } from './filters/auth-exception.filter';
 
 @ApiTags('auth')
+@UseFilters(new AuthExceptionFilter())
 @Controller({ path: 'auth', version: '1' })
 export class AuthController {
   private readonly serverNetwork = process.env.STELLAR_NETWORK ?? 'testnet';

--- a/backend/src/auth/auth.swagger.spec.ts
+++ b/backend/src/auth/auth.swagger.spec.ts
@@ -1,0 +1,70 @@
+import { AuthController } from './auth.controller';
+
+describe('AuthController – Swagger/OpenAPI documentation', () => {
+  const proto = AuthController.prototype;
+
+  const endpoints = ['login', 'register', 'requestChallenge', 'verifyChallenge'];
+
+  it('controller class has ApiTags metadata', () => {
+    const tags = Reflect.getMetadata('swagger/apiUseTags', AuthController);
+    expect(tags).toContain('auth');
+  });
+
+  it.each(endpoints)('%s has ApiOperation metadata', (method) => {
+    const meta = Reflect.getMetadata('swagger/apiOperation', proto[method]);
+    expect(meta).toBeDefined();
+    expect(meta.summary).toBeDefined();
+    expect(meta.summary.length).toBeGreaterThan(0);
+  });
+
+  it.each(endpoints)('%s has at least one ApiResponse', (method) => {
+    const meta = Reflect.getMetadata('swagger/apiResponse', proto[method]);
+    expect(meta).toBeDefined();
+    expect(Object.keys(meta).length).toBeGreaterThan(0);
+  });
+
+  it.each(endpoints)('%s documents 429 rate-limit response', (method) => {
+    const meta = Reflect.getMetadata('swagger/apiResponse', proto[method]);
+    expect(meta['429']).toBeDefined();
+    expect(meta['429'].description).toMatch(/too many requests/i);
+  });
+
+  it.each(endpoints)('%s documents the x-network header', (method) => {
+    const params: Array<{ name: string; in: string }> | undefined =
+      Reflect.getMetadata('swagger/apiParameters', proto[method]);
+    expect(params).toBeDefined();
+    const header = params!.find((p) => p.name === 'x-network' && p.in === 'header');
+    expect(header).toBeDefined();
+  });
+
+  it.each(['login', 'register'])('%s has ApiBody metadata', (method) => {
+    // @ApiBody registers in swagger/apiParameters with { in: 'body' }
+    const params: Array<{ in: string; type?: unknown }> | undefined =
+      Reflect.getMetadata('swagger/apiParameters', proto[method]);
+    expect(params).toBeDefined();
+    const bodyParam = params!.find((p) => p.in === 'body');
+    expect(bodyParam).toBeDefined();
+    expect(bodyParam!.type).toBeDefined();
+  });
+
+  it('register is marked deprecated in ApiOperation', () => {
+    const meta = Reflect.getMetadata('swagger/apiOperation', proto['register']);
+    expect(meta.deprecated).toBe(true);
+  });
+
+  it('login documents a 400 error response', () => {
+    const meta = Reflect.getMetadata('swagger/apiResponse', proto['login']);
+    expect(meta['400']).toBeDefined();
+  });
+
+  it('verifyChallenge documents 401 unauthorized response', () => {
+    const meta = Reflect.getMetadata('swagger/apiResponse', proto['verifyChallenge']);
+    expect(meta['401']).toBeDefined();
+    expect(meta['401'].description).toMatch(/expired|replayed/i);
+  });
+
+  it('requestChallenge documents a 400 error response', () => {
+    const meta = Reflect.getMetadata('swagger/apiResponse', proto['requestChallenge']);
+    expect(meta['400']).toBeDefined();
+  });
+});

--- a/backend/src/auth/dto/auth-responses.dto.ts
+++ b/backend/src/auth/dto/auth-responses.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SessionResponseDto {
+  @ApiProperty({ description: 'Stellar address used as the user identifier' })
+  userId: string;
+
+  @ApiProperty({ description: 'Opaque session token' })
+  token: string;
+}
+
+export class ChallengeResponseDto {
+  @ApiProperty({ description: 'One-time nonce the wallet must sign' })
+  nonce: string;
+
+  @ApiProperty({ description: 'UTC datetime when this challenge expires (5 minutes from issuance)' })
+  expiresAt: Date;
+}
+
+export class TokenResponseDto {
+  @ApiProperty({ description: 'Signed JWT for use in Authorization: Bearer <token> headers' })
+  access_token: string;
+
+  @ApiProperty({ description: 'Token scheme', example: 'Bearer' })
+  token_type: string;
+}
+
+export class AuthErrorResponseDto {
+  @ApiProperty({ example: 400 })
+  statusCode: number;
+
+  @ApiProperty({ example: 'BAD_REQUEST', description: 'Screaming-snake error code' })
+  error: string;
+
+  @ApiProperty({ example: 'Invalid Stellar address' })
+  message: string;
+
+  @ApiProperty({ example: '2026-06-29T10:00:00.000Z', description: 'ISO 8601 timestamp' })
+  timestamp: string;
+
+  @ApiProperty({ example: '/v1/auth/login' })
+  path: string;
+}

--- a/backend/src/auth/dto/login-body.dto.ts
+++ b/backend/src/auth/dto/login-body.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LoginBodyDto {
+  @ApiProperty({
+    description: 'Stellar public key (G-strkey, 56 chars)',
+    example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  })
+  address: string;
+}

--- a/backend/src/auth/filters/auth-exception.filter.spec.ts
+++ b/backend/src/auth/filters/auth-exception.filter.spec.ts
@@ -1,0 +1,178 @@
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  AuthExceptionFilter,
+  AuthErrorResponse,
+} from './auth-exception.filter';
+
+describe('AuthExceptionFilter', () => {
+  let filter: AuthExceptionFilter;
+  let mockJson: jest.Mock;
+  let mockStatus: jest.Mock;
+  let mockHost: any;
+
+  beforeEach(() => {
+    filter = new AuthExceptionFilter();
+    mockJson = jest.fn();
+    mockStatus = jest.fn().mockReturnValue({ json: mockJson });
+    mockHost = {
+      switchToHttp: () => ({
+        getResponse: () => ({ status: mockStatus }),
+        getRequest: () => ({ url: '/v1/auth/login', method: 'POST' }),
+      }),
+    };
+  });
+
+  function getBody(): AuthErrorResponse {
+    return mockJson.mock.calls[0][0];
+  }
+
+  it('returns consistent shape for BadRequestException', () => {
+    filter.catch(new BadRequestException('Invalid Stellar address'), mockHost);
+
+    const body = getBody();
+    expect(mockStatus).toHaveBeenCalledWith(400);
+    expect(body).toEqual({
+      statusCode: 400,
+      error: 'BAD_REQUEST',
+      message: 'Invalid Stellar address',
+      timestamp: expect.any(String),
+      path: '/v1/auth/login',
+    });
+  });
+
+  it('returns consistent shape for UnauthorizedException', () => {
+    filter.catch(new UnauthorizedException('Challenge expired'), mockHost);
+
+    const body = getBody();
+    expect(mockStatus).toHaveBeenCalledWith(401);
+    expect(body.statusCode).toBe(401);
+    expect(body.error).toBe('UNAUTHORIZED');
+    expect(body.message).toBe('Challenge expired');
+    expect(body.path).toBe('/v1/auth/login');
+  });
+
+  it('returns consistent shape for NotFoundException', () => {
+    filter.catch(new NotFoundException('Resource not found'), mockHost);
+
+    const body = getBody();
+    expect(body.statusCode).toBe(404);
+    expect(body.error).toBe('NOT_FOUND');
+    expect(body.message).toBe('Resource not found');
+  });
+
+  it('extracts error and message from HttpException with object response', () => {
+    filter.catch(
+      new HttpException(
+        {
+          error: 'NETWORK_MISMATCH',
+          message: 'Wallet network does not match server network',
+          expectedNetwork: 'testnet',
+          currentNetwork: 'mainnet',
+        },
+        HttpStatus.BAD_REQUEST,
+      ),
+      mockHost,
+    );
+
+    const body = getBody();
+    expect(body.statusCode).toBe(400);
+    expect(body.error).toBe('NETWORK_MISMATCH');
+    expect(body.message).toBe('Wallet network does not match server network');
+  });
+
+  it('returns consistent shape for HttpException with string response', () => {
+    filter.catch(
+      new HttpException('Something went wrong', HttpStatus.FORBIDDEN),
+      mockHost,
+    );
+
+    const body = getBody();
+    expect(body.statusCode).toBe(403);
+    expect(body.error).toBe('FORBIDDEN');
+    expect(body.message).toBe('Something went wrong');
+  });
+
+  it('returns 500 for unknown errors', () => {
+    filter.catch(new Error('unexpected crash'), mockHost);
+
+    const body = getBody();
+    expect(mockStatus).toHaveBeenCalledWith(500);
+    expect(body.statusCode).toBe(500);
+    expect(body.error).toBe('INTERNAL_ERROR');
+    expect(body.message).toBe('unexpected crash');
+  });
+
+  it('returns 500 for non-Error thrown values', () => {
+    filter.catch('string error', mockHost);
+
+    const body = getBody();
+    expect(body.statusCode).toBe(500);
+    expect(body.error).toBe('INTERNAL_ERROR');
+    expect(body.message).toBe('Internal server error');
+  });
+
+  it('joins array messages into a single string', () => {
+    filter.catch(
+      new HttpException(
+        { message: ['field1 is required', 'field2 must be a string'], error: 'Bad Request' },
+        HttpStatus.BAD_REQUEST,
+      ),
+      mockHost,
+    );
+
+    const body = getBody();
+    expect(body.message).toBe('field1 is required; field2 must be a string');
+    expect(body.error).toBe('BAD_REQUEST');
+  });
+
+  it('returns 429 for rate-limit errors', () => {
+    filter.catch(
+      new HttpException('Too many requests', HttpStatus.TOO_MANY_REQUESTS),
+      mockHost,
+    );
+
+    const body = getBody();
+    expect(body.statusCode).toBe(429);
+    expect(body.error).toBe('TOO_MANY_REQUESTS');
+  });
+
+  it('includes a valid ISO timestamp', () => {
+    filter.catch(new BadRequestException('test'), mockHost);
+
+    const body = getBody();
+    expect(() => new Date(body.timestamp)).not.toThrow();
+    expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
+  });
+
+  it('includes the request path', () => {
+    filter.catch(new BadRequestException('test'), mockHost);
+
+    expect(getBody().path).toBe('/v1/auth/login');
+  });
+
+  it('all error responses have exactly the same keys', () => {
+    const exceptions = [
+      new BadRequestException('bad'),
+      new UnauthorizedException('unauth'),
+      new NotFoundException('missing'),
+      new HttpException('forbidden', 403),
+      new Error('crash'),
+    ];
+
+    const expectedKeys = ['statusCode', 'error', 'message', 'timestamp', 'path'];
+
+    for (const exception of exceptions) {
+      mockJson.mockClear();
+      mockStatus.mockClear().mockReturnValue({ json: mockJson });
+      filter.catch(exception, mockHost);
+      const body = getBody();
+      expect(Object.keys(body).sort()).toEqual(expectedKeys.sort());
+    }
+  });
+});

--- a/backend/src/auth/filters/auth-exception.filter.ts
+++ b/backend/src/auth/filters/auth-exception.filter.ts
@@ -1,0 +1,92 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+export interface AuthErrorResponse {
+  statusCode: number;
+  error: string;
+  message: string;
+  timestamp: string;
+  path: string;
+}
+
+@Catch()
+export class AuthExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(AuthExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const res = ctx.getResponse<Response>();
+    const req = ctx.getRequest<Request>();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const exceptionResponse =
+      exception instanceof HttpException ? exception.getResponse() : null;
+
+    let message = 'Internal server error';
+    let error = 'INTERNAL_ERROR';
+
+    if (exception instanceof HttpException) {
+      if (typeof exceptionResponse === 'string') {
+        message = exceptionResponse;
+        error = this.statusToError(status);
+      } else if (
+        typeof exceptionResponse === 'object' &&
+        exceptionResponse !== null
+      ) {
+        const resp = exceptionResponse as Record<string, unknown>;
+        message =
+          typeof resp.message === 'string'
+            ? resp.message
+            : Array.isArray(resp.message)
+              ? resp.message.join('; ')
+              : exception.message;
+        // Use a custom error code only if it follows screaming-snake convention
+        // (e.g. NETWORK_MISMATCH). NestJS defaults like "Bad Request" fall back
+        // to the status-derived code so the shape stays consistent.
+        const rawError = typeof resp.error === 'string' ? resp.error : '';
+        error = /^[A-Z][A-Z0-9_]+$/.test(rawError)
+          ? rawError
+          : this.statusToError(status);
+      }
+    } else if (exception instanceof Error) {
+      message = exception.message;
+    }
+
+    const body: AuthErrorResponse = {
+      statusCode: status,
+      error,
+      message,
+      timestamp: new Date().toISOString(),
+      path: req.url,
+    };
+
+    this.logger.warn(`${req.method} ${req.url} ${status} – ${message}`);
+
+    res.status(status).json(body);
+  }
+
+  private statusToError(status: number): string {
+    const map: Record<number, string> = {
+      400: 'BAD_REQUEST',
+      401: 'UNAUTHORIZED',
+      403: 'FORBIDDEN',
+      404: 'NOT_FOUND',
+      409: 'CONFLICT',
+      422: 'UNPROCESSABLE_ENTITY',
+      429: 'TOO_MANY_REQUESTS',
+      500: 'INTERNAL_ERROR',
+    };
+    return map[status] ?? 'UNKNOWN_ERROR';
+  }
+}


### PR DESCRIPTION
## Summary

<!-- One or two sentences describing what this PR does and why. -->

## Changes

<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [ ] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [ ] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [ ] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [ ] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [ ] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [ ] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [ ] Happy path works end-to-end in a local environment
- [ ] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [ ] No regressions in closely related API or UI flows
- [ ] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [ ] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues

<!-- Closes #NNN -->

## Notes for reviewers

<!-- Anything that needs extra attention, known limitations, or follow-up work. -->
closes #1052 