### PR TITLE
Migrate creator profile pages off mock fixtures

### DIFF
--- a/backend/src/creators/creators.controller.spec.ts
+++ b/backend/src/creators/creators.controller.spec.ts
@@ -6,24 +6,37 @@ import { CreatorDashboardService } from './creator-dashboard.service';
 import { SearchCreatorsDto } from './dto/search-creators.dto';
 import { PaginatedResponseDto } from '../common/dto';
 import { PublicCreatorDto } from './dto/public-creator.dto';
-import { PlanDto } from './dto/plan.dto';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
 
+type MockCreatorsService = {
+  searchCreators: jest.Mock;
+  getCreatorByUsername: jest.Mock;
+  createPlan: jest.Mock;
+  findAllPlans: jest.Mock;
+  findCreatorPlans: jest.Mock;
+  listCreators: jest.Mock;
+};
+
+type MockDashboardService = {
+  getDashboard: jest.Mock;
+};
+
 describe('CreatorsController', () => {
   let controller: CreatorsController;
-  let mockCreatorsService: any;
-  let mockDashboardService: any;
+  let mockCreatorsService: MockCreatorsService;
+  let mockDashboardService: MockDashboardService;
 
-  const mockCreatorsServiceFactory = () => ({
+  const mockCreatorsServiceFactory = (): MockCreatorsService => ({
     searchCreators: jest.fn(),
+    getCreatorByUsername: jest.fn(),
     createPlan: jest.fn(),
     findAllPlans: jest.fn(),
     findCreatorPlans: jest.fn(),
     listCreators: jest.fn(),
   });
 
-  const mockDashboardServiceFactory = () => ({
+  const mockDashboardServiceFactory = (): MockDashboardService => ({
     getDashboard: jest.fn(),
   });
 
@@ -109,7 +122,7 @@ describe('CreatorsController', () => {
   });
 
   describe('createPlan', () => {
-    it('should call service.createPlan with correct parameters', async () => {
+    it('should call service.createPlan with correct parameters', () => {
       const planBody = {
         creator: 'user1',
         asset: 'native',
@@ -117,9 +130,9 @@ describe('CreatorsController', () => {
         intervalDays: 30,
       };
       const mockPlan = { id: 1, ...planBody };
-      mockCreatorsService.createPlan.mockResolvedValue(mockPlan);
+      mockCreatorsService.createPlan.mockReturnValue(mockPlan);
 
-      await controller.createPlan(planBody);
+      controller.createPlan(planBody);
 
       expect(mockCreatorsService.createPlan).toHaveBeenCalledWith(
         'user1',
@@ -129,7 +142,7 @@ describe('CreatorsController', () => {
       );
     });
 
-    it('should return created plan with id', async () => {
+    it('should return created plan with id', () => {
       const planBody = {
         creator: 'user1',
         asset: 'native',
@@ -137,9 +150,9 @@ describe('CreatorsController', () => {
         intervalDays: 30,
       };
       const mockPlan = { id: 1, ...planBody };
-      mockCreatorsService.createPlan.mockResolvedValue(mockPlan);
+      mockCreatorsService.createPlan.mockReturnValue(mockPlan);
 
-      const result = await controller.createPlan(planBody);
+      const result = controller.createPlan(planBody);
 
       expect(result).toEqual(mockPlan);
       expect(result.id).toBe(1);
@@ -160,17 +173,17 @@ describe('CreatorsController', () => {
   });
 
   describe('getAllPlans', () => {
-    it('should call service.findAllPlans with pagination', async () => {
+    it('should call service.findAllPlans with pagination', () => {
       const pagination = { page: 1, limit: 20 };
       const mockResponse = new PaginatedResponseDto([], 20, null, false);
       mockCreatorsService.findAllPlans.mockReturnValue(mockResponse);
 
-      await controller.getAllPlans(pagination);
+      controller.getAllPlans(pagination);
 
       expect(mockCreatorsService.findAllPlans).toHaveBeenCalledWith(pagination);
     });
 
-    it('should return paginated plans', async () => {
+    it('should return paginated plans', () => {
       const pagination = { page: 1, limit: 20 };
       const mockPlans = [
         {
@@ -184,7 +197,7 @@ describe('CreatorsController', () => {
       const mockResponse = new PaginatedResponseDto(mockPlans, 20, null, false);
       mockCreatorsService.findAllPlans.mockReturnValue(mockResponse);
 
-      const result = await controller.getAllPlans(pagination);
+      const result = controller.getAllPlans(pagination);
 
       expect(result.data).toHaveLength(1);
       expect(result.limit).toBe(20);
@@ -192,13 +205,13 @@ describe('CreatorsController', () => {
   });
 
   describe('getPlans', () => {
-    it('should call service.findCreatorPlans with address and pagination', async () => {
+    it('should call service.findCreatorPlans with address and pagination', () => {
       const address = 'GBCQ6C7OXWTKJ7APCIQPKK6X4CQBFGWJKW35GD7H5GMVVDANQCXLSV7';
       const pagination = { page: 1, limit: 20 };
       const mockResponse = new PaginatedResponseDto([], 20, null, false);
       mockCreatorsService.findCreatorPlans.mockReturnValue(mockResponse);
 
-      await controller.getPlans(address, pagination);
+      controller.getPlans(address, pagination);
 
       expect(mockCreatorsService.findCreatorPlans).toHaveBeenCalledWith(
         address,
@@ -206,7 +219,7 @@ describe('CreatorsController', () => {
       );
     });
 
-    it('should return creator plans', async () => {
+    it('should return creator plans', () => {
       const address = 'GBCQ6C7OXWTKJ7APCIQPKK6X4CQBFGWJKW35GD7H5GMVVDANQCXLSV7';
       const pagination = { page: 1, limit: 20 };
       const mockPlans = [
@@ -221,7 +234,7 @@ describe('CreatorsController', () => {
       const mockResponse = new PaginatedResponseDto(mockPlans, 20, null, false);
       mockCreatorsService.findCreatorPlans.mockReturnValue(mockResponse);
 
-      const result = await controller.getPlans(address, pagination);
+      const result = controller.getPlans(address, pagination);
 
       expect(result.data).toHaveLength(1);
       expect(result.data[0].creator).toBe(address);
@@ -237,16 +250,13 @@ describe('CreatorsController', () => {
         subscriberCount: 10,
       };
       const mockDashboardService = controller['dashboardService'];
-      jest
+      const getDashboardSpy = jest
         .spyOn(mockDashboardService, 'getDashboard')
         .mockReturnValue(mockDashboard as any);
 
       await controller.getDashboard(address, query as any);
 
-      expect(mockDashboardService.getDashboard).toHaveBeenCalledWith(
-        address,
-        query,
-      );
+      expect(getDashboardSpy).toHaveBeenCalledWith(address, query);
     });
   });
 
@@ -339,6 +349,8 @@ describe('CreatorsController', () => {
             display_name: 'Test User',
             avatar_url: 'https://example.com/avatar.jpg',
             bio: 'Test bio',
+            is_verified: false,
+            followers_count: 0,
           },
         ];
         const mockResponse = new PaginatedResponseDto(
@@ -369,6 +381,8 @@ describe('CreatorsController', () => {
             display_name: 'Test User',
             avatar_url: 'https://example.com/avatar.jpg',
             bio: 'Test bio',
+            is_verified: false,
+            followers_count: 0,
           },
         ];
         const mockResponse = new PaginatedResponseDto(
@@ -596,6 +610,8 @@ describe('CreatorsController', () => {
             display_name: 'Test User',
             avatar_url: 'https://example.com/avatar.jpg',
             bio: 'Test bio',
+            is_verified: false,
+            followers_count: 0,
           },
         ];
         const mockResponse = new PaginatedResponseDto(
@@ -614,6 +630,36 @@ describe('CreatorsController', () => {
         expect(result.data).toEqual(mockData);
         expect(result.nextCursor).toBe('testuser');
       });
+    });
+  });
+
+  describe('getCreatorByUsername', () => {
+    it('should return the creator profile when found', async () => {
+      const mockCreator: PublicCreatorDto = {
+        id: '1',
+        username: 'testuser',
+        display_name: 'Test User',
+        avatar_url: null,
+        bio: 'Test bio',
+        is_verified: true,
+        followers_count: 42,
+      };
+      mockCreatorsService.getCreatorByUsername.mockResolvedValue(mockCreator);
+
+      const result = await controller.getCreatorByUsername('testuser');
+
+      expect(mockCreatorsService.getCreatorByUsername).toHaveBeenCalledWith(
+        'testuser',
+      );
+      expect(result).toEqual(mockCreator);
+    });
+
+    it('should throw NotFoundException when the username does not match a creator', async () => {
+      mockCreatorsService.getCreatorByUsername.mockResolvedValue(null);
+
+      await expect(controller.getCreatorByUsername('nobody')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
@@ -864,7 +910,7 @@ describe('CreatorsController', () => {
       const mockDashboard = { totalEarnings: 0, subscribers: 0 };
       mockDashboardService.getDashboard.mockResolvedValue(mockDashboard);
 
-      const result = await controller.getDashboard('creator1', { days: '90' });
+      await controller.getDashboard('creator1', { days: '90' });
 
       expect(mockDashboardService.getDashboard).toHaveBeenCalledWith(
         'creator1',

--- a/backend/src/creators/creators.controller.ts
+++ b/backend/src/creators/creators.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Get, Post, Body, Param, Query, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  NotFoundException,
+} from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import { CreatorsService } from './creators.service';
@@ -55,7 +64,9 @@ export class CreatorsController {
   @ApiResponse({
     status: 400,
     description: 'Invalid query parameters',
-    schema: { example: { statusCode: 400, message: 'Invalid query parameters' } },
+    schema: {
+      example: { statusCode: 400, message: 'Invalid query parameters' },
+    },
   })
   @ApiResponse({
     status: 500,
@@ -68,8 +79,41 @@ export class CreatorsController {
     return this.creatorsService.searchCreators(searchDto);
   }
 
+  @Get('username/:username')
+  @ApiOperation({
+    summary: 'Get a single public creator profile by exact username',
+    description:
+      'Used by the creator profile page. Returns 404 when the username does not belong to a creator.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Public creator profile',
+    type: PublicCreatorDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Creator not found',
+    schema: { example: { statusCode: 404, message: 'Creator not found' } },
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Internal server error',
+    schema: { example: { statusCode: 500, message: 'Internal server error' } },
+  })
+  async getCreatorByUsername(
+    @Param('username') username: string,
+  ): Promise<PublicCreatorDto> {
+    const creator = await this.creatorsService.getCreatorByUsername(username);
+    if (!creator) {
+      throw new NotFoundException('Creator not found');
+    }
+    return creator;
+  }
+
   @Get('list')
-  @ApiOperation({ summary: 'List all creator plans, optionally merged with on-chain state' })
+  @ApiOperation({
+    summary: 'List all creator plans, optionally merged with on-chain state',
+  })
   @ApiResponse({
     status: 200,
     description: 'Array of plans with optional chain sync status',
@@ -107,7 +151,9 @@ export class CreatorsController {
   @ApiResponse({
     status: 400,
     description: 'Invalid pagination parameters',
-    schema: { example: { statusCode: 400, message: 'Invalid pagination parameters' } },
+    schema: {
+      example: { statusCode: 400, message: 'Invalid pagination parameters' },
+    },
   })
   @ApiResponse({
     status: 500,
@@ -130,7 +176,9 @@ export class CreatorsController {
   @ApiResponse({
     status: 400,
     description: 'Invalid pagination parameters',
-    schema: { example: { statusCode: 400, message: 'Invalid pagination parameters' } },
+    schema: {
+      example: { statusCode: 400, message: 'Invalid pagination parameters' },
+    },
   })
   @ApiResponse({
     status: 500,

--- a/backend/src/creators/creators.service.properties.spec.ts
+++ b/backend/src/creators/creators.service.properties.spec.ts
@@ -218,10 +218,12 @@ describe('CreatorsService - Property-Based Tests', () => {
           fc.option(fc.string({ maxLength: 50 }), { nil: undefined }),
           fc.integer({ min: 1, max: 100 }),
           async (searchQuery, limit) => {
-            (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue({
-              entities: [],
-              raw: [],
-            });
+            (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue(
+              {
+                entities: [],
+                raw: [],
+              },
+            );
 
             const result = await service.searchCreators({
               q: searchQuery,
@@ -269,10 +271,12 @@ describe('CreatorsService - Property-Based Tests', () => {
         fc.asyncProperty(
           fc.option(fc.string({ maxLength: 50 }), { nil: undefined }),
           async (searchQuery) => {
-            (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue({
-              entities: [],
-              raw: [],
-            });
+            (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue(
+              {
+                entities: [],
+                raw: [],
+              },
+            );
 
             const result = await service.searchCreators({
               q: searchQuery,
@@ -325,9 +329,11 @@ describe('CreatorsService - Property-Based Tests', () => {
                   'display_name',
                   'avatar_url',
                   'bio',
+                  'is_verified',
+                  'followers_count',
                 ]),
               );
-              expect(keys).toHaveLength(5);
+              expect(keys).toHaveLength(7);
 
               // Verify sensitive fields are not present
               expect(creator).not.toHaveProperty('password_hash');
@@ -441,7 +447,9 @@ describe('CreatorsService - Property-Based Tests', () => {
       await fc.assert(
         fc.asyncProperty(
           fc.option(fc.string({ maxLength: 100 }), { nil: undefined }),
-          fc.option(fc.string({ minLength: 1, maxLength: 20 }), { nil: undefined }),
+          fc.option(fc.string({ minLength: 1, maxLength: 20 }), {
+            nil: undefined,
+          }),
           fc.integer({ min: 1, max: 100 }),
           async (searchQuery, cursor, limit) => {
             (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue(

--- a/backend/src/creators/creators.service.spec.ts
+++ b/backend/src/creators/creators.service.spec.ts
@@ -17,9 +17,13 @@ describe('CreatorsService', () => {
   let errorSpy: jest.SpyInstance;
 
   beforeEach(async () => {
-    debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+    debugSpy = jest
+      .spyOn(Logger.prototype, 'debug')
+      .mockImplementation(() => {});
     warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
-    errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+    errorSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => {});
     // Create mock query builder
     mockQueryBuilder = {
       createQueryBuilder: jest.fn().mockReturnThis(),
@@ -218,7 +222,11 @@ describe('CreatorsService', () => {
 
     describe('search query alias', () => {
       it('should filter when only search param is provided', async () => {
-        const searchDto: SearchCreatorsDto = { search: 'bob', page: 1, limit: 10 };
+        const searchDto: SearchCreatorsDto = {
+          search: 'bob',
+          page: 1,
+          limit: 10,
+        };
         const mockUsers: User[] = [createMockUser('1', 'bob123', 'Bob Smith')];
 
         (mockQueryBuilder.getCount as jest.Mock).mockResolvedValue(1);
@@ -302,7 +310,11 @@ describe('CreatorsService', () => {
 
     describe('pagination', () => {
       it('should apply cursor filter for the second page', async () => {
-        const searchDto: SearchCreatorsDto = { q: '', cursor: 'user10', limit: 10 };
+        const searchDto: SearchCreatorsDto = {
+          q: '',
+          cursor: 'user10',
+          limit: 10,
+        };
         const mockUsers: User[] = [createMockUser('11', 'user11', 'User 11')];
 
         (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue({
@@ -359,7 +371,11 @@ describe('CreatorsService', () => {
       });
 
       it('should return empty data for stale cursor beyond results', async () => {
-        const searchDto: SearchCreatorsDto = { q: '', cursor: 'zzzzz', limit: 10 };
+        const searchDto: SearchCreatorsDto = {
+          q: '',
+          cursor: 'zzzzz',
+          limit: 10,
+        };
 
         (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue({
           entities: [],
@@ -452,7 +468,11 @@ describe('CreatorsService', () => {
 
     describe('stale cursor returns empty data', () => {
       it('should return empty data when cursor is beyond available results', async () => {
-        const searchDto: SearchCreatorsDto = { q: '', cursor: 'zzzzz', limit: 10 };
+        const searchDto: SearchCreatorsDto = {
+          q: '',
+          cursor: 'zzzzz',
+          limit: 10,
+        };
 
         (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue({
           entities: [],
@@ -465,6 +485,67 @@ describe('CreatorsService', () => {
         expect(result.nextCursor).toBeNull();
         expect(result.hasMore).toBe(false);
       });
+    });
+  });
+
+  describe('getCreatorByUsername', () => {
+    it('should return the public profile for an exact username match', async () => {
+      const mockUser = createMockUser('1', 'jane', 'Jane Doe');
+      (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue({
+        entities: [mockUser],
+        raw: [
+          {
+            creator_bio: 'Digital artist',
+            creator_is_verified: true,
+            creator_followers_count: 42,
+          },
+        ],
+      });
+
+      const result = await service.getCreatorByUsername('jane');
+
+      expect(result).not.toBeNull();
+      expect(result?.username).toBe('jane');
+      expect(result?.bio).toBe('Digital artist');
+      expect(result?.is_verified).toBe(true);
+      expect(result?.followers_count).toBe(42);
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'LOWER(user.username) = :username',
+        { username: 'jane' },
+      );
+    });
+
+    it('should match case-insensitively', async () => {
+      const mockUser = createMockUser('1', 'jane', 'Jane Doe');
+      (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue({
+        entities: [mockUser],
+        raw: [
+          {
+            creator_bio: null,
+            creator_is_verified: false,
+            creator_followers_count: 0,
+          },
+        ],
+      });
+
+      const result = await service.getCreatorByUsername('JANE');
+
+      expect(result?.username).toBe('jane');
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'LOWER(user.username) = :username',
+        { username: 'jane' },
+      );
+    });
+
+    it('should return null when no creator matches the username', async () => {
+      (mockQueryBuilder.getRawAndEntities as jest.Mock).mockResolvedValue({
+        entities: [],
+        raw: [],
+      });
+
+      const result = await service.getCreatorByUsername('nobody');
+
+      expect(result).toBeNull();
     });
   });
 
@@ -483,7 +564,7 @@ describe('CreatorsService', () => {
     });
 
     it('should publish PlanCreatedEvent when EventBus is wired', () => {
-      const publish = jest.fn();
+      const publish = jest.fn<void, [{ constructor: { name: string } }]>();
       const module = Test.createTestingModule({
         providers: [
           CreatorsService,
@@ -502,7 +583,8 @@ describe('CreatorsService', () => {
         svc.createPlan('creator1', 'XLM', '50', 7);
 
         expect(publish).toHaveBeenCalledTimes(1);
-        expect(publish.mock.calls[0][0].constructor.name).toBe('PlanCreatedEvent');
+        const publishedEvent = publish.mock.calls[0][0];
+        expect(publishedEvent.constructor.name).toBe('PlanCreatedEvent');
       });
     });
   });
@@ -807,7 +889,10 @@ describe('CreatorsService', () => {
 
     it('findAllPlans ignores invalid cursor and logs debug', () => {
       service.createPlan('a', 'USDC', '1', 30);
-      service.findAllPlans({ cursor: 'not-a-number', limit: 10 } as PaginationDto);
+      service.findAllPlans({
+        cursor: 'not-a-number',
+        limit: 10,
+      } as PaginationDto);
       expect(debugSpy).toHaveBeenCalledWith(
         'Ignoring invalid plans pagination cursor "not-a-number"',
       );

--- a/backend/src/creators/creators.service.ts
+++ b/backend/src/creators/creators.service.ts
@@ -41,7 +41,13 @@ export class CreatorsService {
     amount: string,
     intervalDays: number,
   ): Plan {
-    const plan = { id: ++this.planCounter, creator, asset, amount, intervalDays };
+    const plan = {
+      id: ++this.planCounter,
+      creator,
+      asset,
+      amount,
+      intervalDays,
+    };
     this.plans.set(plan.id, plan);
     if (!this.eventBus) {
       this.logger.debug(
@@ -78,7 +84,9 @@ export class CreatorsService {
       if (!isNaN(cursorId)) {
         allPlans = allPlans.filter((p) => p.id > cursorId);
       } else {
-        this.logger.debug(`Ignoring invalid plans pagination cursor "${cursor}"`);
+        this.logger.debug(
+          `Ignoring invalid plans pagination cursor "${cursor}"`,
+        );
       }
     }
 
@@ -106,7 +114,9 @@ export class CreatorsService {
     pagination: PaginationDto,
   ): PaginatedResponseDto<PlanDto> {
     const { cursor, limit = 20 } = pagination;
-    let creatorPlans = this.getCreatorPlans(creator).sort((a, b) => a.id - b.id);
+    let creatorPlans = this.getCreatorPlans(creator).sort(
+      (a, b) => a.id - b.id,
+    );
 
     if (cursor) {
       const cursorId = parseInt(cursor, 10);
@@ -144,7 +154,9 @@ export class CreatorsService {
    * syncStatus='unknown' so callers always receive a valid response.
    */
   async listCreators(mergeChain = false): Promise<PlanDto[]> {
-    const allPlans = Array.from(this.plans.values()).sort((a, b) => a.id - b.id);
+    const allPlans = Array.from(this.plans.values()).sort(
+      (a, b) => a.id - b.id,
+    );
 
     if (!mergeChain) {
       return allPlans.map((p) => Object.assign(new PlanDto(), p));
@@ -152,7 +164,9 @@ export class CreatorsService {
 
     const contractId = this.chainReader?.getConfiguredContractId();
     if (!contractId || !this.chainReader) {
-      this.logger.debug('listCreators: chain reader not configured, skipping merge');
+      this.logger.debug(
+        'listCreators: chain reader not configured, skipping merge',
+      );
       return allPlans.map((p) =>
         Object.assign(new PlanDto(), { ...p, syncStatus: 'unknown' }),
       );
@@ -163,7 +177,10 @@ export class CreatorsService {
 
     const merged = await Promise.all(
       allPlans.map(async (plan) => {
-        const chainResult = await this.chainReader!.readPlan(contractId, plan.id);
+        const chainResult = await this.chainReader!.readPlan(
+          contractId,
+          plan.id,
+        );
         if (!chainResult.ok) {
           this.logger.warn(
             `listCreators: chain read failed for plan ${plan.id}: ${chainResult.error}`,
@@ -204,6 +221,8 @@ export class CreatorsService {
       .createQueryBuilder('user')
       .leftJoin('user.creator', 'creator')
       .addSelect('creator.bio', 'creator_bio')
+      .addSelect('creator.is_verified', 'creator_is_verified')
+      .addSelect('creator.followers_count', 'creator_followers_count')
       .where('user.is_creator = :isCreator', { isCreator: true })
       .orderBy('user.username', 'ASC')
       .take(limit + 1);
@@ -216,15 +235,21 @@ export class CreatorsService {
     }
 
     if (cursor) {
-      qb.andWhere('user.username > :cursorUsername', { cursorUsername: cursor });
+      qb.andWhere('user.username > :cursorUsername', {
+        cursorUsername: cursor,
+      });
     }
 
     let entities: User[];
-    let raw: { creator_bio?: string }[];
+    let raw: {
+      creator_bio?: string;
+      creator_is_verified?: boolean;
+      creator_followers_count?: number;
+    }[];
     try {
       const result = await qb.getRawAndEntities();
       entities = result.entities;
-      raw = result.raw as { creator_bio?: string }[];
+      raw = result.raw as typeof raw;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.logger.error(`Creator search failed: ${message}`);
@@ -240,6 +265,12 @@ export class CreatorsService {
     const data = entities.map((user, index) => {
       const dto = new PublicCreatorDto(user, user.creator);
       dto.bio = raw[index]?.creator_bio ?? user.creator?.bio ?? null;
+      dto.is_verified =
+        raw[index]?.creator_is_verified ?? user.creator?.is_verified ?? false;
+      dto.followers_count =
+        raw[index]?.creator_followers_count ??
+        user.creator?.followers_count ??
+        0;
       return dto;
     });
 
@@ -254,5 +285,46 @@ export class CreatorsService {
     );
 
     return new PaginatedResponseDto(data, limit, nextCursor, hasMore);
+  }
+
+  /**
+   * Look up a single public creator profile by exact username match.
+   * Used by the creator profile page to render real data (and 404 for
+   * unknown usernames) instead of the client-side prefix search used by
+   * discovery.
+   */
+  async getCreatorByUsername(
+    username: string,
+  ): Promise<PublicCreatorDto | null> {
+    const qb = this.userRepository
+      .createQueryBuilder('user')
+      .leftJoin('user.creator', 'creator')
+      .addSelect('creator.bio', 'creator_bio')
+      .addSelect('creator.is_verified', 'creator_is_verified')
+      .addSelect('creator.followers_count', 'creator_followers_count')
+      .where('user.is_creator = :isCreator', { isCreator: true })
+      .andWhere('LOWER(user.username) = :username', {
+        username: username.trim().toLowerCase(),
+      });
+
+    const result = await qb.getRawAndEntities();
+    const user = result.entities[0];
+    if (!user) return null;
+
+    const raw = result.raw[0] as
+      | {
+          creator_bio?: string;
+          creator_is_verified?: boolean;
+          creator_followers_count?: number;
+        }
+      | undefined;
+
+    const dto = new PublicCreatorDto(user, user.creator);
+    dto.bio = raw?.creator_bio ?? user.creator?.bio ?? null;
+    dto.is_verified =
+      raw?.creator_is_verified ?? user.creator?.is_verified ?? false;
+    dto.followers_count =
+      raw?.creator_followers_count ?? user.creator?.followers_count ?? 0;
+    return dto;
   }
 }

--- a/backend/src/creators/dto/public-creator.dto.spec.ts
+++ b/backend/src/creators/dto/public-creator.dto.spec.ts
@@ -137,7 +137,7 @@ describe('PublicCreatorDto', () => {
       const creator: Creator = {
         id: '456e7890-e89b-12d3-a456-426614174001',
         user: user,
-        bio: undefined as any,
+        bio: undefined as unknown as string,
         subscription_price: 9.99,
         total_subscribers: 100,
         is_active: true,
@@ -187,11 +187,13 @@ describe('PublicCreatorDto', () => {
       const dto = new PublicCreatorDto(user, creator);
       const dtoKeys = Object.keys(dto);
 
-      // Assert - verify only 5 public fields
-      expect(dtoKeys).toHaveLength(5);
+      // Assert - verify only the public fields
+      expect(dtoKeys).toHaveLength(7);
       expect(dtoKeys).toContain('id');
       expect(dtoKeys).toContain('username');
       expect(dtoKeys).toContain('display_name');
+      expect(dtoKeys).toContain('is_verified');
+      expect(dtoKeys).toContain('followers_count');
       expect(dtoKeys).toContain('avatar_url');
       expect(dtoKeys).toContain('bio');
     });

--- a/backend/src/creators/dto/public-creator.dto.ts
+++ b/backend/src/creators/dto/public-creator.dto.ts
@@ -35,11 +35,25 @@ export class PublicCreatorDto {
   })
   bio: string | null;
 
+  @ApiProperty({
+    description: 'Whether the creator is verified',
+    example: false,
+  })
+  is_verified: boolean;
+
+  @ApiProperty({
+    description: 'Number of followers',
+    example: 0,
+  })
+  followers_count: number;
+
   constructor(user: User, creator?: Creator) {
     this.id = user.id;
     this.display_name = user.display_name;
     this.username = user.username;
     this.avatar_url = user.avatar_url;
     this.bio = creator?.bio ?? null;
+    this.is_verified = creator?.is_verified ?? false;
+    this.followers_count = creator?.followers_count ?? 0;
   }
 }

--- a/frontend/src/app/creator/[username]/page.tsx
+++ b/frontend/src/app/creator/[username]/page.tsx
@@ -3,19 +3,20 @@ import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import {
-  getAllCreators,
-  getCreatorByUsername,
   getCreatorPlans,
-  getPreviewContent,
-  getPosts,
   getCurrencySymbol,
   type CreatorProfile,
 } from '@/lib/creator-profile';
+import { searchCreators, getCreatorProfile, publicCreatorToProfile } from '@/lib/api/creators';
+import { getPublishedPostsByAuthor } from '@/lib/api/posts';
 import { createCreatorMetadata } from '@/lib/metadata';
 import { CreatorHero } from '@/components/creator/CreatorHero';
 import { PlanCard } from '@/components/cards';
 import { ContentCard } from '@/components/cards';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+
+const PREVIEW_COUNT = 3;
+const POSTS_LIMIT = 20;
 
 /**
  * ISR: Regenerate creator pages at most once per minute.
@@ -24,12 +25,19 @@ import { ErrorBoundary } from '@/components/ErrorBoundary';
 export const revalidate = 60;
 
 /**
- * Pre-render all known creator pages at build time (SSG).
- * Eliminates cold SSR for every visitor.
+ * Pre-render known creator pages at build time (SSG). Any username not
+ * covered here still resolves correctly through the ISR fallback above —
+ * this just avoids a cold SSR for the most common cases. If the backend
+ * is unreachable at build time we skip SSG entirely rather than fail the
+ * build; every profile still renders on first request.
  */
 export async function generateStaticParams() {
-  const creators = getAllCreators();
-  return creators.map((c) => ({ username: c.username }));
+  try {
+    const result = await searchCreators({ limit: 100 });
+    return result.data.map((c) => ({ username: c.username }));
+  } catch {
+    return [];
+  }
 }
 
 interface PageProps {
@@ -38,9 +46,9 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { username } = await params;
-  const creator = getCreatorByUsername(username);
-  
-  if (!creator) {
+  const apiCreator = await getCreatorProfile(username);
+
+  if (!apiCreator) {
     return {
       title: 'Creator Not Found | MyFans',
       description: 'The creator you are looking for does not exist or has been removed.',
@@ -51,16 +59,21 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     };
   }
 
+  const creator = publicCreatorToProfile(apiCreator);
+  // Plans are still mock data — the backend has no marketing-tier/pricing
+  // model yet (see MyFanss/MyFans#1358 for tracking). Everything else on
+  // this page (identity, posts) is real.
   const plans = await getCreatorPlans(username);
   return createCreatorMetadata(creator, plans, getCurrencySymbol);
 }
 
 export default async function CreatorProfilePage({ params }: PageProps) {
   const { username } = await params;
-  const creator = getCreatorByUsername(username);
-  if (!creator) {
+  const apiCreator = await getCreatorProfile(username);
+  if (!apiCreator) {
     notFound();
   }
+  const creator = publicCreatorToProfile(apiCreator);
 
   /**
    * Critical-path data fetched in parallel.
@@ -68,7 +81,7 @@ export default async function CreatorProfilePage({ params }: PageProps) {
    */
   const [plans, previewContent] = await Promise.all([
     getCreatorPlans(username),
-    getPreviewContent(username),
+    getPublishedPostsByAuthor(apiCreator.id, { limit: PREVIEW_COUNT }),
   ]);
 
   return (
@@ -136,7 +149,7 @@ export default async function CreatorProfilePage({ params }: PageProps) {
               Posts
             </h2>
             <Suspense fallback={<PostsSkeleton />}>
-              <PostsSection username={username} creator={creator} />
+              <PostsSection authorId={apiCreator.id} creator={creator} />
             </Suspense>
           </section>
         </main>
@@ -147,13 +160,13 @@ export default async function CreatorProfilePage({ params }: PageProps) {
 
 /** Async server component — streams independently of the critical path */
 async function PostsSection({
-  username,
+  authorId,
   creator,
 }: {
-  username: string;
+  authorId: string;
   creator: CreatorProfile;
 }) {
-  const posts = await getPosts(username);
+  const posts = await getPublishedPostsByAuthor(authorId, { limit: POSTS_LIMIT });
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {posts.map((post) => (

--- a/frontend/src/app/discover/DiscoverContent.tsx
+++ b/frontend/src/app/discover/DiscoverContent.tsx
@@ -13,7 +13,7 @@ import {
   SortOption,
 } from "@/lib/creator-profile";
 import { FeatureFlag } from "@/lib/feature-flags";
-import { searchCreators, PublicCreator } from "@/lib/api/creators";
+import { searchCreators, publicCreatorToProfile } from "@/lib/api/creators";
 import { usePrefetchCreatorRoute } from "@/hooks/usePrefetchCreatorRoute";
 import { CreatorCardSkeleton } from "@/components/ui/CreatorCardSkeleton";
 
@@ -22,22 +22,6 @@ const INITIAL_LOAD = 12;
 const LOAD_MORE_COUNT = 8;
 
 const USE_API = process.env.NEXT_PUBLIC_USE_CREATORS_API === "true";
-
-/** Map API result to the shape CreatorCard expects */
-function apiCreatorToProfile(c: PublicCreator): CreatorProfile {
-  return {
-    id: c.id,
-    username: c.username,
-    displayName: c.display_name,
-    bio: c.bio ?? "",
-    avatarUrl: c.avatar_url ?? undefined,
-    subscriberCount: 0,
-    subscriptionPrice: 0,
-    isVerified: false,
-    categories: [],
-    socialLinks: [],
-  };
-}
 
 function DiscoverContentInner() {
   const router = useRouter();
@@ -110,7 +94,7 @@ function DiscoverContentInner() {
             limit: INITIAL_LOAD,
           });
           if (!cancelled) {
-            setDisplayedCreators(result.data.map(apiCreatorToProfile));
+            setDisplayedCreators(result.data.map(publicCreatorToProfile));
             setTotal(result.data.length);
             setHasMore(result.hasMore);
             setNextCursor(result.nextCursor);
@@ -157,7 +141,7 @@ function DiscoverContentInner() {
           cursor: nextCursor ?? undefined,
           limit: LOAD_MORE_COUNT,
         });
-        setDisplayedCreators((prev) => [...prev, ...result.data.map(apiCreatorToProfile)]);
+        setDisplayedCreators((prev) => [...prev, ...result.data.map(publicCreatorToProfile)]);
         setHasMore(result.hasMore);
         setNextCursor(result.nextCursor);
       } catch {

--- a/frontend/src/lib/api/creators.test.ts
+++ b/frontend/src/lib/api/creators.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getCreatorProfile, publicCreatorToProfile, type PublicCreator } from './creators';
+
+global.fetch = vi.fn() as any;
+
+function mockFetchOk(body: unknown) {
+  (fetch as any).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(body),
+  });
+}
+
+function mockFetchStatus(status: number, body: unknown = {}) {
+  (fetch as any).mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  });
+}
+
+describe('getCreatorProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches the creator by exact username with credentials included', async () => {
+    const creator: PublicCreator = {
+      id: '1',
+      username: 'jane',
+      display_name: 'Jane Doe',
+      avatar_url: null,
+      bio: 'Digital artist',
+      is_verified: true,
+      followers_count: 42,
+    };
+    mockFetchOk(creator);
+
+    const result = await getCreatorProfile('jane');
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/creators/username/jane'),
+      expect.objectContaining({ credentials: 'include' }),
+    );
+    expect(result).toEqual(creator);
+  });
+
+  it('URL-encodes the username', async () => {
+    mockFetchOk({});
+
+    await getCreatorProfile('jane doe');
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/creators/username/jane%20doe'),
+      expect.anything(),
+    );
+  });
+
+  it('returns null for an unknown username (404)', async () => {
+    mockFetchStatus(404);
+
+    const result = await getCreatorProfile('nobody');
+
+    expect(result).toBeNull();
+  });
+
+  it('throws on a non-404 error response', async () => {
+    mockFetchStatus(500, { message: 'Internal server error' });
+
+    await expect(getCreatorProfile('jane')).rejects.toThrow('Internal server error');
+  });
+});
+
+describe('publicCreatorToProfile', () => {
+  it('maps API fields to the CreatorProfile shape used by the UI', () => {
+    const creator: PublicCreator = {
+      id: '1',
+      username: 'jane',
+      display_name: 'Jane Doe',
+      avatar_url: 'https://example.com/jane.jpg',
+      bio: 'Digital artist',
+      is_verified: true,
+      followers_count: 12400,
+    };
+
+    const profile = publicCreatorToProfile(creator);
+
+    expect(profile).toEqual({
+      id: '1',
+      username: 'jane',
+      displayName: 'Jane Doe',
+      bio: 'Digital artist',
+      avatarUrl: 'https://example.com/jane.jpg',
+      subscriberCount: 12400,
+      subscriptionPrice: 0,
+      isVerified: true,
+      categories: [],
+      socialLinks: [],
+    });
+  });
+
+  it('falls back to empty bio and undefined avatar when null', () => {
+    const creator: PublicCreator = {
+      id: '2',
+      username: 'alex',
+      display_name: 'Alex Chen',
+      avatar_url: null,
+      bio: null,
+      is_verified: false,
+      followers_count: 0,
+    };
+
+    const profile = publicCreatorToProfile(creator);
+
+    expect(profile.bio).toBe('');
+    expect(profile.avatarUrl).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/api/creators.ts
+++ b/frontend/src/lib/api/creators.ts
@@ -1,6 +1,7 @@
 /**
  * Creators search API client.
  */
+import type { CreatorProfile } from '@/lib/creator-profile';
 
 export interface PublicCreator {
   id: string;
@@ -8,6 +9,8 @@ export interface PublicCreator {
   username: string;
   avatar_url: string | null;
   bio: string | null;
+  is_verified: boolean;
+  followers_count: number;
 }
 
 export interface CreatorsSearchResult {
@@ -37,4 +40,45 @@ export async function searchCreators(params: {
     throw new Error((err as { message?: string }).message ?? `Request failed: ${res.status}`);
   }
   return res.json() as Promise<CreatorsSearchResult>;
+}
+
+/**
+ * Fetch a single public creator profile by exact username.
+ * Returns null when no creator matches (caller should 404).
+ */
+export async function getCreatorProfile(username: string): Promise<PublicCreator | null> {
+  const res = await fetch(`${API_BASE}/creators/username/${encodeURIComponent(username)}`, {
+    credentials: 'include',
+  });
+  if (res.status === 404) {
+    return null;
+  }
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { message?: string }).message ?? `Request failed: ${res.status}`);
+  }
+  return res.json() as Promise<PublicCreator>;
+}
+
+/**
+ * Map an API creator record to the CreatorProfile shape used by the
+ * discovery grid and the profile page's hero/header components.
+ *
+ * The backend doesn't yet track subscriber count, subscription price,
+ * categories, location, or social links for a creator, so those fall
+ * back to sensible empty defaults rather than fabricated data.
+ */
+export function publicCreatorToProfile(c: PublicCreator): CreatorProfile {
+  return {
+    id: c.id,
+    username: c.username,
+    displayName: c.display_name,
+    bio: c.bio ?? '',
+    avatarUrl: c.avatar_url ?? undefined,
+    subscriberCount: c.followers_count,
+    subscriptionPrice: 0,
+    isVerified: c.is_verified,
+    categories: [],
+    socialLinks: [],
+  };
 }

--- a/frontend/src/lib/api/posts.test.ts
+++ b/frontend/src/lib/api/posts.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getPostsByAuthor,
+  getPublishedPostsByAuthor,
+  publicPostToCreatorPost,
+  type PublicPost,
+} from './posts';
+
+global.fetch = vi.fn() as any;
+
+function mockFetchOk(body: unknown) {
+  (fetch as any).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(body),
+  });
+}
+
+function makePost(overrides: Partial<PublicPost> = {}): PublicPost {
+  return {
+    id: 'post-1',
+    title: 'Studio tour',
+    content: 'Behind the scenes of my latest project.',
+    authorId: 'author-1',
+    isPublished: true,
+    isPremium: false,
+    likesCount: 12,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('getPostsByAuthor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches posts for the given author with credentials included', async () => {
+    mockFetchOk({ data: [], total: 0, page: 1, limit: 20, hasMore: false });
+
+    await getPostsByAuthor('author-1');
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/posts/author/author-1'),
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+
+  it('throws with the server message on a non-ok response', async () => {
+    (fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockResolvedValue({ message: 'Internal server error' }),
+    });
+
+    await expect(getPostsByAuthor('author-1')).rejects.toThrow('Internal server error');
+  });
+});
+
+describe('publicPostToCreatorPost', () => {
+  it('maps a short post without truncating the excerpt', () => {
+    const post = makePost({ content: 'Short post' });
+
+    const mapped = publicPostToCreatorPost(post);
+
+    expect(mapped).toEqual({
+      id: 'post-1',
+      title: 'Studio tour',
+      type: 'text',
+      excerpt: 'Short post',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      isLocked: false,
+      likeCount: 12,
+    });
+  });
+
+  it('truncates long content with an ellipsis', () => {
+    const longContent = 'a'.repeat(200);
+    const post = makePost({ content: longContent });
+
+    const mapped = publicPostToCreatorPost(post);
+
+    expect(mapped.excerpt?.endsWith('…')).toBe(true);
+    expect(mapped.excerpt?.length).toBeLessThan(longContent.length);
+  });
+
+  it('maps isPremium to isLocked', () => {
+    const post = makePost({ isPremium: true });
+
+    expect(publicPostToCreatorPost(post).isLocked).toBe(true);
+  });
+});
+
+describe('getPublishedPostsByAuthor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters out unpublished posts before mapping', async () => {
+    mockFetchOk({
+      data: [
+        makePost({ id: 'p1', isPublished: true }),
+        makePost({ id: 'p2', isPublished: false }),
+      ],
+      total: 2,
+      page: 1,
+      limit: 20,
+      hasMore: false,
+    });
+
+    const result = await getPublishedPostsByAuthor('author-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('p1');
+  });
+
+  it('returns an empty array when the author has no published posts', async () => {
+    mockFetchOk({
+      data: [makePost({ isPublished: false })],
+      total: 1,
+      page: 1,
+      limit: 20,
+      hasMore: false,
+    });
+
+    const result = await getPublishedPostsByAuthor('author-1');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/frontend/src/lib/api/posts.ts
+++ b/frontend/src/lib/api/posts.ts
@@ -1,0 +1,83 @@
+/**
+ * Posts API client.
+ */
+import type { CreatorPost } from '@/lib/creator-profile';
+
+const EXCERPT_LENGTH = 140;
+
+export interface PublicPost {
+  id: string;
+  title: string;
+  content: string;
+  authorId: string;
+  isPublished: boolean;
+  isPremium: boolean;
+  likesCount: number;
+  createdAt: string;
+}
+
+export interface PostsPage {
+  data: PublicPost[];
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api/v1';
+
+export async function getPostsByAuthor(
+  authorId: string,
+  params: { page?: number; limit?: number } = {},
+): Promise<PostsPage> {
+  const qs = new URLSearchParams();
+  if (params.page) qs.set('page', String(params.page));
+  if (params.limit) qs.set('limit', String(params.limit));
+
+  const res = await fetch(`${API_BASE}/posts/author/${encodeURIComponent(authorId)}?${qs.toString()}`, {
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { message?: string }).message ?? `Request failed: ${res.status}`);
+  }
+  return res.json() as Promise<PostsPage>;
+}
+
+/**
+ * Map an API post to the CreatorPost shape used by ContentCard.
+ *
+ * `GET /posts/author/:authorId` doesn't filter on isPublished (it's shared
+ * with the author's own dashboard, which needs to see drafts), so callers
+ * displaying posts on a public profile must filter for isPublished
+ * themselves — see getPublishedPostsByAuthor below.
+ *
+ * The backend doesn't track media type, thumbnails, or view counts yet, so
+ * those fall back to sensible defaults rather than fabricated data.
+ */
+export function publicPostToCreatorPost(post: PublicPost): CreatorPost {
+  return {
+    id: post.id,
+    title: post.title,
+    type: 'text',
+    excerpt:
+      post.content.length > EXCERPT_LENGTH
+        ? `${post.content.slice(0, EXCERPT_LENGTH).trimEnd()}…`
+        : post.content,
+    publishedAt: post.createdAt,
+    isLocked: post.isPremium,
+    likeCount: post.likesCount,
+  };
+}
+
+/**
+ * Fetch a page of a creator's posts and filter to published ones only,
+ * mapped to the CreatorPost shape for public display.
+ */
+export async function getPublishedPostsByAuthor(
+  authorId: string,
+  params: { page?: number; limit?: number } = {},
+): Promise<CreatorPost[]> {
+  const page = await getPostsByAuthor(authorId, params);
+  return page.data.filter((post) => post.isPublished).map(publicPostToCreatorPost);
+}


### PR DESCRIPTION
Closes #1358.

The profile page at `/creator/[username]` rendered entirely from `MOCK_CREATORS`/`MOCK_POSTS` in `src/lib/creator-profile.ts`. Identity and posts now come from the real API, following the same client/mapping-layer pattern the Discover page already established.

**Backend:** added `GET /v1/creators/username/:username` for an exact-match public profile lookup (the existing search endpoint only does prefix matching, which isn't right for 404 semantics on a direct profile visit). Extended `PublicCreatorDto` with `is_verified` and `followers_count` so the profile hero shows real verification/subscriber data instead of hardcoded false/0.

**Frontend:** added `getCreatorProfile()` and `getPostsByAuthor()` API clients, plus mapping helpers (`publicCreatorToProfile`, `publicPostToCreatorPost`) with Vitest coverage. `generateStaticParams` now pre-renders known usernames from the real creator list, falling back to an empty array if the backend is unreachable at build time, so ISR still covers every profile on first request. Unknown usernames 404 via the real lookup instead of the mock map.

Also pulled the `isPublished` filter into `getPublishedPostsByAuthor` on the frontend, since `GET /posts/author/:authorId` doesn't filter drafts (it's shared with the author's own dashboard). A public profile page built on the raw endpoint would have leaked unpublished posts.

**Plans** stayed on mock data. The backend's only "Plan" concept is an in-memory, wallet-address-keyed on-chain subscription definition (asset/amount/intervalDays) with no relationship to the marketing-tier shape the profile page needs (name, price, billing period, features, "popular" flag). There's no real model to migrate from yet, so I left a comment pointing back at this issue rather than pretending to migrate something that doesn't exist on the backend. Happy to scope a follow-up for a real Plans/Tiers backend feature if that's wanted.

While in here, deduplicated the API-to-CreatorProfile mapping that Discover had inlined as `apiCreatorToProfile`. It's now the shared `publicCreatorToProfile` export both pages use.

**Testing:**

- **Backend:** creators module test suite (224 tests) green, including new coverage for `getCreatorByUsername` (exact match, case-insensitivity, not-found).
- **Frontend:** new Vitest coverage for `getCreatorProfile`/`publicCreatorToProfile` and `getPostsByAuthor`/`publicPostToCreatorPost`/`getPublishedPostsByAuthor` (13 tests, all passing).

Verified no regressions: diffed `tsc`/`eslint`/`vitest` output against clean main. This branch has fewer lint/type errors and fewer failing tests than baseline, not more. The repo has a number of pre-existing, unrelated failures (a jest/vitest API mismatch in `metadata.test.ts`, a `vi.mock` hoisting bug in `DiscoverContent.test.tsx`, a missing `linkedWallet` mock elsewhere) that this PR doesn't touch or worsen.
