### PR TITLE
Document feature flags OpenAPI response

### DIFF
--- a/backend/src/feature-flags/dto/feature-flags-response.dto.ts
+++ b/backend/src/feature-flags/dto/feature-flags-response.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { FeatureFlagsSnapshot } from '../feature-flags.service';
+
+export class FeatureFlagsResponseDto implements FeatureFlagsSnapshot {
+  @ApiProperty({
+    description: 'Whether bookmark features are enabled.',
+    example: false,
+  })
+  bookmarks!: boolean;
+
+  @ApiProperty({
+    description: 'Whether earnings withdrawal features are enabled.',
+    example: false,
+  })
+  earnings_withdrawals!: boolean;
+
+  @ApiProperty({
+    description: 'Whether earnings fee transparency features are enabled.',
+    example: false,
+  })
+  earnings_fee_transparency!: boolean;
+
+  @ApiProperty({
+    description: 'Whether the new subscription flow is enabled.',
+    example: false,
+  })
+  newSubscriptionFlow!: boolean;
+
+  @ApiProperty({
+    description: 'Whether crypto payment flows are enabled.',
+    example: false,
+  })
+  cryptoPayments!: boolean;
+
+  @ApiProperty({
+    description: 'Whether referral code features are enabled.',
+    example: false,
+  })
+  referralCodes!: boolean;
+
+  @ApiProperty({
+    description: 'Whether the Soroban poller is enabled.',
+    example: true,
+  })
+  sorobanPoller!: boolean;
+}

--- a/backend/src/feature-flags/feature-flags.controller.ts
+++ b/backend/src/feature-flags/feature-flags.controller.ts
@@ -1,6 +1,10 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { FeatureFlagsService } from './feature-flags.service';
+import {
+  FeatureFlagsService,
+  FeatureFlagsSnapshot,
+} from './feature-flags.service';
+import { FeatureFlagsResponseDto } from './dto/feature-flags-response.dto';
 
 @ApiTags('feature-flags')
 @Controller({ path: 'feature-flags', version: '1' })
@@ -8,9 +12,19 @@ export class FeatureFlagsController {
   constructor(private readonly featureFlagsService: FeatureFlagsService) {}
 
   @Get()
-  @ApiOperation({ summary: 'List all feature flags and their current state' })
-  @ApiResponse({ status: 200, description: 'Feature flags map' })
-  getFlags() {
+  @ApiOperation({
+    summary: 'List all feature flags and their current state',
+    description:
+      'Returns the currently enabled backend feature flags exposed to clients.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Feature flags and their current enabled state.',
+    type: FeatureFlagsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
+  getFlags(): FeatureFlagsSnapshot {
     return this.featureFlagsService.getAllFlags();
   }
 }

--- a/backend/src/feature-flags/feature-flags.swagger.spec.ts
+++ b/backend/src/feature-flags/feature-flags.swagger.spec.ts
@@ -1,0 +1,47 @@
+import { FeatureFlagsController } from './feature-flags.controller';
+
+describe('FeatureFlagsController - Swagger/OpenAPI documentation', () => {
+  const proto = FeatureFlagsController.prototype;
+
+  function getControllerMethod(name: 'getFlags'): object {
+    const value: unknown = Object.getOwnPropertyDescriptor(proto, name)?.value;
+
+    if (typeof value !== 'function') {
+      throw new Error(`Missing controller method: ${name}`);
+    }
+
+    return value;
+  }
+
+  it('controller carries the feature-flags API tag', () => {
+    const tags = Reflect.getMetadata(
+      'swagger/apiUseTags',
+      FeatureFlagsController,
+    ) as string[];
+
+    expect(tags).toContain('feature-flags');
+  });
+
+  it('documents the GET feature flags operation', () => {
+    const operation = Reflect.getMetadata(
+      'swagger/apiOperation',
+      getControllerMethod('getFlags'),
+    ) as { summary?: string; description?: string };
+
+    expect(operation.summary).toMatch(/feature flags/i);
+    expect(operation.description).toMatch(/currently enabled/i);
+  });
+
+  it('documents typed success and standard guarded responses', () => {
+    const responses = Reflect.getMetadata(
+      'swagger/apiResponse',
+      getControllerMethod('getFlags'),
+    ) as Record<string, { description?: string; type?: unknown }> | undefined;
+
+    expect(
+      (responses?.['200']?.type as { name?: string } | undefined)?.name,
+    ).toBe('FeatureFlagsResponseDto');
+    expect(responses?.['401']?.description).toMatch(/unauthorized/i);
+    expect(responses?.['429']?.description).toMatch(/too many requests/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add a typed Swagger response DTO for the feature flags endpoint
- document success, unauthorized, and rate-limit responses on GET /v1/feature-flags
- add a Swagger metadata regression spec for the feature-flags controller

## Verification
- npm test --prefix backend -- feature-flags.swagger.spec.ts --runInBand
- npm test --prefix backend -- feature-flags --runInBand
- npm run test:e2e --prefix backend -- feature-flags.e2e-spec.ts --runInBand -t "GET /v1/feature-flags returns|returns false for all flags|reflects FEATURE_NEW_SUBSCRIPTION_FLOW=true|reflects FEATURE_CRYPTO_PAYMENTS=true|reflects both flags enabled simultaneously"
- cd backend && npx --no-install eslint src/feature-flags/feature-flags.controller.ts src/feature-flags/dto/feature-flags-response.dto.ts src/feature-flags/feature-flags.swagger.spec.ts
- git diff --check -- backend/src/feature-flags/feature-flags.controller.ts backend/src/feature-flags/dto/feature-flags-response.dto.ts backend/src/feature-flags/feature-flags.swagger.spec.ts

Note: the full existing feature-flags e2e suite still has a pre-existing failing assertion for FEATURE_NEW_SUBSCRIPTION_FLOW=yes expecting false while the service currently parses yes as true; I left that runtime behavior unchanged.