### PR TITLE
test: cover feature flags controller

### DIFF
--- a/backend/src/feature-flags/feature-flags.controller.spec.ts
+++ b/backend/src/feature-flags/feature-flags.controller.spec.ts
@@ -1,0 +1,48 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FeatureFlagsController } from './feature-flags.controller';
+import {
+  FeatureFlagsService,
+  FeatureFlagsSnapshot,
+} from './feature-flags.service';
+
+describe('FeatureFlagsController', () => {
+  let controller: FeatureFlagsController;
+  let featureFlagsService: jest.Mocked<
+    Pick<FeatureFlagsService, 'getAllFlags'>
+  >;
+
+  beforeEach(async () => {
+    featureFlagsService = {
+      getAllFlags: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FeatureFlagsController],
+      providers: [
+        { provide: FeatureFlagsService, useValue: featureFlagsService },
+      ],
+    }).compile();
+
+    controller = module.get(FeatureFlagsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('returns the feature flag snapshot from the service', () => {
+    const snapshot: FeatureFlagsSnapshot = {
+      bookmarks: true,
+      earnings_withdrawals: false,
+      earnings_fee_transparency: true,
+      newSubscriptionFlow: true,
+      cryptoPayments: false,
+      referralCodes: true,
+      sorobanPoller: true,
+    };
+    featureFlagsService.getAllFlags.mockReturnValue(snapshot);
+
+    expect(controller.getFlags()).toBe(snapshot);
+    expect(featureFlagsService.getAllFlags).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- adds controller unit coverage for the feature flags endpoint
- verifies FeatureFlagsController delegates to the mocked FeatureFlagsService
- verifies the returned snapshot is passed through unchanged

Closes #1078

## Verification
- npm test --prefix backend -- feature-flags.controller.spec.ts
- npm test --prefix backend -- feature-flags.service.spec.ts feature-flags.controller.spec.ts
- git diff --check HEAD~1..HEAD -- backend/src/feature-flags/feature-flags.controller.spec.ts
- cd backend && npx --no-install eslint src/feature-flags/feature-flags.controller.spec.ts