### PR TITLE
test(health): add DTO validation tests, e2e test, and checks pagination

### DIFF
--- a/backend/src/health/dto/health-query.dto.spec.ts
+++ b/backend/src/health/dto/health-query.dto.spec.ts
@@ -1,0 +1,52 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { HealthQueryDto } from './health-query.dto';
+
+async function validateDto(plain: object) {
+  return validate(plainToInstance(HealthQueryDto, plain));
+}
+
+describe('HealthQueryDto', () => {
+  it('accepts valid page and limit', async () => {
+    expect(await validateDto({ page: 1, limit: 10 })).toHaveLength(0);
+  });
+
+  it('accepts empty input (all fields optional)', async () => {
+    expect(await validateDto({})).toHaveLength(0);
+  });
+
+  it('rejects page = 0', async () => {
+    const errors = await validateDto({ page: 0 });
+    expect(errors.some((e) => e.property === 'page')).toBe(true);
+  });
+
+  it('rejects negative page', async () => {
+    const errors = await validateDto({ page: -1 });
+    expect(errors.some((e) => e.property === 'page')).toBe(true);
+  });
+
+  it('rejects non-integer page', async () => {
+    const errors = await validateDto({ page: 1.5 });
+    expect(errors.some((e) => e.property === 'page')).toBe(true);
+  });
+
+  it('rejects limit = 0', async () => {
+    const errors = await validateDto({ limit: 0 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('rejects limit > 100', async () => {
+    const errors = await validateDto({ limit: 101 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('rejects non-integer limit', async () => {
+    const errors = await validateDto({ limit: 2.5 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('accepts limit at boundary values 1 and 100', async () => {
+    expect(await validateDto({ limit: 1 })).toHaveLength(0);
+    expect(await validateDto({ limit: 100 })).toHaveLength(0);
+  });
+});

--- a/backend/src/health/dto/health-query.dto.ts
+++ b/backend/src/health/dto/health-query.dto.ts
@@ -1,0 +1,3 @@
+import { PaginationDto } from '../../common/dto';
+
+export class HealthQueryDto extends PaginationDto {}

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Res } from '@nestjs/common';
+import { Controller, Get, Query, Res } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import type { Response } from 'express';
@@ -10,6 +10,7 @@ import {
   SubsystemStatusDto,
   QueueMetricsDto,
 } from './dto/health-response.dto';
+import { HealthQueryDto } from './dto/health-query.dto';
 
 @ApiTags('health')
 @Controller({ path: 'health', version: '1' })
@@ -125,5 +126,13 @@ export class HealthController {
   @ApiResponse({ status: 429, description: 'Too many requests' })
   getQueueMetrics() {
     return this.healthService.getQueueMetrics();
+  }
+
+  @Get('checks')
+  @ApiOperation({ summary: 'Paginated list of available health check endpoints' })
+  @ApiResponse({ status: 200, description: 'Paginated health check list' })
+  @ApiResponse({ status: 400, description: 'Invalid pagination parameters' })
+  getHealthChecks(@Query() query: HealthQueryDto) {
+    return this.healthService.getHealthChecks(query.page, query.limit);
   }
 }

--- a/backend/src/health/health.service.ts
+++ b/backend/src/health/health.service.ts
@@ -186,4 +186,21 @@ export class HealthService {
       queues: this.queueMetrics.snapshot(),
     };
   }
+
+  private readonly HEALTH_CHECKS = [
+    { name: 'app', endpoint: '/health' },
+    { name: 'detailed', endpoint: '/health/detailed' },
+    { name: 'aggregate', endpoint: '/health/aggregate' },
+    { name: 'db', endpoint: '/health/db' },
+    { name: 'redis', endpoint: '/health/redis' },
+    { name: 'soroban', endpoint: '/health/soroban' },
+    { name: 'soroban-contract', endpoint: '/health/soroban-contract' },
+    { name: 'queue-metrics', endpoint: '/health/queue-metrics' },
+  ];
+
+  getHealthChecks(page = 1, limit = 20) {
+    const start = (page - 1) * limit;
+    const data = this.HEALTH_CHECKS.slice(start, start + limit);
+    return { data, total: this.HEALTH_CHECKS.length, page, limit };
+  }
 }

--- a/backend/test/health.e2e-spec.ts
+++ b/backend/test/health.e2e-spec.ts
@@ -1,0 +1,114 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  INestApplication,
+  ValidationPipe,
+  VersioningType,
+} from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { HealthController } from '../src/health/health.controller';
+import { HealthService } from '../src/health/health.service';
+import { DataSource } from 'typeorm';
+import { SorobanRpcService } from '../src/common/services/soroban-rpc.service';
+import { QueueMetricsService } from '../src/common/services/queue-metrics.service';
+
+describe('Health (e2e)', () => {
+  let app: INestApplication<App>;
+
+  const mockDataSource = { query: jest.fn().mockResolvedValue([1]) };
+  const mockSorobanRpcService = {
+    checkConnectivity: jest.fn().mockResolvedValue({ status: 'up' }),
+    checkKnownContract: jest.fn().mockResolvedValue({ status: 'up' }),
+  };
+  const mockQueueMetrics = { snapshot: jest.fn().mockReturnValue({}) };
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        HealthService,
+        { provide: DataSource, useValue: mockDataSource },
+        { provide: SorobanRpcService, useValue: mockSorobanRpcService },
+        { provide: QueueMetricsService, useValue: mockQueueMetrics },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('GET /v1/health', () => {
+    it('returns 200 with status up', () => {
+      return request(app.getHttpServer())
+        .get('/v1/health')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.status).toBe('up');
+          expect(res.body.timestamp).toBeDefined();
+        });
+    });
+
+    it('timestamp is a valid ISO string', () => {
+      return request(app.getHttpServer())
+        .get('/v1/health')
+        .expect(200)
+        .expect((res) => {
+          expect(new Date(res.body.timestamp as string).toISOString()).toBe(
+            res.body.timestamp,
+          );
+        });
+    });
+  });
+
+  describe('GET /v1/health/checks', () => {
+    it('returns paginated health checks with defaults', () => {
+      return request(app.getHttpServer())
+        .get('/v1/health/checks')
+        .expect(200)
+        .expect((res) => {
+          expect(Array.isArray(res.body.data)).toBe(true);
+          expect(res.body.total).toBeGreaterThan(0);
+          expect(res.body.page).toBe(1);
+          expect(res.body.limit).toBe(20);
+        });
+    });
+
+    it('respects limit query param', () => {
+      return request(app.getHttpServer())
+        .get('/v1/health/checks?limit=2')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data).toHaveLength(2);
+          expect(res.body.limit).toBe(2);
+        });
+    });
+
+    it('respects page query param', () => {
+      return request(app.getHttpServer())
+        .get('/v1/health/checks?page=2&limit=2')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.page).toBe(2);
+        });
+    });
+
+    it('rejects limit > 100 with 400', () => {
+      return request(app.getHttpServer())
+        .get('/v1/health/checks?limit=999')
+        .expect(400);
+    });
+
+    it('rejects page < 1 with 400', () => {
+      return request(app.getHttpServer())
+        .get('/v1/health/checks?page=0')
+        .expect(400);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `HealthQueryDto` with validation tests for invalid pagination inputs (#1064)
- Add e2e test for the primary `GET /v1/health` endpoint (#1065)
- Add `GET /health/checks` endpoint with `page`/`limit` pagination support (#1066)

> Note: #1063 (service unit tests for happy path) is already covered in the upstream `health.service.spec.ts`.

## Test plan
- [ ] Run `npm test` — all unit tests pass including new DTO validation tests
- [ ] Run `npm run test:e2e` — new `health.e2e-spec.ts` passes
- [ ] `GET /v1/health` returns `{ status: 'up', timestamp }` with 200
- [ ] `GET /v1/health/checks?page=1&limit=2` returns paginated results
- [ ] `GET /v1/health/checks?limit=999` returns 400 (invalid input)
- [ ] `GET /v1/health/checks?page=0` returns 400 (invalid input)

Closes #1063

closes #1064

closes  #1065,

closes #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)