### PR TITLE
feat(health): implement Redis PING health probe (#1356)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -63,6 +63,17 @@ STARTUP_PROBE_RPC=true
 STARTUP_RPC_RETRIES=3
 STARTUP_RPC_RETRY_DELAY_MS=2000
 
+# -----------------------------------------------------------------------------
+# Redis (OPTIONAL — cache / session store)
+# Used only by the /v1/health/redis and /v1/health/aggregate probes today.
+# Leave everything unset to disable: the health checks report "not_configured"
+# and Redis is skipped in the aggregate (no crash, no degraded status).
+# Prefer REDIS_URL; if unset, REDIS_HOST/REDIS_PORT are used instead.
+# -----------------------------------------------------------------------------
+REDIS_URL=
+REDIS_HOST=
+REDIS_PORT=6379
+
 # Contract IDs — set by CI after deploy, or resolved from artifact file
 # Resolution: see contract/docs/DEPLOYED_ENV.md
 # Env wins when either (1) CONTRACT_ID_MYFANS + CONTRACT_ID_MYFANS_TOKEN, or

--- a/backend/src/health/dto/health-response.dto.ts
+++ b/backend/src/health/dto/health-response.dto.ts
@@ -19,6 +19,17 @@ export class SubsystemStatusDto {
   error?: string;
 }
 
+export class RedisStatusDto {
+  @ApiProperty({ enum: ['up', 'down', 'not_configured'] })
+  status: 'up' | 'down' | 'not_configured';
+
+  @ApiProperty({ required: false, example: 5 })
+  latencyMs?: number;
+
+  @ApiProperty({ required: false, example: 'Connection refused' })
+  error?: string;
+}
+
 export class SorobanStatusDto {
   @ApiProperty({ enum: ['up', 'down', 'degraded'] })
   status: 'up' | 'down' | 'degraded';
@@ -73,8 +84,12 @@ export class AggregatedSubsystemsDto {
   @ApiProperty({ type: SubsystemStatusDto })
   database: SubsystemStatusDto;
 
-  @ApiProperty({ type: SubsystemStatusDto })
-  redis: SubsystemStatusDto;
+  @ApiProperty({
+    type: RedisStatusDto,
+    required: false,
+    description: 'Omitted when Redis is not configured.',
+  })
+  redis?: RedisStatusDto;
 
   @ApiProperty({ type: SorobanStatusDto })
   sorobanRpc: SorobanStatusDto;

--- a/backend/src/health/health.controller.spec.ts
+++ b/backend/src/health/health.controller.spec.ts
@@ -126,11 +126,11 @@ describe('HealthController', () => {
                 version: '0.0.1',
                 subsystems: {
                     database: { status: 'up' as const, latencyMs: 5 },
-                    redis: { status: 'down' as const, error: 'Redis not configured' },
+                    redis: { status: 'up' as const, latencyMs: 2 },
                     sorobanRpc: { status: 'up' as const, timestamp: new Date().toISOString() },
                     sorobanContract: { status: 'up' as const, timestamp: new Date().toISOString() },
                 },
-                summary: { total: 4, up: 3, degraded: 0, down: 1 },
+                summary: { total: 4, up: 4, degraded: 0, down: 0 },
             };
             mockHealthService.getAggregatedHealth.mockResolvedValue(health);
 
@@ -149,11 +149,11 @@ describe('HealthController', () => {
                 version: '0.0.1',
                 subsystems: {
                     database: { status: 'up' as const, latencyMs: 5 },
-                    redis: { status: 'down' as const, error: 'Redis not configured' },
+                    redis: { status: 'up' as const, latencyMs: 2 },
                     sorobanRpc: { status: 'degraded' as const, timestamp: new Date().toISOString() },
                     sorobanContract: { status: 'up' as const, timestamp: new Date().toISOString() },
                 },
-                summary: { total: 4, up: 2, degraded: 1, down: 1 },
+                summary: { total: 4, up: 3, degraded: 1, down: 0 },
             };
             mockHealthService.getAggregatedHealth.mockResolvedValue(health);
 
@@ -171,11 +171,11 @@ describe('HealthController', () => {
                 version: '0.0.1',
                 subsystems: {
                     database: { status: 'down' as const, latencyMs: 0, error: 'DB unreachable' },
-                    redis: { status: 'down' as const, error: 'Redis not configured' },
+                    redis: { status: 'up' as const, latencyMs: 2 },
                     sorobanRpc: { status: 'up' as const, timestamp: new Date().toISOString() },
                     sorobanContract: { status: 'up' as const, timestamp: new Date().toISOString() },
                 },
-                summary: { total: 4, up: 2, degraded: 0, down: 2 },
+                summary: { total: 4, up: 3, degraded: 0, down: 1 },
             };
             mockHealthService.getAggregatedHealth.mockResolvedValue(health);
 
@@ -219,23 +219,34 @@ describe('HealthController', () => {
     });
 
     describe('getRedisHealth', () => {
-        it('returns 503 when Redis is not configured', async () => {
-            mockHealthService.checkRedis.mockResolvedValue({ status: 'down', error: 'Redis not configured' });
-
-            const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
-            await controller.getRedisHealth(res);
-
-            expect(res.status).toHaveBeenCalledWith(503);
-            expect(res.json).toHaveBeenCalledWith({ status: 'down', error: 'Redis not configured' });
-        });
-
-        it('returns 200 when Redis is up', async () => {
-            mockHealthService.checkRedis.mockResolvedValue({ status: 'up' });
+        it('returns 200 when Redis is not configured (optional subsystem)', async () => {
+            mockHealthService.checkRedis.mockResolvedValue({ status: 'not_configured' });
 
             const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
             await controller.getRedisHealth(res);
 
             expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith({ status: 'not_configured' });
+        });
+
+        it('returns 200 with latency when Redis is up', async () => {
+            mockHealthService.checkRedis.mockResolvedValue({ status: 'up', latencyMs: 3 });
+
+            const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+            await controller.getRedisHealth(res);
+
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith({ status: 'up', latencyMs: 3 });
+        });
+
+        it('returns 503 when a configured Redis is down', async () => {
+            mockHealthService.checkRedis.mockResolvedValue({ status: 'down', error: 'connect ECONNREFUSED' });
+
+            const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+            await controller.getRedisHealth(res);
+
+            expect(res.status).toHaveBeenCalledWith(503);
+            expect(res.json).toHaveBeenCalledWith({ status: 'down', error: 'connect ECONNREFUSED' });
         });
     });
 

--- a/backend/src/health/health.service.spec.ts
+++ b/backend/src/health/health.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import * as net from 'net';
 import { HealthService } from './health.service';
 import { SorobanRpcService } from '../common/services/soroban-rpc.service';
 import { QueueMetricsService } from '../common/services/queue-metrics.service';
@@ -10,7 +11,18 @@ describe('HealthService', () => {
     let mockSorobanRpcService: any;
     let mockQueueMetrics: any;
 
+    const REDIS_ENV_KEYS = ['REDIS_URL', 'REDIS_HOST', 'REDIS_PORT'];
+    let savedRedisEnv: Record<string, string | undefined>;
+
     beforeEach(async () => {
+        // Isolate the Redis probe from the runner's environment so tests are
+        // deterministic. Individual tests opt in by setting REDIS_URL.
+        savedRedisEnv = {};
+        for (const key of REDIS_ENV_KEYS) {
+            savedRedisEnv[key] = process.env[key];
+            delete process.env[key];
+        }
+
         mockDataSource = {
             query: jest.fn(),
         };
@@ -34,6 +46,16 @@ describe('HealthService', () => {
         }).compile();
 
         service = module.get<HealthService>(HealthService);
+    });
+
+    afterEach(() => {
+        for (const key of REDIS_ENV_KEYS) {
+            if (savedRedisEnv[key] === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = savedRedisEnv[key];
+            }
+        }
     });
 
     describe('getHealth', () => {
@@ -211,10 +233,166 @@ describe('HealthService', () => {
     });
 
     describe('checkRedis', () => {
-        it('should return down with message', async () => {
+        it('returns not_configured when no Redis env is set', async () => {
+            const pingSpy = jest.spyOn(service as any, 'pingRedis');
+
             const result = await service.checkRedis();
+
+            expect(result.status).toBe('not_configured');
+            expect(result.error).toBeUndefined();
+            // No socket should be opened when Redis is unconfigured.
+            expect(pingSpy).not.toHaveBeenCalled();
+        });
+
+        it('returns up with latency when PING succeeds', async () => {
+            process.env.REDIS_URL = 'redis://localhost:6379';
+            const pingSpy = jest
+                .spyOn(service as any, 'pingRedis')
+                .mockResolvedValue(undefined);
+
+            const result = await service.checkRedis();
+
+            expect(result.status).toBe('up');
+            expect(typeof result.latencyMs).toBe('number');
+            expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+            expect(pingSpy).toHaveBeenCalledWith('redis://localhost:6379', expect.any(Number));
+        });
+
+        it('returns down with the error when the connection fails', async () => {
+            process.env.REDIS_URL = 'redis://bad-host:6379';
+            jest
+                .spyOn(service as any, 'pingRedis')
+                .mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+            const result = await service.checkRedis();
+
             expect(result.status).toBe('down');
-            expect(result.error).toBe('Redis not configured');
+            expect(result.error).toBe('connect ECONNREFUSED');
+            expect(typeof result.latencyMs).toBe('number');
+        });
+
+        it('returns down when PING replies with an unexpected value', async () => {
+            process.env.REDIS_URL = 'redis://localhost:6379';
+            jest
+                .spyOn(service as any, 'pingRedis')
+                .mockRejectedValue(new Error('Unexpected PING reply: NOPE'));
+
+            const result = await service.checkRedis();
+
+            expect(result.status).toBe('down');
+            expect(result.error).toContain('NOPE');
+        });
+
+        it('builds a URL from REDIS_HOST / REDIS_PORT when REDIS_URL is absent', async () => {
+            process.env.REDIS_HOST = 'cache.internal';
+            process.env.REDIS_PORT = '6380';
+            const pingSpy = jest
+                .spyOn(service as any, 'pingRedis')
+                .mockResolvedValue(undefined);
+
+            await service.checkRedis();
+
+            expect(pingSpy).toHaveBeenCalledWith('redis://cache.internal:6380', expect.any(Number));
+        });
+    });
+
+    describe('pingRedis (against a fake RESP server)', () => {
+        const servers: net.Server[] = [];
+        const openSockets: net.Socket[] = [];
+
+        const startServer = (handler: (socket: net.Socket) => void): Promise<number> =>
+            new Promise((resolve) => {
+                const server = net.createServer((socket) => {
+                    openSockets.push(socket);
+                    handler(socket);
+                });
+                servers.push(server);
+                server.listen(0, '127.0.0.1', () => {
+                    resolve((server.address() as net.AddressInfo).port);
+                });
+            });
+
+        afterEach(async () => {
+            // Force-close any lingering server-side sockets (e.g. the silent
+            // timeout server) so server.close() can resolve.
+            for (const s of openSockets) s.destroy();
+            openSockets.length = 0;
+            await Promise.all(
+                servers.map((s) => new Promise<void>((r) => s.close(() => r()))),
+            );
+            servers.length = 0;
+        });
+
+        it('reports up when the server replies +PONG', async () => {
+            const port = await startServer((socket) => {
+                socket.on('data', () => socket.write('+PONG\r\n'));
+            });
+            process.env.REDIS_URL = `redis://127.0.0.1:${port}`;
+
+            const result = await service.checkRedis();
+
+            expect(result.status).toBe('up');
+            expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+        });
+
+        it('sends AUTH before PING when the URL carries a password', async () => {
+            const received: string[] = [];
+            const port = await startServer((socket) => {
+                socket.on('data', (buf) => {
+                    const msg = buf.toString();
+                    received.push(msg.trim());
+                    if (msg.startsWith('AUTH')) socket.write('+OK\r\n');
+                    else if (msg.startsWith('PING')) socket.write('+PONG\r\n');
+                });
+            });
+            process.env.REDIS_URL = `redis://:s3cr3t@127.0.0.1:${port}`;
+
+            const result = await service.checkRedis();
+
+            expect(result.status).toBe('up');
+            expect(received[0]).toContain('AUTH');
+            expect(received[0]).toContain('s3cr3t');
+            expect(received.some((m) => m.includes('PING'))).toBe(true);
+        });
+
+        it('reports down with the RESP error when the server rejects', async () => {
+            const port = await startServer((socket) => {
+                socket.on('data', () => socket.write('-NOAUTH Authentication required\r\n'));
+            });
+            process.env.REDIS_URL = `redis://127.0.0.1:${port}`;
+
+            const result = await service.checkRedis();
+
+            expect(result.status).toBe('down');
+            expect(result.error).toContain('NOAUTH');
+        });
+
+        it('reports down on an unexpected reply', async () => {
+            const port = await startServer((socket) => {
+                socket.on('data', () => socket.write('+WAT\r\n'));
+            });
+            process.env.REDIS_URL = `redis://127.0.0.1:${port}`;
+
+            const result = await service.checkRedis();
+
+            expect(result.status).toBe('down');
+            expect(result.error).toContain('WAT');
+        });
+
+        it('rejects when the server never replies (timeout)', async () => {
+            const port = await startServer(() => {
+                // Accept the connection but stay silent.
+            });
+
+            await expect(
+                (service as any).pingRedis(`redis://127.0.0.1:${port}`, 80),
+            ).rejects.toThrow(/timed out/);
+        });
+
+        it('rejects an invalid URL without opening a socket', async () => {
+            await expect(
+                (service as any).pingRedis('not-a-valid-url', 100),
+            ).rejects.toThrow(/Invalid Redis URL/);
         });
     });
 
@@ -231,22 +409,56 @@ describe('HealthService', () => {
     });
 
     describe('getAggregatedHealth', () => {
-        it('should return up when all subsystems are up', async () => {
+        it('should return up when all subsystems are up and Redis is unconfigured', async () => {
             mockDataSource.query.mockResolvedValue([1]);
             mockSorobanRpcService.checkConnectivity.mockResolvedValue({ status: 'up', timestamp: new Date().toISOString() });
             mockSorobanRpcService.checkKnownContract.mockResolvedValue({ status: 'up', timestamp: new Date().toISOString() });
 
             const result = await service.getAggregatedHealth();
 
-            expect(result.status).toBe('degraded');
-            expect(result.summary.total).toBe(4);
-            // database + sorobanRpc + sorobanContract are up; redis is down (not configured)
+            // Redis unconfigured is skipped entirely, so it neither counts nor
+            // degrades the aggregate.
+            expect(result.status).toBe('up');
+            expect(result.summary.total).toBe(3);
             expect(result.summary.up).toBe(3);
-            expect(result.summary.down).toBe(1); // redis
+            expect(result.summary.down).toBe(0);
             expect(result.subsystems.database.status).toBe('up');
             expect(result.subsystems.sorobanRpc.status).toBe('up');
             expect(result.subsystems.sorobanContract.status).toBe('up');
-            expect(result.subsystems.redis.status).toBe('down');
+            expect(result.subsystems.redis).toBeUndefined();
+        });
+
+        it('includes Redis in the summary when it is configured and up', async () => {
+            process.env.REDIS_URL = 'redis://localhost:6379';
+            jest.spyOn(service as any, 'pingRedis').mockResolvedValue(undefined);
+            mockDataSource.query.mockResolvedValue([1]);
+            mockSorobanRpcService.checkConnectivity.mockResolvedValue({ status: 'up', timestamp: new Date().toISOString() });
+            mockSorobanRpcService.checkKnownContract.mockResolvedValue({ status: 'up', timestamp: new Date().toISOString() });
+
+            const result = await service.getAggregatedHealth();
+
+            expect(result.status).toBe('up');
+            expect(result.summary.total).toBe(4);
+            expect(result.summary.up).toBe(4);
+            expect(result.subsystems.redis?.status).toBe('up');
+        });
+
+        it('degrades the aggregate when configured Redis is down', async () => {
+            process.env.REDIS_URL = 'redis://localhost:6379';
+            jest
+                .spyOn(service as any, 'pingRedis')
+                .mockRejectedValue(new Error('connect ECONNREFUSED'));
+            mockDataSource.query.mockResolvedValue([1]);
+            mockSorobanRpcService.checkConnectivity.mockResolvedValue({ status: 'up', timestamp: new Date().toISOString() });
+            mockSorobanRpcService.checkKnownContract.mockResolvedValue({ status: 'up', timestamp: new Date().toISOString() });
+
+            const result = await service.getAggregatedHealth();
+
+            // DB is up, so a down Redis degrades rather than takes the service down.
+            expect(result.status).toBe('degraded');
+            expect(result.summary.total).toBe(4);
+            expect(result.summary.down).toBe(1);
+            expect(result.subsystems.redis?.status).toBe('down');
         });
 
         it('should return down when database is down', async () => {

--- a/backend/src/health/health.service.ts
+++ b/backend/src/health/health.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common';
+import * as net from 'net';
+import * as tls from 'tls';
 import { DataSource } from 'typeorm';
 import { SorobanRpcService, SorobanHealthStatus } from '../common/services/soroban-rpc.service';
 import { QueueMetricsService, QueueSnapshot } from '../common/services/queue-metrics.service';
@@ -6,6 +8,19 @@ import { QueueMetricsService, QueueSnapshot } from '../common/services/queue-met
 export interface HealthCheckResult {
     status: 'up' | 'down' | 'degraded';
     timestamp: string;
+}
+
+/**
+ * Result of the Redis PING probe.
+ *
+ * Redis is an optional cache/session store. When no connection is configured
+ * the probe reports `not_configured` rather than `down`, so an absent Redis
+ * does not drag the aggregate health to `degraded`.
+ */
+export interface RedisHealthStatus {
+    status: 'up' | 'down' | 'not_configured';
+    latencyMs?: number;
+    error?: string;
 }
 
 export interface DetailedHealthCheckResult extends HealthCheckResult {
@@ -23,7 +38,8 @@ export interface AggregatedHealthResult {
   version: string;
   subsystems: {
     database: { status: 'up' | 'down' | 'degraded'; latencyMs?: number; error?: string };
-    redis: { status: 'up' | 'down' | 'degraded'; latencyMs?: number; error?: string };
+    // Omitted entirely when Redis is not configured (optional subsystem).
+    redis?: RedisHealthStatus;
     sorobanRpc: SorobanHealthStatus;
     sorobanContract: SorobanHealthStatus;
   };
@@ -39,6 +55,9 @@ const START_TIME = Date.now();
 
 @Injectable()
 export class HealthService {
+  /** Upper bound for connecting to Redis and awaiting the PING reply. */
+  private static readonly REDIS_PING_TIMEOUT_MS = 2000;
+
   constructor(
     private dataSource: DataSource,
     private sorobanRpcService: SorobanRpcService,
@@ -103,12 +122,16 @@ export class HealthService {
       this.checkSorobanContract(),
     ]);
 
+    // An unconfigured Redis is skipped so it neither counts toward the summary
+    // nor degrades the aggregate status.
+    const redisConfigured = redisHealth.status !== 'not_configured';
+
     const subsystems = [
       dbHealth.status,
-      redisHealth.status,
+      ...(redisConfigured ? [redisHealth.status] : []),
       rpcHealth.status,
       contractHealth.status,
-    ] as const;
+    ];
 
     const summary = {
       total: subsystems.length,
@@ -132,7 +155,7 @@ export class HealthService {
       version: process.env.npm_package_version ?? 'unknown',
       subsystems: {
         database: dbHealth,
-        redis: redisHealth,
+        ...(redisConfigured ? { redis: redisHealth } : {}),
         sorobanRpc: rpcHealth,
         sorobanContract: contractHealth,
       },
@@ -165,11 +188,137 @@ export class HealthService {
     }
   }
 
-  async checkRedis(): Promise<{ status: 'up' | 'down' | 'degraded'; latencyMs?: number; error?: string }> {
-    // Redis is not yet wired — return a stable 'down' so the aggregator can
-    // include it in the summary without crashing. When Redis is configured,
-    // replace this stub with a real PING check.
-    return { status: 'down', error: 'Redis not configured' };
+  /**
+   * Latency-measured Redis PING probe.
+   *
+   * - Connection is read from `REDIS_URL`, falling back to `REDIS_HOST` /
+   *   `REDIS_PORT` (the pair used by docker-compose).
+   * - When nothing is configured the probe returns `not_configured` and does
+   *   not open a socket.
+   * - A configured but unreachable Redis (bad URL, refused connection, PING
+   *   timeout) returns `down` with the error message.
+   */
+  async checkRedis(): Promise<RedisHealthStatus> {
+    const url = this.getRedisUrl();
+    if (!url) {
+      return { status: 'not_configured' };
+    }
+
+    const start = Date.now();
+    try {
+      await this.pingRedis(url, HealthService.REDIS_PING_TIMEOUT_MS);
+      return { status: 'up', latencyMs: Date.now() - start };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { status: 'down', latencyMs: Date.now() - start, error: msg };
+    }
+  }
+
+  /**
+   * Resolve the Redis connection string. Prefers `REDIS_URL`; falls back to
+   * building one from `REDIS_HOST` / `REDIS_PORT`. Returns `undefined` when
+   * Redis is not configured.
+   */
+  private getRedisUrl(): string | undefined {
+    const url = process.env.REDIS_URL?.trim();
+    if (url) return url;
+
+    const host = process.env.REDIS_HOST?.trim();
+    if (host) {
+      const port = process.env.REDIS_PORT?.trim() || '6379';
+      return `redis://${host}:${port}`;
+    }
+    return undefined;
+  }
+
+  /**
+   * Send a single Redis PING over a short-lived socket and resolve when the
+   * server replies `+PONG`. Uses only Node built-ins (`net` / `tls`) so the
+   * health probe adds no runtime dependency.
+   *
+   * Supports `redis://` and `rediss://` (TLS), and `AUTH` when the URL carries
+   * a username / password. The socket is always torn down. Extracted as a
+   * protected method so tests can stub it.
+   *
+   * @throws when the URL is invalid, the connection fails, the reply is not
+   *   `+PONG`, or the probe exceeds `timeoutMs`.
+   */
+  protected pingRedis(url: string, timeoutMs: number): Promise<void> {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return Promise.reject(new Error(`Invalid Redis URL: ${url}`));
+    }
+
+    const useTls = parsed.protocol === 'rediss:';
+    const host = parsed.hostname;
+    const port = parsed.port ? Number(parsed.port) : 6379;
+    const password = parsed.password ? decodeURIComponent(parsed.password) : undefined;
+    const username = parsed.username ? decodeURIComponent(parsed.username) : undefined;
+
+    return new Promise<void>((resolve, reject) => {
+      const socket = useTls
+        ? tls.connect({ host, port, servername: host })
+        : net.createConnection({ host, port });
+
+      let settled = false;
+      let buffer = '';
+      // When a password is present we AUTH first, then PING.
+      let awaitingAuth = password !== undefined;
+
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        socket.removeAllListeners();
+        socket.destroy();
+        if (error) reject(error);
+        else resolve();
+      };
+
+      socket.setTimeout(timeoutMs, () =>
+        finish(new Error(`Redis PING timed out after ${timeoutMs}ms`)),
+      );
+      socket.on('error', finish);
+
+      const onConnect = () => {
+        if (password !== undefined) {
+          const authCmd =
+            username !== undefined
+              ? `AUTH ${username} ${password}\r\n`
+              : `AUTH ${password}\r\n`;
+          socket.write(authCmd);
+        } else {
+          socket.write('PING\r\n');
+        }
+      };
+      socket.once(useTls ? 'secureConnect' : 'connect', onConnect);
+
+      socket.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString('utf8');
+        const eol = buffer.indexOf('\r\n');
+        if (eol === -1) return; // wait for a complete reply line
+
+        const line = buffer.slice(0, eol);
+        // RESP error reply, e.g. "-NOAUTH Authentication required".
+        if (line.startsWith('-')) {
+          finish(new Error(line.slice(1)));
+          return;
+        }
+        if (awaitingAuth) {
+          // AUTH acknowledged (+OK); reset and send the PING.
+          awaitingAuth = false;
+          buffer = '';
+          socket.write('PING\r\n');
+          return;
+        }
+        if (line.startsWith('+PONG')) {
+          finish();
+        } else {
+          finish(new Error(`Unexpected PING reply: ${line}`));
+        }
+      });
+    });
   }
 
   async checkSorobanRpc(): Promise<SorobanHealthStatus> {

--- a/backend/test/health.e2e-spec.ts
+++ b/backend/test/health.e2e-spec.ts
@@ -23,7 +23,17 @@ describe('Health (e2e)', () => {
   };
   const mockQueueMetrics = { snapshot: jest.fn().mockReturnValue({}) };
 
+  const REDIS_ENV_KEYS = ['REDIS_URL', 'REDIS_HOST', 'REDIS_PORT'];
+  let savedRedisEnv: Record<string, string | undefined>;
+
   beforeEach(async () => {
+    // Keep the Redis probe unconfigured so these tests never open a socket.
+    savedRedisEnv = {};
+    for (const key of REDIS_ENV_KEYS) {
+      savedRedisEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],
       providers: [
@@ -42,6 +52,13 @@ describe('Health (e2e)', () => {
 
   afterEach(async () => {
     await app.close();
+    for (const key of REDIS_ENV_KEYS) {
+      if (savedRedisEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedRedisEnv[key];
+      }
+    }
   });
 
   describe('GET /v1/health', () => {
@@ -63,6 +80,32 @@ describe('Health (e2e)', () => {
           expect(new Date(res.body.timestamp as string).toISOString()).toBe(
             res.body.timestamp,
           );
+        });
+    });
+  });
+
+  describe('GET /v1/health/redis', () => {
+    it('returns 200 and not_configured when Redis is unset', () => {
+      return request(app.getHttpServer())
+        .get('/v1/health/redis')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.status).toBe('not_configured');
+        });
+    });
+  });
+
+  describe('GET /v1/health/aggregate', () => {
+    it('reports up and omits Redis when it is unconfigured', () => {
+      return request(app.getHttpServer())
+        .get('/v1/health/aggregate')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.status).toBe('up');
+          // Redis is skipped entirely, so it is absent and does not count.
+          expect(res.body.subsystems.redis).toBeUndefined();
+          expect(res.body.summary.total).toBe(3);
+          expect(res.body.summary.down).toBe(0);
         });
     });
   });


### PR DESCRIPTION
## Summary

Implements the Redis PING health probe from #1356. The previous `checkRedis()` was a stub that always reported `down` / "Redis not configured", which meant the aggregate health check permanently read `degraded` even on a healthy deployment. This replaces it with a real, latency-measured PING and treats Redis as the optional subsystem it is.

## Changes

- **Real PING probe** (`health.service.ts`): reads the connection from `REDIS_URL`, falling back to `REDIS_HOST` / `REDIS_PORT` (the pair docker-compose already sets). Probes over Node's built-in `net` / `tls` — no new runtime dependency. Handles `redis://` and `rediss://` (TLS) and sends `AUTH` when the URL carries credentials. Fails fast with a 2s timeout and always tears the socket down.
- **Unconfigured is not a failure**: when nothing is configured the probe returns a new `not_configured` status and is skipped entirely in `/health/aggregate` — so an absent optional cache no longer drags the service to `degraded`. A configured-but-unreachable Redis still reports `down` with the error.
- **HTTP mapping**: `/health/redis` returns 200 for `up` and `not_configured`, 503 only when a configured Redis is `down`.
- **DTOs**: added `RedisStatusDto` (`up | down | not_configured`) and made the aggregate `redis` field optional.
- **Env docs**: documented `REDIS_URL` / `REDIS_HOST` / `REDIS_PORT` in `backend/.env.example`.

## Test Plan

### Automated tests added or updated

- [x] **Unit tests** (`backend/src/health/*.spec.ts`) — `checkRedis` for up / down / unconfigured / bad-reply / timeout / AUTH, plus a real fake-RESP-server integration test that exercises the actual socket path; aggregate behaviour with Redis configured vs skipped; controller status-code mapping.
- [x] **Integration / e2e tests** (`backend/test/health.e2e-spec.ts`) — `GET /v1/health/redis` returns 200 `not_configured` and `GET /v1/health/aggregate` reports `up` with Redis omitted when unconfigured.

### How to run the tests locally

```bash
# Backend unit tests (health)
cd backend && npm test -- src/health

# Backend e2e tests
cd backend && npm run test:e2e -- health
```

Result on this branch: **health unit 81/81 pass, health e2e 9/9 pass.**

Before/after check: the new unit tests were run against the old stub first — 14 of them fail (they capture the new probe behaviour) — and all pass against the new implementation.

### Manual verification checklist

- [x] Happy path: with a live `redis:7` (`REDIS_URL=redis://localhost:6379`) `/v1/health/redis` returns `up` with `latencyMs`.
- [x] Error case: bad host / refused connection returns `down` with the error; `/v1/health/redis` → 503.
- [x] Unconfigured: no Redis env → `/v1/health/redis` returns 200 `not_configured` and `/v1/health/aggregate` stays `up` with `redis` omitted.

## Related issues

Closes #1356

## Notes for reviewers

- **No new dependency.** The probe uses `net` / `tls` because the project currently has no Redis client and this only needs a single PING. If you'd prefer `ioredis` (e.g. for future caching work), I'm happy to switch — say the word.
- **`not_configured` is deliberate.** Reporting an unconfigured optional cache as `down` (the old behaviour) made aggregate health permanently `degraded`. Omitting it keeps the aggregate honest. If you'd rather it always appear (with a `not_configured` status) rather than be omitted, that's a one-line change.
- **Pre-existing CI state.** `main` currently fails `npm ci` (the committed `backend/package-lock.json` is missing `husky` / `lint-staged`), the backend `nest build` fails on two unrelated errors (`QueueSnapshotDto` decorator in `health-response.dto.ts`, missing `FanDashboardQueryDto` in `subscriptions.controller.ts`), and ~82 unrelated unit tests fail (ThrottlerGuard DI). None of these are touched or caused by this PR — the health suites here are green. Happy to open separate PRs for any of them if useful.
