### PR TITLE
fix(ci): repair backend tests, backend build, and frontend build

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,11 +1,13 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { Public } from './common/decorators/public.decorator';
 
 @Controller({ version: '1' })
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
+  @Public()
   getHello(): string {
     return this.appService.getHello();
   }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,7 +8,6 @@ import { OpenAPIController } from './common/openapi-publish.controller';
 import { ThrottlerGuard } from './auth/throttler.guard';
 import { JwtAuthGuard } from './auth-module/guards/jwt-auth.guard';
 import { RolesGuard } from './auth-module/guards/roles.guard';
-import { PublicGuard } from './auth-module/guards/public.guard';
 import { LoggingModule } from './common/logging.module';
 import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware';
 import { LoggingMiddleware } from './common/middleware/logging.middleware';
@@ -65,9 +64,10 @@ const IDEMPOTENCY_ROUTES = [
   providers: [
     AppService,
     { provide: APP_GUARD, useClass: ThrottlerGuard },
+    // JwtAuthGuard authenticates every route unless it opts out with @Public();
+    // RolesGuard then enforces @Roles() on the routes that declare one.
     { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: RolesGuard },
-    { provide: APP_GUARD, useClass: PublicGuard },
     RequestContextService,
     {
       provide: APP_FILTER,

--- a/backend/src/auth-module/guards/jwt-auth.guard.spec.ts
+++ b/backend/src/auth-module/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,49 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AuthGuard } from '@nestjs/passport';
+import { JwtAuthGuard } from './jwt-auth.guard';
+import { IS_PUBLIC_KEY } from '../../common/decorators/public.decorator';
+
+describe('JwtAuthGuard', () => {
+  let guard: JwtAuthGuard;
+  let reflectorMock: jest.Mocked<Reflector>;
+
+  const context = {
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+  } as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    reflectorMock = {
+      getAllAndOverride: jest.fn(),
+    } as unknown as jest.Mocked<Reflector>;
+    guard = new JwtAuthGuard(reflectorMock);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('allows routes marked @Public() without authenticating', () => {
+    reflectorMock.getAllAndOverride.mockReturnValue(true);
+    const superSpy = jest.spyOn(AuthGuard('jwt').prototype, 'canActivate');
+
+    expect(guard.canActivate(context)).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(reflectorMock.getAllAndOverride).toHaveBeenCalledWith(
+      IS_PUBLIC_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    expect(superSpy).not.toHaveBeenCalled();
+  });
+
+  it('delegates to passport JWT authentication on protected routes', () => {
+    reflectorMock.getAllAndOverride.mockReturnValue(undefined);
+    const superSpy = jest
+      .spyOn(AuthGuard('jwt').prototype, 'canActivate')
+      .mockReturnValue(true);
+
+    expect(guard.canActivate(context)).toBe(true);
+    expect(superSpy).toHaveBeenCalledWith(context);
+  });
+});

--- a/backend/src/auth-module/guards/jwt-auth.guard.ts
+++ b/backend/src/auth-module/guards/jwt-auth.guard.ts
@@ -1,5 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../../common/decorators/public.decorator';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') { }
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private readonly reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    return super.canActivate(context);
+  }
+}

--- a/backend/src/auth-module/guards/roles.guard.spec.ts
+++ b/backend/src/auth-module/guards/roles.guard.spec.ts
@@ -8,7 +8,9 @@ describe('RolesGuard', () => {
   let reflectorMock: jest.Mocked<Reflector>;
 
   beforeEach(() => {
-    reflectorMock = { getAllAndOverride: jest.fn() } as any;
+    reflectorMock = {
+      getAllAndOverride: jest.fn(),
+    } as unknown as jest.Mocked<Reflector>;
     guard = new RolesGuard(reflectorMock);
   });
 
@@ -24,20 +26,44 @@ describe('RolesGuard', () => {
 
   it('should allow access if user has required role', () => {
     reflectorMock.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
-    const ctx = { 
+    const ctx = {
       getHandler: jest.fn(),
       getClass: jest.fn(),
-      switchToHttp: () => ({ getRequest: () => ({ user: { role: UserRole.ADMIN } }) }) 
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role: UserRole.ADMIN } }),
+      }),
+    } as unknown as ExecutionContext;
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('should deny access if the request carries no authenticated user', () => {
+    reflectorMock.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
+    const ctx = {
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+      switchToHttp: () => ({ getRequest: () => ({}) }),
+    } as unknown as ExecutionContext;
+    expect(guard.canActivate(ctx)).toBe(false);
+  });
+
+  it('should allow access if the roles metadata is an empty list', () => {
+    reflectorMock.getAllAndOverride.mockReturnValue([]);
+    const ctx = {
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+      switchToHttp: () => ({ getRequest: () => ({}) }),
     } as unknown as ExecutionContext;
     expect(guard.canActivate(ctx)).toBe(true);
   });
 
   it('should deny access if user lacks required role', () => {
     reflectorMock.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
-    const ctx = { 
+    const ctx = {
       getHandler: jest.fn(),
       getClass: jest.fn(),
-      switchToHttp: () => ({ getRequest: () => ({ user: { role: UserRole.USER } }) }) 
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role: UserRole.USER } }),
+      }),
     } as unknown as ExecutionContext;
     expect(guard.canActivate(ctx)).toBe(false);
   });

--- a/backend/src/auth-module/guards/roles.guard.ts
+++ b/backend/src/auth-module/guards/roles.guard.ts
@@ -1,22 +1,32 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { UserRole } from '../../common/enums/user-role.enum';
+import { ROLES_KEY } from '../decorators/roles.decorator';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>('roles', [
-      context.getHandler(),
-      context.getClass(),
-    ]);
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
 
-    if (!requiredRoles) {
+    if (!requiredRoles || requiredRoles.length === 0) {
       return true;
     }
 
-    const { user } = context.switchToHttp().getRequest();
+    const { user } = context
+      .switchToHttp()
+      .getRequest<{ user?: { role?: UserRole } }>();
+
+    // No authenticated principal on a role-restricted route: deny with 403
+    // instead of raising a 500 by dereferencing an undefined user.
+    if (!user) {
+      return false;
+    }
+
     return requiredRoles.some((role) => user.role === role);
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -24,8 +24,7 @@ import { AuthService } from './auth.service';
 import { WalletAuthService } from './wallet-auth.service';
 import { RequestChallengeDto, VerifyChallengeDto } from './wallet-auth.dto';
 import { Deprecated, DeprecationInterceptor } from '../common/deprecation';
-import { PublicGuard } from '../auth-module/guards/public.guard';
-import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
+import { Public } from '../common/decorators/public.decorator';
 import { AuthExceptionFilter } from './filters/auth-exception.filter';
 import { LoginBodyDto } from './dto/login-body.dto';
 import {
@@ -44,6 +43,7 @@ const X_NETWORK_HEADER = {
 } as const;
 
 @ApiTags('auth')
+@Public()
 @UseGuards(ThrottlerGuard)
 @UseFilters(new AuthExceptionFilter())
 @Controller({ path: 'auth', version: '1' })
@@ -76,9 +76,21 @@ export class AuthController {
   @ApiOperation({ summary: 'Authenticate with a Stellar wallet address' })
   @ApiHeader(X_NETWORK_HEADER)
   @ApiBody({ type: LoginBodyDto })
-  @ApiResponse({ status: 201, description: 'Session created', type: SessionResponseDto })
-  @ApiResponse({ status: 400, description: 'Invalid Stellar address or network mismatch', type: AuthErrorResponseDto })
-  @ApiResponse({ status: 429, description: 'Too many requests', type: AuthErrorResponseDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Session created',
+    type: SessionResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid Stellar address or network mismatch',
+    type: AuthErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Too many requests',
+    type: AuthErrorResponseDto,
+  })
   async login(
     @Body() body: { address?: string },
     @Headers('x-network') requestNetwork?: string,
@@ -99,12 +111,27 @@ export class AuthController {
     message: 'Use POST /v1/auth/login instead. Removal date: 2026-01-01.',
   })
   @UseInterceptors(new DeprecationInterceptor(new Reflector()))
-  @ApiOperation({ summary: '[Deprecated] Register with a Stellar wallet address', deprecated: true })
+  @ApiOperation({
+    summary: '[Deprecated] Register with a Stellar wallet address',
+    deprecated: true,
+  })
   @ApiHeader(X_NETWORK_HEADER)
   @ApiBody({ type: LoginBodyDto })
-  @ApiResponse({ status: 201, description: 'Session created', type: SessionResponseDto })
-  @ApiResponse({ status: 400, description: 'Invalid Stellar address or network mismatch', type: AuthErrorResponseDto })
-  @ApiResponse({ status: 429, description: 'Too many requests', type: AuthErrorResponseDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Session created',
+    type: SessionResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid Stellar address or network mismatch',
+    type: AuthErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Too many requests',
+    type: AuthErrorResponseDto,
+  })
   async register(
     @Body() body: { address?: string },
     @Headers('x-network') requestNetwork?: string,
@@ -122,12 +149,25 @@ export class AuthController {
   @Throttle({ auth: { limit: 5, ttl: 60000 } })
   @ApiOperation({
     summary: 'Request a sign-in challenge for a Stellar wallet',
-    description: 'Returns a one-time nonce the wallet must sign. The challenge expires after 5 minutes.',
+    description:
+      'Returns a one-time nonce the wallet must sign. The challenge expires after 5 minutes.',
   })
   @ApiHeader(X_NETWORK_HEADER)
-  @ApiResponse({ status: 200, description: 'Nonce and expiry returned', type: ChallengeResponseDto })
-  @ApiResponse({ status: 400, description: 'Invalid Stellar address or network mismatch', type: AuthErrorResponseDto })
-  @ApiResponse({ status: 429, description: 'Too many requests', type: AuthErrorResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Nonce and expiry returned',
+    type: ChallengeResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid Stellar address or network mismatch',
+    type: AuthErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Too many requests',
+    type: AuthErrorResponseDto,
+  })
   async requestChallenge(
     @Body() dto: RequestChallengeDto,
     @Headers('x-network') requestNetwork?: string,
@@ -144,13 +184,30 @@ export class AuthController {
   @Throttle({ auth: { limit: 5, ttl: 60000 } })
   @ApiOperation({
     summary: 'Verify wallet signature and receive JWT',
-    description: 'Validates the Ed25519 signature against the previously issued nonce and returns a Bearer token on success.',
+    description:
+      'Validates the Ed25519 signature against the previously issued nonce and returns a Bearer token on success.',
   })
   @ApiHeader(X_NETWORK_HEADER)
-  @ApiResponse({ status: 200, description: 'JWT access token', type: TokenResponseDto })
-  @ApiResponse({ status: 400, description: 'Invalid Stellar address or signature', type: AuthErrorResponseDto })
-  @ApiResponse({ status: 401, description: 'Expired or replayed challenge', type: AuthErrorResponseDto })
-  @ApiResponse({ status: 429, description: 'Too many requests', type: AuthErrorResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'JWT access token',
+    type: TokenResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid Stellar address or signature',
+    type: AuthErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Expired or replayed challenge',
+    type: AuthErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Too many requests',
+    type: AuthErrorResponseDto,
+  })
   async verifyChallenge(
     @Body() dto: VerifyChallengeDto,
     @Headers('x-network') requestNetwork?: string,

--- a/backend/src/auth/throttler.guard.spec.ts
+++ b/backend/src/auth/throttler.guard.spec.ts
@@ -1,12 +1,18 @@
 import { ExecutionContext } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ThrottlerGuard } from './throttler.guard';
-import { ThrottlerModule } from '@nestjs/throttler';
+import {
+  ThrottlerModule,
+  ThrottlerGuard as NestThrottlerGuard,
+} from '@nestjs/throttler';
 
 describe('ThrottlerGuard', () => {
   let guard: ThrottlerGuard;
 
-  const mockExecutionContext = (url: string, method: string = 'GET'): ExecutionContext => {
+  const mockExecutionContext = (
+    url: string,
+    method: string = 'GET',
+  ): ExecutionContext => {
     const mockRequest = {
       url,
       method,
@@ -17,8 +23,8 @@ describe('ThrottlerGuard', () => {
       switchToHttp: () => ({
         getRequest: () => mockRequest,
       }),
-      getHandler: () => (() => {}) as any,
-      getClass: () => (() => {}) as any,
+      getHandler: () => () => {},
+      getClass: () => () => {},
     } as unknown as ExecutionContext;
   };
 
@@ -34,67 +40,55 @@ describe('ThrottlerGuard', () => {
       providers: [ThrottlerGuard],
     }).compile();
 
+    // init() (not just compile()) so the base guard's onModuleInit runs and
+    // populates its throttler config.
+    await module.init();
+
     guard = module.get<ThrottlerGuard>(ThrottlerGuard);
   });
 
   describe('Health Check Exemption', () => {
-    it('should exempt /health endpoint', async () => {
-      const context = mockExecutionContext('/health');
-      const result = await guard.canActivate(context);
-      expect(result).toBe(true);
+    // Only the cheap liveness probe is exempt. The expensive sub-checks are
+    // deliberately throttled so scanning probes cannot exhaust resources.
+    let superCanActivate: jest.SpyInstance;
+
+    beforeEach(() => {
+      superCanActivate = jest
+        .spyOn(NestThrottlerGuard.prototype, 'canActivate')
+        .mockResolvedValue(true);
     });
 
-    it('should exempt /v1/health endpoint', async () => {
-      const context = mockExecutionContext('/v1/health');
-      const result = await guard.canActivate(context);
-      expect(result).toBe(true);
+    afterEach(() => {
+      superCanActivate.mockRestore();
     });
 
-    it('should exempt /health/db endpoint', async () => {
-      const context = mockExecutionContext('/health/db');
-      const result = await guard.canActivate(context);
-      expect(result).toBe(true);
-    });
+    it.each(['/health', '/v1/health'])(
+      'exempts %s without consulting the throttler',
+      async (url) => {
+        await expect(
+          guard.canActivate(mockExecutionContext(url)),
+        ).resolves.toBe(true);
+        expect(superCanActivate).not.toHaveBeenCalled();
+      },
+    );
 
-    it('should exempt /v1/health/db endpoint', async () => {
-      const context = mockExecutionContext('/v1/health/db');
-      const result = await guard.canActivate(context);
-      expect(result).toBe(true);
-    });
-
-    it('should exempt /health/redis endpoint', async () => {
-      const context = mockExecutionContext('/health/redis');
-      const result = await guard.canActivate(context);
-      expect(result).toBe(true);
-    });
-
-    it('should exempt /v1/health/soroban endpoint', async () => {
-      const context = mockExecutionContext('/v1/health/soroban');
-      const result = await guard.canActivate(context);
-      expect(result).toBe(true);
-    });
-
-    it('should exempt /health/queue-metrics endpoint', async () => {
-      const context = mockExecutionContext('/health/queue-metrics');
-      const result = await guard.canActivate(context);
-      expect(result).toBe(true);
-    });
-
-    it('should exempt /v1/health/queue-metrics endpoint', async () => {
-      const context = mockExecutionContext('/v1/health/queue-metrics');
-      const result = await guard.canActivate(context);
-      expect(result).toBe(true);
-    });
-
-    it('should exempt /v1/health/soroban-contract endpoint', async () => {
-      const context = mockExecutionContext('/v1/health/soroban-contract');
-      const result = await guard.canActivate(context);
-      expect(result).toBe(true);
+    it.each([
+      '/health/db',
+      '/v1/health/db',
+      '/health/redis',
+      '/v1/health/soroban',
+      '/health/queue-metrics',
+      '/v1/health/queue-metrics',
+      '/v1/health/soroban-contract',
+    ])('throttles %s like any other route', async (url) => {
+      await guard.canActivate(mockExecutionContext(url));
+      expect(superCanActivate).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('Guard Interface', () => {
     it('should implement CanActivate interface', () => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(guard.canActivate).toBeDefined();
       expect(typeof guard.canActivate).toBe('function');
     });

--- a/backend/src/comments/comments.swagger.spec.ts
+++ b/backend/src/comments/comments.swagger.spec.ts
@@ -1,65 +1,100 @@
 import { CommentsController } from './comments.controller';
 
-describe('CommentsController – Swagger/OpenAPI documentation', () => {
-  const proto = CommentsController.prototype;
+// Decorator metadata lives on the unbound prototype methods, so reading it
+// back is exactly what these specs are meant to do.
 
-  const endpoints = ['create', 'findAll', 'findByPost', 'findOne', 'update', 'remove'];
+describe('CommentsController – Swagger/OpenAPI documentation', () => {
+  const proto = CommentsController.prototype as unknown as Record<
+    string,
+    object
+  >;
+
+  const endpoints = [
+    'create',
+    'findAll',
+    'findByPost',
+    'findOne',
+    'update',
+    'remove',
+  ];
 
   it.each(endpoints)('%s has ApiOperation metadata', (method) => {
-    const metadata = Reflect.getMetadata('swagger/apiOperation', proto[method]);
+    const metadata = Reflect.getMetadata(
+      'swagger/apiOperation',
+      proto[method],
+    ) as { summary?: string } | undefined;
     expect(metadata).toBeDefined();
-    expect(metadata.summary).toBeDefined();
-    expect(metadata.summary.length).toBeGreaterThan(0);
+    expect(metadata?.summary).toBeDefined();
+    expect(metadata?.summary?.length).toBeGreaterThan(0);
   });
 
   it.each(endpoints)('%s has at least one ApiResponse metadata', (method) => {
-    const metadata = Reflect.getMetadata('swagger/apiResponse', proto[method]);
+    const metadata = Reflect.getMetadata(
+      'swagger/apiResponse',
+      proto[method],
+    ) as Record<string, unknown> | undefined;
     expect(metadata).toBeDefined();
-    expect(Object.keys(metadata).length).toBeGreaterThan(0);
+    expect(Object.keys(metadata ?? {}).length).toBeGreaterThan(0);
   });
 
   it('controller class has ApiTags metadata', () => {
-    const tags = Reflect.getMetadata('swagger/apiUseTags', CommentsController);
+    const tags = Reflect.getMetadata(
+      'swagger/apiUseTags',
+      CommentsController,
+    ) as string[];
     expect(tags).toContain('comments');
   });
 
   const writeEndpoints = ['create', 'update', 'remove'];
 
   it.each(writeEndpoints)('%s documents 429 rate-limit response', (method) => {
-    const metadata = Reflect.getMetadata('swagger/apiResponse', proto[method]);
+    const metadata = Reflect.getMetadata(
+      'swagger/apiResponse',
+      proto[method],
+    ) as Record<string, { description: string } | undefined>;
     expect(metadata['429']).toBeDefined();
-    expect(metadata['429'].description).toMatch(/too many requests/i);
+    expect(metadata['429']?.description).toMatch(/too many requests/i);
   });
 
   const paramEndpoints = ['findOne', 'update', 'remove'];
 
   it.each(paramEndpoints)('%s has ApiParam metadata for id', (method) => {
-    const params = Reflect.getMetadata('swagger/apiParameters', proto[method]);
+    const params = Reflect.getMetadata(
+      'swagger/apiParameters',
+      proto[method],
+    ) as { name: string }[];
     expect(params).toBeDefined();
-    const idParam = params.find((p: { name: string }) => p.name === 'id');
+    const idParam = params.find((p) => p.name === 'id');
     expect(idParam).toBeDefined();
   });
 
   it('findByPost has ApiParam metadata for postId', () => {
-    const params = Reflect.getMetadata('swagger/apiParameters', proto.findByPost);
+    const params = Reflect.getMetadata(
+      'swagger/apiParameters',
+      proto.findByPost,
+    ) as { name: string }[];
     expect(params).toBeDefined();
-    const postIdParam = params.find((p: { name: string }) => p.name === 'postId');
+    const postIdParam = params.find((p) => p.name === 'postId');
     expect(postIdParam).toBeDefined();
   });
 
-  it('create has ApiBody metadata', () => {
-    const body = Reflect.getMetadata('swagger/apiBody', proto.create);
-    expect(body).toBeDefined();
+  // @ApiBody and @ApiQuery both write into the shared apiParameters array and
+  // are told apart by their `in` field — there is no per-decorator metadata key.
+  const parametersIn = (method: string, location: string) =>
+    (
+      (Reflect.getMetadata('swagger/apiParameters', proto[method]) ?? []) as {
+        in: string;
+      }[]
+    ).filter((p) => p.in === location);
+
+  it.each(['create', 'update'])('%s has ApiBody metadata', (method) => {
+    expect(parametersIn(method, 'body').length).toBeGreaterThan(0);
   });
 
-  it('update has ApiBody metadata', () => {
-    const body = Reflect.getMetadata('swagger/apiBody', proto.update);
-    expect(body).toBeDefined();
-  });
-
-  it.each(['findAll', 'findByPost'])('%s has ApiQuery metadata for pagination', (method) => {
-    const queries = Reflect.getMetadata('swagger/apiQuery', proto[method]);
-    expect(queries).toBeDefined();
-    expect(queries.length).toBeGreaterThan(0);
-  });
+  it.each(['findAll', 'findByPost'])(
+    '%s has ApiQuery metadata for pagination',
+    (method) => {
+      expect(parametersIn(method, 'query').length).toBeGreaterThan(0);
+    },
+  );
 });

--- a/backend/src/comments/comments.throttle.spec.ts
+++ b/backend/src/comments/comments.throttle.spec.ts
@@ -5,11 +5,18 @@ import { CommentsController } from './comments.controller';
 import { CommentsService } from './comments.service';
 import { Comment } from './entities/comment.entity';
 
+// Decorator metadata lives on the unbound prototype methods, so reading it
+// back is exactly what these specs are meant to do.
+/* eslint-disable @typescript-eslint/unbound-method */
+
 describe('CommentsController – rate limiting', () => {
   let controller: CommentsController;
 
   const mockService: jest.Mocked<
-    Pick<CommentsService, 'create' | 'findAll' | 'findByPost' | 'findOne' | 'update' | 'remove'>
+    Pick<
+      CommentsService,
+      'create' | 'findAll' | 'findByPost' | 'findOne' | 'update' | 'remove'
+    >
   > = {
     create: jest.fn(),
     findAll: jest.fn(),
@@ -21,7 +28,9 @@ describe('CommentsController – rate limiting', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [ThrottlerModule.forRoot([{ name: 'short', ttl: 60000, limit: 10 }])],
+      imports: [
+        ThrottlerModule.forRoot([{ name: 'short', ttl: 60000, limit: 10 }]),
+      ],
       controllers: [CommentsController],
       providers: [
         { provide: CommentsService, useValue: mockService },
@@ -35,48 +44,51 @@ describe('CommentsController – rate limiting', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('has ThrottlerGuard applied at controller level', () => {
-    const guards = Reflect.getMetadata('__guards__', CommentsController);
+    const guards = Reflect.getMetadata(
+      '__guards__',
+      CommentsController,
+    ) as unknown;
     expect(guards).toBeDefined();
     expect(guards).toContain(ThrottlerGuard);
   });
 
   it('create has throttle metadata', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITshort',
       CommentsController.prototype.create,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('update has throttle metadata', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITshort',
       CommentsController.prototype.update,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('remove has throttle metadata', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITshort',
       CommentsController.prototype.remove,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('findAll does not have throttle metadata', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITshort',
       CommentsController.prototype.findAll,
-    );
+    ) as unknown;
     expect(metadata).toBeUndefined();
   });
 
   it('findOne does not have throttle metadata', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITshort',
       CommentsController.prototype.findOne,
-    );
+    ) as unknown;
     expect(metadata).toBeUndefined();
   });
 
@@ -90,7 +102,9 @@ describe('CommentsController – rate limiting', () => {
 
     mockService.update.mockResolvedValue({} as any);
     await controller.update('comment-1', { content: 'Updated' });
-    expect(mockService.update).toHaveBeenCalledWith('comment-1', { content: 'Updated' });
+    expect(mockService.update).toHaveBeenCalledWith('comment-1', {
+      content: 'Updated',
+    });
 
     mockService.remove.mockResolvedValue(undefined);
     await controller.remove('comment-1');

--- a/backend/src/comments/filters/comments-exception.filter.ts
+++ b/backend/src/comments/filters/comments-exception.filter.ts
@@ -16,6 +16,9 @@ export interface CommentErrorResponse {
   path: string;
 }
 
+// Machine-readable error codes are SCREAMING_SNAKE_CASE.
+const MACHINE_ERROR_CODE = /^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/;
+
 @Catch()
 export class CommentsExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(CommentsExceptionFilter.name);
@@ -34,7 +37,7 @@ export class CommentsExceptionFilter implements ExceptionFilter {
       exception instanceof HttpException ? exception.getResponse() : null;
 
     let message = 'Internal server error';
-    let error = 'INTERNAL_ERROR';
+    let error: string | undefined;
 
     if (exception instanceof HttpException) {
       if (typeof exceptionResponse === 'string') {
@@ -50,7 +53,15 @@ export class CommentsExceptionFilter implements ExceptionFilter {
             : Array.isArray(resp.message)
               ? resp.message.join('; ')
               : exception.message;
-        error = typeof resp.error === 'string' ? resp.error : this.statusToError(status);
+        // Keep a caller-supplied machine code (e.g. VALIDATION_FAILED) but drop
+        // Nest's human reason phrases ("Bad Request") so statusToError below
+        // yields the stable code clients actually match on.
+        if (
+          typeof resp.error === 'string' &&
+          MACHINE_ERROR_CODE.test(resp.error)
+        ) {
+          error = resp.error;
+        }
       }
     } else if (exception instanceof Error) {
       message = exception.message;

--- a/backend/src/common/openapi-publish.controller.ts
+++ b/backend/src/common/openapi-publish.controller.ts
@@ -4,23 +4,25 @@ import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import type { Response } from 'express';
 import { AppModule } from '../app.module';
+import { Public } from './decorators/public.decorator';
 
 @ApiTags('system')
 @Controller({ path: 'system', version: '1' })
 export class OpenAPIController {
-    @Get('openapi.json')
-    @ApiOperation({ summary: 'Get the raw OpenAPI JSON specification' })
-    @ApiResponse({ status: 200, description: 'OpenAPI specification' })
-    async getOpenApi(@Res() res: Response) {
-        const app = await NestFactory.create(AppModule, { logger: false });
-        const config = new DocumentBuilder()
-            .setTitle('MyFans API')
-            .setDescription('MyFans backend REST API')
-            .setVersion('1.0')
-            .addBearerAuth()
-            .build();
-        const document = SwaggerModule.createDocument(app, config);
-        await app.close();
-        return res.json(document);
-    }
+  @Get('openapi.json')
+  @Public()
+  @ApiOperation({ summary: 'Get the raw OpenAPI JSON specification' })
+  @ApiResponse({ status: 200, description: 'OpenAPI specification' })
+  async getOpenApi(@Res() res: Response) {
+    const app = await NestFactory.create(AppModule, { logger: false });
+    const config = new DocumentBuilder()
+      .setTitle('MyFans API')
+      .setDescription('MyFans backend REST API')
+      .setVersion('1.0')
+      .addBearerAuth()
+      .build();
+    const document = SwaggerModule.createDocument(app, config);
+    await app.close();
+    return res.json(document);
+  }
 }

--- a/backend/src/conversations/conversations.controller.spec.ts
+++ b/backend/src/conversations/conversations.controller.spec.ts
@@ -1,70 +1,79 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { NotFoundException } from '@nestjs/common';
 import { ConversationsController } from './conversations.controller';
 import { ConversationsService } from './conversations.service';
-import { ConversationDto, MessageDto, CreateConversationDto, SendMessageDto } from './dto';
+import {
+  ConversationDto,
+  MessageDto,
+  CreateConversationDto,
+  SendMessageDto,
+} from './dto';
 import { PaginatedResponseDto } from '../common/dto';
 
-const makeConversationDto = (overrides: Partial<ConversationDto> = {}): ConversationDto =>
-  ({
-    id: 'conv-1',
-    participant1Id: 'temp-user-id',
-    participant2Id: 'user-2',
-    lastMessageId: null,
-    createdAt: new Date('2026-01-01T00:00:00Z'),
-    updatedAt: new Date('2026-01-01T00:00:00Z'),
-    ...overrides,
-  }) as ConversationDto;
+const makeConversationDto = (
+  overrides: Partial<ConversationDto> = {},
+): ConversationDto => ({
+  id: 'conv-1',
+  participant1Id: 'temp-user-id',
+  participant2Id: 'user-2',
+  lastMessageId: null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  ...overrides,
+});
 
-const makeMessageDto = (overrides: Partial<MessageDto> = {}): MessageDto =>
-  ({
-    id: 'msg-1',
-    conversationId: 'conv-1',
-    senderId: 'temp-user-id',
-    content: 'Hello!',
-    isRead: false,
-    createdAt: new Date('2026-01-01T00:00:00Z'),
-    ...overrides,
-  }) as MessageDto;
+const makeMessageDto = (overrides: Partial<MessageDto> = {}): MessageDto => ({
+  id: 'msg-1',
+  conversationId: 'conv-1',
+  senderId: 'temp-user-id',
+  content: 'Hello!',
+  isRead: false,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  ...overrides,
+});
 
 const makePaginatedConversations = (
   data: ConversationDto[],
   overrides?: Partial<PaginatedResponseDto<ConversationDto>>,
-): PaginatedResponseDto<ConversationDto> =>
-  ({
-    data,
-    total: data.length,
-    page: 1,
-    limit: 20,
-    totalPages: 1,
-    hasMore: false,
-    nextCursor: null,
-    cursor: null,
-    ...overrides,
-  }) as PaginatedResponseDto<ConversationDto>;
+): PaginatedResponseDto<ConversationDto> => ({
+  data,
+  total: data.length,
+  page: 1,
+  limit: 20,
+  totalPages: 1,
+  hasMore: false,
+  nextCursor: null,
+  cursor: null,
+  ...overrides,
+});
 
 const makePaginatedMessages = (
   data: MessageDto[],
   overrides?: Partial<PaginatedResponseDto<MessageDto>>,
-): PaginatedResponseDto<MessageDto> =>
-  ({
-    data,
-    total: data.length,
-    page: 1,
-    limit: 20,
-    totalPages: 1,
-    hasMore: false,
-    nextCursor: null,
-    cursor: null,
-    ...overrides,
-  }) as PaginatedResponseDto<MessageDto>;
+): PaginatedResponseDto<MessageDto> => ({
+  data,
+  total: data.length,
+  page: 1,
+  limit: 20,
+  totalPages: 1,
+  hasMore: false,
+  nextCursor: null,
+  cursor: null,
+  ...overrides,
+});
 
 describe('ConversationsController', () => {
   let controller: ConversationsController;
   let service: jest.Mocked<
     Pick<
       ConversationsService,
-      'create' | 'findAll' | 'findOne' | 'getMessages' | 'sendMessage' | 'remove'
+      | 'create'
+      | 'findAll'
+      | 'findOne'
+      | 'getMessages'
+      | 'sendMessage'
+      | 'remove'
     >
   >;
 
@@ -79,6 +88,9 @@ describe('ConversationsController', () => {
     };
 
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot([{ name: 'default', ttl: 60000, limit: 10 }]),
+      ],
       controllers: [ConversationsController],
       providers: [{ provide: ConversationsService, useValue: service }],
     }).compile();
@@ -104,7 +116,10 @@ describe('ConversationsController', () => {
 
     it('returns created conversation with id', async () => {
       const dto: CreateConversationDto = { participant2Id: 'user-99' };
-      const result = makeConversationDto({ id: 'new-conv-id', participant2Id: 'user-99' });
+      const result = makeConversationDto({
+        id: 'new-conv-id',
+        participant2Id: 'user-99',
+      });
       service.create.mockResolvedValue(result);
 
       const actual = await controller.create(dto);
@@ -190,7 +205,9 @@ describe('ConversationsController', () => {
         new NotFoundException('Conversation with id "missing" not found'),
       );
 
-      await expect(controller.findOne('missing')).rejects.toBeInstanceOf(NotFoundException);
+      await expect(controller.findOne('missing')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
     });
 
     it('propagates service errors', async () => {
@@ -210,7 +227,11 @@ describe('ConversationsController', () => {
 
       await controller.getMessages('conv-1', pagination);
 
-      expect(service.getMessages).toHaveBeenCalledWith('temp-user-id', 'conv-1', pagination);
+      expect(service.getMessages).toHaveBeenCalledWith(
+        'temp-user-id',
+        'conv-1',
+        pagination,
+      );
     });
 
     it('returns paginated messages for the conversation', async () => {
@@ -257,7 +278,11 @@ describe('ConversationsController', () => {
 
       await controller.sendMessage('conv-1', dto);
 
-      expect(service.sendMessage).toHaveBeenCalledWith('temp-user-id', 'conv-1', dto);
+      expect(service.sendMessage).toHaveBeenCalledWith(
+        'temp-user-id',
+        'conv-1',
+        dto,
+      );
     });
 
     it('returns the sent message', async () => {
@@ -286,7 +311,9 @@ describe('ConversationsController', () => {
       const dto: SendMessageDto = { content: 'Hi' };
       service.sendMessage.mockRejectedValue(new Error('DB error'));
 
-      await expect(controller.sendMessage('conv-1', dto)).rejects.toThrow('DB error');
+      await expect(controller.sendMessage('conv-1', dto)).rejects.toThrow(
+        'DB error',
+      );
     });
   });
 
@@ -314,7 +341,9 @@ describe('ConversationsController', () => {
         new NotFoundException('Conversation with id "missing" not found'),
       );
 
-      await expect(controller.remove('missing')).rejects.toBeInstanceOf(NotFoundException);
+      await expect(controller.remove('missing')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
     });
 
     it('propagates service errors', async () => {

--- a/backend/src/conversations/conversations.throttle.spec.ts
+++ b/backend/src/conversations/conversations.throttle.spec.ts
@@ -3,6 +3,10 @@ import { ConversationsController } from './conversations.controller';
 import { ConversationsService } from './conversations.service';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 
+// Decorator metadata lives on the unbound prototype methods, so reading it
+// back is exactly what these specs are meant to do.
+/* eslint-disable @typescript-eslint/unbound-method */
+
 describe('ConversationsController – rate limiting', () => {
   let controller: ConversationsController;
 
@@ -17,7 +21,9 @@ describe('ConversationsController – rate limiting', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [ThrottlerModule.forRoot([{ name: 'default', ttl: 60000, limit: 100 }])],
+      imports: [
+        ThrottlerModule.forRoot([{ name: 'default', ttl: 60000, limit: 100 }]),
+      ],
       controllers: [ConversationsController],
       providers: [{ provide: ConversationsService, useValue: mockService }],
     }).compile();
@@ -26,41 +32,44 @@ describe('ConversationsController – rate limiting', () => {
   });
 
   it('should have ThrottlerGuard applied at controller level', () => {
-    const guards = Reflect.getMetadata('__guards__', ConversationsController);
+    const guards = Reflect.getMetadata(
+      '__guards__',
+      ConversationsController,
+    ) as unknown;
     expect(guards).toBeDefined();
     expect(guards).toContain(ThrottlerGuard);
   });
 
   it('should have throttle metadata on create', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITdefault',
       ConversationsController.prototype.create,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('should have throttle metadata on sendMessage', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITdefault',
       ConversationsController.prototype.sendMessage,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('should have throttle metadata on remove', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITdefault',
       ConversationsController.prototype.remove,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('read endpoints do not have explicit throttle overrides', () => {
     for (const method of ['findAll', 'findOne', 'getMessages'] as const) {
       const metadata = Reflect.getMetadata(
-        'THROTTLER:LIMIT',
+        'THROTTLER:LIMITdefault',
         ConversationsController.prototype[method],
-      );
+      ) as unknown;
       expect(metadata).toBeUndefined();
     }
   });

--- a/backend/src/conversations/filters/conversations-exception.filter.ts
+++ b/backend/src/conversations/filters/conversations-exception.filter.ts
@@ -16,6 +16,9 @@ export interface ConversationErrorResponse {
   path: string;
 }
 
+// Machine-readable error codes are SCREAMING_SNAKE_CASE.
+const MACHINE_ERROR_CODE = /^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/;
+
 @Catch()
 export class ConversationsExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(ConversationsExceptionFilter.name);
@@ -34,7 +37,7 @@ export class ConversationsExceptionFilter implements ExceptionFilter {
       exception instanceof HttpException ? exception.getResponse() : null;
 
     let message = 'Internal server error';
-    let error = 'INTERNAL_ERROR';
+    let error: string | undefined;
 
     if (exception instanceof HttpException) {
       if (typeof exceptionResponse === 'string') {
@@ -50,7 +53,15 @@ export class ConversationsExceptionFilter implements ExceptionFilter {
             : Array.isArray(resp.message)
               ? resp.message.join('; ')
               : exception.message;
-        error = typeof resp.error === 'string' ? resp.error : this.statusToError(status);
+        // Keep a caller-supplied machine code (e.g. VALIDATION_FAILED) but drop
+        // Nest's human reason phrases ("Bad Request") so statusToError below
+        // yields the stable code clients actually match on.
+        if (
+          typeof resp.error === 'string' &&
+          MACHINE_ERROR_CODE.test(resp.error)
+        ) {
+          error = resp.error;
+        }
       }
     } else if (exception instanceof Error) {
       message = exception.message;

--- a/backend/src/creators/creators.controller.ts
+++ b/backend/src/creators/creators.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Post, Body, Param, Query, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import { CreatorsService } from './creators.service';
@@ -10,6 +18,7 @@ import { PublicCreatorDto } from './dto/public-creator.dto';
 import { DashboardQueryDto } from './dto/creator-dashboard.dto';
 import { CreatePlanDto } from './dto/create-plan.dto';
 import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiTags('creators')
 @UseGuards(JwtAuthGuard, ThrottlerGuard)
@@ -21,6 +30,7 @@ export class CreatorsController {
   ) {}
 
   @Get()
+  @Public()
   @ApiOperation({
     summary: 'Search creators by display name or username',
     description:
@@ -55,7 +65,9 @@ export class CreatorsController {
   @ApiResponse({
     status: 400,
     description: 'Invalid query parameters',
-    schema: { example: { statusCode: 400, message: 'Invalid query parameters' } },
+    schema: {
+      example: { statusCode: 400, message: 'Invalid query parameters' },
+    },
   })
   @ApiResponse({
     status: 500,
@@ -69,7 +81,10 @@ export class CreatorsController {
   }
 
   @Get('list')
-  @ApiOperation({ summary: 'List all creator plans, optionally merged with on-chain state' })
+  @Public()
+  @ApiOperation({
+    summary: 'List all creator plans, optionally merged with on-chain state',
+  })
   @ApiResponse({
     status: 200,
     description: 'Array of plans with optional chain sync status',
@@ -98,6 +113,7 @@ export class CreatorsController {
   }
 
   @Get('plans')
+  @Public()
   @ApiOperation({ summary: 'List all plans (paginated)' })
   @ApiResponse({
     status: 200,
@@ -107,7 +123,9 @@ export class CreatorsController {
   @ApiResponse({
     status: 400,
     description: 'Invalid pagination parameters',
-    schema: { example: { statusCode: 400, message: 'Invalid pagination parameters' } },
+    schema: {
+      example: { statusCode: 400, message: 'Invalid pagination parameters' },
+    },
   })
   @ApiResponse({
     status: 500,
@@ -121,6 +139,7 @@ export class CreatorsController {
   }
 
   @Get(':address/plans')
+  @Public()
   @ApiOperation({ summary: 'List creator plans (paginated)' })
   @ApiResponse({
     status: 200,
@@ -130,7 +149,9 @@ export class CreatorsController {
   @ApiResponse({
     status: 400,
     description: 'Invalid pagination parameters',
-    schema: { example: { statusCode: 400, message: 'Invalid pagination parameters' } },
+    schema: {
+      example: { statusCode: 400, message: 'Invalid pagination parameters' },
+    },
   })
   @ApiResponse({
     status: 500,

--- a/backend/src/feature-flags/feature-flags.controller.ts
+++ b/backend/src/feature-flags/feature-flags.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { FeatureFlagsService } from './feature-flags.service';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiTags('feature-flags')
 @Controller({ path: 'feature-flags', version: '1' })
@@ -8,6 +9,7 @@ export class FeatureFlagsController {
   constructor(private readonly featureFlagsService: FeatureFlagsService) {}
 
   @Get()
+  @Public()
   @ApiOperation({ summary: 'List all feature flags and their current state' })
   @ApiResponse({ status: 200, description: 'Feature flags map' })
   getFlags() {

--- a/backend/src/health/dto/health-response.dto.ts
+++ b/backend/src/health/dto/health-response.dto.ts
@@ -98,7 +98,6 @@ export class AggregatedHealthDto extends HealthStatusDto {
 }
 
 export class QueueSnapshotDto {
-  @ApiProperty({ type: Object, additionalProperties: { type: 'number' } })
   [key: string]: unknown;
 }
 
@@ -106,6 +105,8 @@ export class QueueMetricsDto {
   @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
   timestamp: string;
 
-  @ApiProperty({ type: QueueSnapshotDto })
+  // Open-ended map of queue name -> depth. The shape is described here because
+  // an index signature cannot carry its own @ApiProperty decorator.
+  @ApiProperty({ type: 'object', additionalProperties: { type: 'number' } })
   queues: QueueSnapshotDto;
 }

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -11,15 +11,21 @@ import {
   QueueMetricsDto,
 } from './dto/health-response.dto';
 import { HealthQueryDto } from './dto/health-query.dto';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiTags('health')
+@Public()
 @Controller({ path: 'health', version: '1' })
 export class HealthController {
   constructor(private readonly healthService: HealthService) {}
 
   @Get()
   @ApiOperation({ summary: 'Basic health check' })
-  @ApiResponse({ status: 200, description: 'Service is healthy', type: HealthStatusDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Service is healthy',
+    type: HealthStatusDto,
+  })
   getHealth() {
     return this.healthService.getHealth();
   }
@@ -74,8 +80,16 @@ export class HealthController {
   @Get('db')
   @Throttle({ medium: { limit: 50, ttl: 60000 } })
   @ApiOperation({ summary: 'Database health check' })
-  @ApiResponse({ status: 200, description: 'Database is healthy', type: SubsystemStatusDto })
-  @ApiResponse({ status: 503, description: 'Database is down', type: SubsystemStatusDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Database is healthy',
+    type: SubsystemStatusDto,
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Database is down',
+    type: SubsystemStatusDto,
+  })
   @ApiResponse({ status: 429, description: 'Too many requests' })
   async getDbHealth(@Res() res: Response) {
     const health = await this.healthService.checkDatabase();
@@ -86,8 +100,16 @@ export class HealthController {
   @Get('redis')
   @Throttle({ medium: { limit: 50, ttl: 60000 } })
   @ApiOperation({ summary: 'Redis health check' })
-  @ApiResponse({ status: 200, description: 'Redis is healthy', type: SubsystemStatusDto })
-  @ApiResponse({ status: 503, description: 'Redis is down', type: SubsystemStatusDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Redis is healthy',
+    type: SubsystemStatusDto,
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Redis is down',
+    type: SubsystemStatusDto,
+  })
   @ApiResponse({ status: 429, description: 'Too many requests' })
   async getRedisHealth(@Res() res: Response) {
     const health = await this.healthService.checkRedis();
@@ -98,8 +120,16 @@ export class HealthController {
   @Get('soroban')
   @Throttle({ medium: { limit: 50, ttl: 60000 } })
   @ApiOperation({ summary: 'Soroban RPC health check' })
-  @ApiResponse({ status: 200, description: 'Soroban RPC is healthy or degraded', type: DetailedHealthStatusDto })
-  @ApiResponse({ status: 503, description: 'Soroban RPC is down', type: DetailedHealthStatusDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Soroban RPC is healthy or degraded',
+    type: DetailedHealthStatusDto,
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Soroban RPC is down',
+    type: DetailedHealthStatusDto,
+  })
   @ApiResponse({ status: 429, description: 'Too many requests' })
   async getSorobanHealth(@Res() res: Response) {
     const health = await this.healthService.checkSorobanRpc();
@@ -110,8 +140,16 @@ export class HealthController {
   @Get('soroban-contract')
   @Throttle({ medium: { limit: 50, ttl: 60000 } })
   @ApiOperation({ summary: 'Soroban contract health check' })
-  @ApiResponse({ status: 200, description: 'Soroban contract is healthy or degraded', type: DetailedHealthStatusDto })
-  @ApiResponse({ status: 503, description: 'Soroban contract is down', type: DetailedHealthStatusDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Soroban contract is healthy or degraded',
+    type: DetailedHealthStatusDto,
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Soroban contract is down',
+    type: DetailedHealthStatusDto,
+  })
   @ApiResponse({ status: 429, description: 'Too many requests' })
   async getSorobanContractHealth(@Res() res: Response) {
     const health = await this.healthService.checkSorobanContract();
@@ -122,14 +160,20 @@ export class HealthController {
   @Get('queue-metrics')
   @Throttle({ medium: { limit: 50, ttl: 60000 } })
   @ApiOperation({ summary: 'Worker queue performance metrics' })
-  @ApiResponse({ status: 200, description: 'Queue metrics snapshot', type: QueueMetricsDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Queue metrics snapshot',
+    type: QueueMetricsDto,
+  })
   @ApiResponse({ status: 429, description: 'Too many requests' })
   getQueueMetrics() {
     return this.healthService.getQueueMetrics();
   }
 
   @Get('checks')
-  @ApiOperation({ summary: 'Paginated list of available health check endpoints' })
+  @ApiOperation({
+    summary: 'Paginated list of available health check endpoints',
+  })
   @ApiResponse({ status: 200, description: 'Paginated health check list' })
   @ApiResponse({ status: 400, description: 'Invalid pagination parameters' })
   getHealthChecks(@Query() query: HealthQueryDto) {

--- a/backend/src/likes/likes.controller.spec.ts
+++ b/backend/src/likes/likes.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { NotFoundException } from '@nestjs/common';
 import { LikesController } from './likes.controller';
 import { LikesService } from './likes.service';
@@ -10,23 +11,34 @@ const mockUser = { userId: 'user-1' };
 describe('LikesController', () => {
   let controller: LikesController;
   let service: jest.Mocked<
-    Pick<LikesService, 'addLike' | 'removeLike' | 'getLikesCount' | 'hasUserLiked'>
+    Pick<
+      LikesService,
+      'addLike' | 'removeLike' | 'getLikesCount' | 'hasUserLiked'
+    >
   >;
 
   beforeEach(async () => {
     service = {
-      addLike: jest.fn().mockResolvedValue({ status: 201, message: 'Like added successfully' }),
+      addLike: jest
+        .fn()
+        .mockResolvedValue({ status: 201, message: 'Like added successfully' }),
       removeLike: jest.fn().mockResolvedValue(undefined),
       getLikesCount: jest.fn().mockResolvedValue(42),
       hasUserLiked: jest.fn().mockResolvedValue(true),
     };
 
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot([{ name: 'default', ttl: 60000, limit: 10 }]),
+      ],
       controllers: [LikesController],
       providers: [
         { provide: LikesService, useValue: service },
         Reflector,
-        { provide: JwtAuthGuard, useValue: { canActivate: jest.fn().mockReturnValue(true) } },
+        {
+          provide: JwtAuthGuard,
+          useValue: { canActivate: jest.fn().mockReturnValue(true) },
+        },
       ],
     })
       .overrideGuard(JwtAuthGuard)
@@ -49,7 +61,10 @@ describe('LikesController', () => {
     });
 
     it('returns idempotent response when post already liked', async () => {
-      service.addLike.mockResolvedValue({ status: 200, message: 'Post already liked' });
+      service.addLike.mockResolvedValue({
+        status: 200,
+        message: 'Post already liked',
+      });
 
       const result = await controller.likePost('post-1', mockUser);
 
@@ -61,9 +76,13 @@ describe('LikesController', () => {
     });
 
     it('propagates NotFoundException when post does not exist', async () => {
-      service.addLike.mockRejectedValue(new NotFoundException('Post not found'));
+      service.addLike.mockRejectedValue(
+        new NotFoundException('Post not found'),
+      );
 
-      await expect(controller.likePost('bad-post', mockUser)).rejects.toThrow(NotFoundException);
+      await expect(controller.likePost('bad-post', mockUser)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
@@ -76,15 +95,23 @@ describe('LikesController', () => {
     });
 
     it('propagates NotFoundException when like does not exist', async () => {
-      service.removeLike.mockRejectedValue(new NotFoundException('Like not found'));
+      service.removeLike.mockRejectedValue(
+        new NotFoundException('Like not found'),
+      );
 
-      await expect(controller.unlikePost('post-1', mockUser)).rejects.toThrow(NotFoundException);
+      await expect(controller.unlikePost('post-1', mockUser)).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('propagates NotFoundException when post does not exist', async () => {
-      service.removeLike.mockRejectedValue(new NotFoundException('Post not found'));
+      service.removeLike.mockRejectedValue(
+        new NotFoundException('Post not found'),
+      );
 
-      await expect(controller.unlikePost('bad-post', mockUser)).rejects.toThrow(NotFoundException);
+      await expect(controller.unlikePost('bad-post', mockUser)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 

--- a/backend/src/likes/likes.throttle.spec.ts
+++ b/backend/src/likes/likes.throttle.spec.ts
@@ -5,11 +5,17 @@ import { LikesController } from './likes.controller';
 import { LikesService } from './likes.service';
 import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
 
+// Decorator metadata lives on the unbound prototype methods, so reading it
+// back is exactly what these specs are meant to do.
+/* eslint-disable @typescript-eslint/unbound-method */
+
 describe('LikesController – rate limiting', () => {
   let controller: LikesController;
 
   const mockLikesService = {
-    addLike: jest.fn().mockResolvedValue({ status: 201, message: 'Like added successfully' }),
+    addLike: jest
+      .fn()
+      .mockResolvedValue({ status: 201, message: 'Like added successfully' }),
     removeLike: jest.fn().mockResolvedValue(undefined),
     getLikesCount: jest.fn().mockResolvedValue(0),
     hasUserLiked: jest.fn().mockResolvedValue(false),
@@ -34,36 +40,39 @@ describe('LikesController – rate limiting', () => {
   });
 
   it('should have ThrottlerGuard applied at controller level', () => {
-    const guards = Reflect.getMetadata('__guards__', LikesController);
+    const guards = Reflect.getMetadata(
+      '__guards__',
+      LikesController,
+    ) as unknown[];
     expect(guards).toBeDefined();
     expect(guards.some((g: unknown) => g === ThrottlerGuard)).toBe(true);
   });
 
   it('should have throttle metadata on likePost', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITdefault',
       LikesController.prototype.likePost,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('should have throttle metadata on unlikePost', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITdefault',
       LikesController.prototype.unlikePost,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('GET endpoints do not have per-route throttle metadata', () => {
     const countMeta = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITdefault',
       LikesController.prototype.getLikesCount,
-    );
+    ) as unknown;
     const statusMeta = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITdefault',
       LikesController.prototype.getLikeStatus,
-    );
+    ) as unknown;
     expect(countMeta).toBeUndefined();
     expect(statusMeta).toBeUndefined();
   });

--- a/backend/src/migration.datasource.ts
+++ b/backend/src/migration.datasource.ts
@@ -10,6 +10,7 @@ import { AddQueuedAtToModerationFlags1745000000000 } from './moderation/17450000
 import { CreateReferralTables1745000000000 } from './referral/1745000000000-CreateReferralTables';
 import { AddDigestColumnsToNotifications1745100000000 } from './notifications/1745100000000-AddDigestColumnsToNotifications';
 import { AddOnboardingStateToUsers1745200000000 } from './users/1745200000000-AddOnboardingStateToUsers';
+import { AddRoleToUsers1747000000000 } from './users/1747000000000-AddRoleToUsers';
 
 export const migrationDataSource = new DataSource({
   type: 'postgres',
@@ -29,5 +30,6 @@ export const migrationDataSource = new DataSource({
     CreateReferralTables1745000000000,
     AddDigestColumnsToNotifications1745100000000,
     AddOnboardingStateToUsers1745200000000,
+    AddRoleToUsers1747000000000,
   ],
 });

--- a/backend/src/moderation/moderation.controller.ts
+++ b/backend/src/moderation/moderation.controller.ts
@@ -31,7 +31,6 @@ import { UserRole } from '../common/enums/user-role.enum';
 @ApiTags('moderation')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
-@Roles(UserRole.ADMIN)
 @Controller({ path: 'moderation', version: '1' })
 export class ModerationController {
   constructor(
@@ -45,14 +44,16 @@ export class ModerationController {
   @ApiOperation({ summary: 'Report content for moderation' })
   @ApiResponse({ status: 201, description: 'Flag created' })
   @ApiResponse({ status: 409, description: 'Already flagged' })
-  createFlag(@Request() req, @Body() dto: CreateFlagDto) {
+  createFlag(
+    @Request() req: { user: { id: string } },
+    @Body() dto: CreateFlagDto,
+  ) {
     return this.moderationService.createFlag(req.user.id, dto);
   }
 
   // ── Admin endpoints ───────────────────────────────────────────────────
 
   @Get('flags')
-  @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN)
   @ApiOperation({ summary: '[Admin] List all moderation flags' })
   @ApiResponse({ status: 200, description: 'Paginated flags list' })
@@ -61,7 +62,6 @@ export class ModerationController {
   }
 
   @Get('flags/:id')
-  @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN)
   @ApiOperation({ summary: '[Admin] Get a single moderation flag' })
   @ApiResponse({ status: 200, description: 'Flag details' })
@@ -71,13 +71,12 @@ export class ModerationController {
   }
 
   @Patch('flags/:id/review')
-  @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: '[Admin] Review / update a moderation flag' })
   @ApiResponse({ status: 200, description: 'Flag updated' })
   reviewFlag(
-    @Request() req,
+    @Request() req: { user: { id: string } },
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: ReviewFlagDto,
   ) {
@@ -85,7 +84,6 @@ export class ModerationController {
   }
 
   @Get('flags/:id/audit')
-  @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN)
   @ApiOperation({ summary: '[Admin] Get audit trail for a flag' })
   @ApiResponse({ status: 200, description: 'Audit log entries' })
@@ -96,7 +94,6 @@ export class ModerationController {
   // ── SLA metrics ───────────────────────────────────────────────────────
 
   @Get('sla')
-  @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN)
   @ApiOperation({
     summary: '[Admin] Moderation queue SLA metrics',

--- a/backend/src/refresh-module/auth.controller.ts
+++ b/backend/src/refresh-module/auth.controller.ts
@@ -13,14 +13,19 @@ import {
   ApiResponse,
   ApiBearerAuth,
 } from '@nestjs/swagger';
-import { RefreshTokenService, TokenPair } from './refresh-token.service';
-import { RefreshTokenDto, LogoutDto, TokenResponseDto } from './refresh-token.dto';
+import { RefreshTokenService } from './refresh-token.service';
+import {
+  RefreshTokenDto,
+  LogoutDto,
+  TokenResponseDto,
+} from './refresh-token.dto';
 import { JwtAuthGuard } from './jwt-auth.guard';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiTags('auth')
 @Controller({ path: 'auth', version: '1' })
 export class AuthController {
-  constructor(private readonly refreshTokenService: RefreshTokenService) { }
+  constructor(private readonly refreshTokenService: RefreshTokenService) {}
 
   /**
    * POST /auth/refresh
@@ -28,6 +33,7 @@ export class AuthController {
    * The old refresh token is invalidated (rotation).
    */
   @Post('refresh')
+  @Public()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Refresh access token using a refresh token' })
   @ApiResponse({ status: 200, type: TokenResponseDto })
@@ -50,7 +56,10 @@ export class AuthController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Invalidate refresh token (logout)' })
   @ApiResponse({ status: 204, description: 'Logged out successfully' })
-  async logout(@Body() dto: LogoutDto, @Request() req: any): Promise<void> {
+  async logout(
+    @Body() dto: LogoutDto,
+    @Request() req: { user: { userId: string } },
+  ): Promise<void> {
     if (dto.all_devices) {
       await this.refreshTokenService.invalidateAll(req.user.userId);
     } else {

--- a/backend/src/social-link/social-links.controller.spec.ts
+++ b/backend/src/social-link/social-links.controller.spec.ts
@@ -1,41 +1,30 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
 import {
   THROTTLER_LIMIT,
   THROTTLER_TTL,
 } from '@nestjs/throttler/dist/throttler.constants';
-import { DECORATORS } from '@nestjs/swagger/dist/constants';
 import { SocialLinksDto } from './social-links.dto';
+import {
+  SocialLinksResponseDto,
+  SocialLinksListItemDto,
+} from './user-profile.dto';
 import { SocialLinkController } from './social-links.controller';
 import { SocialLinksService } from './social-links.service';
 import { PaginatedResponseDto } from '../common/dto';
-import { SocialLinksListItem } from './social-links.service';
 
-// ─── shared mock ────────────────────────────────────────────────────────────
+// Decorator metadata lives on the unbound prototype methods, so reading it
+// back is exactly what these specs are meant to do.
+/* eslint-disable @typescript-eslint/unbound-method */
 
-const mockPaginatedResult: PaginatedResponseDto<SocialLinksListItem> = {
-  data: [],
-  cursor: null,
-  limit: 20,
-  nextCursor: null,
-  hasMore: false,
-  total: 0,
-  page: 1,
-  totalPages: 0,
-};
-
-const mockSocialLinksService = {
-  extractUpdatePayload: jest
-    .fn()
-    .mockImplementation((dto: SocialLinksDto) => dto),
-  createSocialLinks: jest
-    .fn()
-    .mockImplementation((dto: SocialLinksDto) => dto),
-  updateSocialLinks: jest
-    .fn()
-    .mockImplementation((_id: string, dto: SocialLinksDto) => dto),
-  listSocialLinks: jest.fn().mockReturnValue(mockPaginatedResult),
-};
+// @nestjs/swagger does not expose its constants as a public subpath, so mirror
+// the metadata keys the decorators write to.
+const DECORATORS = {
+  API_OPERATION: 'swagger/apiOperation',
+  API_RESPONSE: 'swagger/apiResponse',
+  API_TAGS: 'swagger/apiUseTags',
+  API_EXTRA_MODELS: 'swagger/apiExtraModels',
+} as const;
 
 describe('SocialLinkController', () => {
   let controller: SocialLinkController;
@@ -73,59 +62,39 @@ describe('SocialLinkController', () => {
 
     it('configures create with the expected throttling policy', () => {
       const createHandler = SocialLinkController.prototype.create;
-      const limit = Reflect.getMetadata(THROTTLER_LIMIT + 'default', createHandler);
-      const ttl = Reflect.getMetadata(THROTTLER_TTL + 'default', createHandler);
+      const limit = Reflect.getMetadata(
+        THROTTLER_LIMIT + 'default',
+        createHandler,
+      ) as unknown;
+      const ttl = Reflect.getMetadata(
+        THROTTLER_TTL + 'default',
+        createHandler,
+      ) as unknown;
       expect(limit).toBe(5);
       expect(ttl).toBe(60000);
     });
 
     it('configures update with the expected throttling policy', () => {
       const updateHandler = SocialLinkController.prototype.update;
-      const limit = Reflect.getMetadata(THROTTLER_LIMIT + 'default', updateHandler);
-      const ttl = Reflect.getMetadata(THROTTLER_TTL + 'default', updateHandler);
+      const limit = Reflect.getMetadata(
+        THROTTLER_LIMIT + 'default',
+        updateHandler,
+      ) as unknown;
+      const ttl = Reflect.getMetadata(
+        THROTTLER_TTL + 'default',
+        updateHandler,
+      ) as unknown;
       expect(limit).toBe(5);
       expect(ttl).toBe(60000);
     });
 
     it('list (read endpoint) has no @Throttle metadata', () => {
       const listHandler = SocialLinkController.prototype.list;
-      const limit = Reflect.getMetadata(THROTTLER_LIMIT + 'default', listHandler);
+      const limit = Reflect.getMetadata(
+        THROTTLER_LIMIT + 'default',
+        listHandler,
+      ) as unknown;
       expect(limit).toBeUndefined();
-    });
-  });
-
-  it('configures create with the expected throttling policy', () => {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const createHandler = controller.create;
-    const limit: unknown = Reflect.getMetadata(THROTTLER_LIMIT + 'default', createHandler);
-    const ttl: unknown = Reflect.getMetadata(THROTTLER_TTL + 'default', createHandler);
-
-    it('update has @ApiResponse for 404', () => {
-      const meta = Reflect.getMetadata(
-        'swagger/apiResponse',
-        SocialLinkController.prototype.update,
-      );
-      expect(meta?.['404']).toBeDefined();
-    });
-  });
-
-  it('configures update with the expected throttling policy', () => {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const updateHandler = controller.update;
-    const limit: unknown = Reflect.getMetadata(THROTTLER_LIMIT + 'default', updateHandler);
-    const ttl: unknown = Reflect.getMetadata(THROTTLER_TTL + 'default', updateHandler);
-
-      controller.list(pagination);
-
-      expect(mockSocialLinksService.listSocialLinks).toHaveBeenCalledWith(pagination);
-    });
-
-    it('propagates errors thrown by the service', () => {
-      mockSocialLinksService.listSocialLinks.mockImplementationOnce(() => {
-        throw new BadRequestException('Invalid pagination');
-      });
-
-      expect(() => controller.list({ page: -1, limit: 0 })).toThrow(BadRequestException);
     });
   });
 
@@ -137,7 +106,9 @@ describe('SocialLinkController', () => {
 
       const result = controller.create(dto);
 
-      expect(mockSocialLinksService.createSocialLinks).toHaveBeenCalledWith(dto);
+      expect(mockSocialLinksService.createSocialLinks).toHaveBeenCalledWith(
+        dto,
+      );
       expect(result).toBe(payload);
     });
   });
@@ -150,7 +121,10 @@ describe('SocialLinkController', () => {
 
       const result = controller.update('user-123', dto);
 
-      expect(mockSocialLinksService.updateSocialLinks).toHaveBeenCalledWith('user-123', dto);
+      expect(mockSocialLinksService.updateSocialLinks).toHaveBeenCalledWith(
+        'user-123',
+        dto,
+      );
       expect(result).toBe(payload);
     });
   });
@@ -158,13 +132,31 @@ describe('SocialLinkController', () => {
   describe('list', () => {
     it('delegates to listSocialLinks with pagination params and returns its result', () => {
       const pagination = { page: 1, limit: 10 };
-      const response = { data: [], page: 1, limit: 10, total: 0, hasMore: false };
+      const response = {
+        data: [],
+        page: 1,
+        limit: 10,
+        total: 0,
+        hasMore: false,
+      };
       mockSocialLinksService.listSocialLinks.mockReturnValue(response);
 
-      const result = controller.list(pagination as any);
+      const result = controller.list(pagination);
 
-      expect(mockSocialLinksService.listSocialLinks).toHaveBeenCalledWith(pagination);
+      expect(mockSocialLinksService.listSocialLinks).toHaveBeenCalledWith(
+        pagination,
+      );
       expect(result).toBe(response);
+    });
+
+    it('propagates errors thrown by the service', () => {
+      mockSocialLinksService.listSocialLinks.mockImplementationOnce(() => {
+        throw new BadRequestException('Invalid pagination');
+      });
+
+      expect(() => controller.list({ page: -1, limit: 0 } as any)).toThrow(
+        BadRequestException,
+      );
     });
   });
 
@@ -175,12 +167,22 @@ describe('SocialLinkController', () => {
     // { '200': { description: '...', type: Foo }, '400': { ... } }
     function getResponsesForMethod(
       methodName: 'list' | 'create' | 'update',
-    ): Array<{ status: number; description: string; type?: unknown; schema?: unknown }> {
+    ): Array<{
+      status: number;
+      description: string;
+      type?: unknown;
+      schema?: unknown;
+    }> {
       const proto = SocialLinkController.prototype as Record<string, unknown>;
       const meta = Reflect.getMetadata(
         DECORATORS.API_RESPONSE,
         proto[methodName],
-      ) as Record<string, { description: string; type?: unknown; schema?: unknown }> | undefined;
+      ) as
+        | Record<
+            string,
+            { description: string; type?: unknown; schema?: unknown }
+          >
+        | undefined;
       if (!meta) return [];
       return Object.entries(meta).map(([statusKey, entry]) => ({
         status: Number(statusKey),

--- a/backend/src/subscriptions/dto/dto-validation.spec.ts
+++ b/backend/src/subscriptions/dto/dto-validation.spec.ts
@@ -78,7 +78,10 @@ describe('ListCreatorSubscribersQueryDto – invalid input', () => {
   });
 
   it('fails when status is not active or expired', async () => {
-    const errors = await validateDto({ creator: 'GCREATOR', status: 'pending' });
+    const errors = await validateDto({
+      creator: 'GCREATOR',
+      status: 'pending',
+    });
     expect(errors.some((e) => e.property === 'status')).toBe(true);
   });
 
@@ -140,57 +143,112 @@ describe('SubscriptionIndexerEventDto – invalid input', () => {
   }
 
   it('fails when event is missing', async () => {
-    const errors = await validateDto({ userId: 'GFAN', creatorId: 'GCREATOR', planId: 1 });
+    const errors = await validateDto({
+      userId: 'GFAN',
+      creatorId: 'GCREATOR',
+      planId: 1,
+    });
     expect(errors.some((e) => e.property === 'event')).toBe(true);
   });
 
   it('fails when event is invalid value', async () => {
-    const errors = await validateDto({ event: 'created', userId: 'GFAN', creatorId: 'GCREATOR', planId: 1 });
+    const errors = await validateDto({
+      event: 'created',
+      userId: 'GFAN',
+      creatorId: 'GCREATOR',
+      planId: 1,
+    });
     expect(errors.some((e) => e.property === 'event')).toBe(true);
   });
 
   it('fails when userId is missing', async () => {
-    const errors = await validateDto({ event: 'renewed', creatorId: 'GCREATOR', planId: 1 });
+    const errors = await validateDto({
+      event: 'renewed',
+      creatorId: 'GCREATOR',
+      planId: 1,
+    });
     expect(errors.some((e) => e.property === 'userId')).toBe(true);
   });
 
   it('fails when creatorId is missing', async () => {
-    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', planId: 1 });
+    const errors = await validateDto({
+      event: 'renewed',
+      userId: 'GFAN',
+      planId: 1,
+    });
     expect(errors.some((e) => e.property === 'creatorId')).toBe(true);
   });
 
   it('fails when planId is missing', async () => {
-    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', creatorId: 'GCREATOR' });
+    const errors = await validateDto({
+      event: 'renewed',
+      userId: 'GFAN',
+      creatorId: 'GCREATOR',
+    });
     expect(errors.some((e) => e.property === 'planId')).toBe(true);
   });
 
   it('fails when planId is zero', async () => {
-    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', creatorId: 'GCREATOR', planId: 0 });
+    const errors = await validateDto({
+      event: 'renewed',
+      userId: 'GFAN',
+      creatorId: 'GCREATOR',
+      planId: 0,
+    });
     expect(errors.some((e) => e.property === 'planId')).toBe(true);
   });
 
   it('fails when planId is negative', async () => {
-    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', creatorId: 'GCREATOR', planId: -1 });
+    const errors = await validateDto({
+      event: 'renewed',
+      userId: 'GFAN',
+      creatorId: 'GCREATOR',
+      planId: -1,
+    });
     expect(errors.some((e) => e.property === 'planId')).toBe(true);
   });
 
   it('fails when expiry is negative', async () => {
-    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', creatorId: 'GCREATOR', planId: 1, expiry: -100 });
+    const errors = await validateDto({
+      event: 'renewed',
+      userId: 'GFAN',
+      creatorId: 'GCREATOR',
+      planId: 1,
+      expiry: -100,
+    });
     expect(errors.some((e) => e.property === 'expiry')).toBe(true);
   });
 
   it('fails when cancelledAt is negative', async () => {
-    const errors = await validateDto({ event: 'cancelled', userId: 'GFAN', creatorId: 'GCREATOR', planId: 1, cancelledAt: -1 });
+    const errors = await validateDto({
+      event: 'cancelled',
+      userId: 'GFAN',
+      creatorId: 'GCREATOR',
+      planId: 1,
+      cancelledAt: -1,
+    });
     expect(errors.some((e) => e.property === 'cancelledAt')).toBe(true);
   });
 
   it('passes for valid renewed event', async () => {
-    const errors = await validateDto({ event: 'renewed', userId: 'GFAN', creatorId: 'GCREATOR', planId: 1, expiry: 1700000000 });
+    const errors = await validateDto({
+      event: 'renewed',
+      userId: 'GFAN',
+      creatorId: 'GCREATOR',
+      planId: 1,
+      expiry: 1700000000,
+    });
     expect(errors).toHaveLength(0);
   });
 
   it('passes for valid cancelled event', async () => {
-    const errors = await validateDto({ event: 'cancelled', userId: 'GFAN', creatorId: 'GCREATOR', planId: 1, cancelledAt: 1700000000 });
+    const errors = await validateDto({
+      event: 'cancelled',
+      userId: 'GFAN',
+      creatorId: 'GCREATOR',
+      planId: 1,
+      cancelledAt: 1700000000,
+    });
     expect(errors).toHaveLength(0);
   });
 });
@@ -201,8 +259,9 @@ describe('SetSpendingCapDto – invalid input', () => {
     return validate(dto);
   }
 
+  // 'weekly' | 'monthly' | 'total' are the valid CapPeriod values.
   it('fails when period is invalid', async () => {
-    const errors = await validateDto({ period: 'weekly' });
+    const errors = await validateDto({ period: 'daily' });
     expect(errors.some((e) => e.property === 'period')).toBe(true);
   });
 

--- a/backend/src/subscriptions/filters/subscriptions-exception.filter.ts
+++ b/backend/src/subscriptions/filters/subscriptions-exception.filter.ts
@@ -16,6 +16,9 @@ export interface SubscriptionErrorResponse {
   path: string;
 }
 
+// Machine-readable error codes are SCREAMING_SNAKE_CASE.
+const MACHINE_ERROR_CODE = /^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/;
+
 @Catch()
 export class SubscriptionsExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(SubscriptionsExceptionFilter.name);
@@ -34,7 +37,7 @@ export class SubscriptionsExceptionFilter implements ExceptionFilter {
       exception instanceof HttpException ? exception.getResponse() : null;
 
     let message = 'Internal server error';
-    let error = 'INTERNAL_ERROR';
+    let error: string | undefined;
 
     if (exception instanceof HttpException) {
       if (typeof exceptionResponse === 'string') {
@@ -50,7 +53,15 @@ export class SubscriptionsExceptionFilter implements ExceptionFilter {
             : Array.isArray(resp.message)
               ? resp.message.join('; ')
               : exception.message;
-        error = typeof resp.error === 'string' ? resp.error : this.statusToError(status);
+        // Keep a caller-supplied machine code (e.g. VALIDATION_FAILED) but drop
+        // Nest's human reason phrases ("Bad Request") so statusToError below
+        // yields the stable code clients actually match on.
+        if (
+          typeof resp.error === 'string' &&
+          MACHINE_ERROR_CODE.test(resp.error)
+        ) {
+          error = resp.error;
+        }
       }
     } else if (exception instanceof Error) {
       message = exception.message;
@@ -68,9 +79,7 @@ export class SubscriptionsExceptionFilter implements ExceptionFilter {
       path: req.url,
     };
 
-    this.logger.warn(
-      `${req.method} ${req.url} ${status} – ${message}`,
-    );
+    this.logger.warn(`${req.method} ${req.url} ${status} – ${message}`);
 
     res.status(status).json(body);
   }

--- a/backend/src/subscriptions/subscriptions.controller.spec.ts
+++ b/backend/src/subscriptions/subscriptions.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { ThrottlerModule } from '@nestjs/throttler';
+import { UnauthorizedException } from '@nestjs/common';
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import { SubscriptionsController } from './subscriptions.controller';
@@ -8,10 +9,7 @@ import { SubscriptionStatus } from './entities/subscription-index.entity';
 import { Reflector } from '@nestjs/core';
 import { FeatureFlagGuard } from '../feature-flags/feature-flag.guard';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
-import {
-  FanBearerGuard,
-  RequestWithFan,
-} from './guards/fan-bearer.guard';
+import { FanBearerGuard, RequestWithFan } from './guards/fan-bearer.guard';
 import { ListSubscriptionsQueryDto } from './dto/list-subscriptions-query.dto';
 
 describe('SubscriptionsController', () => {
@@ -19,7 +17,10 @@ describe('SubscriptionsController', () => {
   let service: jest.Mocked<
     Pick<
       SubscriptionsService,
-      'getFanCreatorSubscriptionState' | 'listCreatorSubscribers' | 'listSubscriptions' | 'getFanDashboardSummary'
+      | 'getFanCreatorSubscriptionState'
+      | 'listCreatorSubscribers'
+      | 'listSubscriptions'
+      | 'getFanDashboardSummary'
     >
   >;
 
@@ -74,6 +75,9 @@ describe('SubscriptionsController', () => {
     };
 
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot([{ name: 'short', ttl: 60000, limit: 10 }]),
+      ],
       controllers: [SubscriptionsController],
       providers: [
         { provide: SubscriptionsService, useValue: service },
@@ -176,7 +180,11 @@ describe('SubscriptionsController', () => {
     const req = { fanAddress: fan } as RequestWithFan;
     await controller.getFanDashboard(req, {});
 
-    expect(service.getFanDashboardSummary).toHaveBeenCalledWith(fan, undefined, undefined);
+    expect(service.getFanDashboardSummary).toHaveBeenCalledWith(
+      fan,
+      undefined,
+      undefined,
+    );
   });
 });
 
@@ -221,7 +229,9 @@ describe('ListSubscriptionsQueryDto – status validation', () => {
     const errors = await validateDto({ fan: 'GFAN', sort: 'invalid' });
     const sortErrors = errors.filter((e) => e.property === 'sort');
     expect(sortErrors).toHaveLength(1);
-    expect(Object.values(sortErrors[0].constraints ?? {})[0]).toMatch(/created, expiry/);
+    expect(Object.values(sortErrors[0].constraints ?? {})[0]).toMatch(
+      /created, expiry/,
+    );
   });
 
   it('passes when sort is omitted', async () => {
@@ -232,17 +242,34 @@ describe('ListSubscriptionsQueryDto – status validation', () => {
 
 describe('SubscriptionsController – listSubscriptions', () => {
   let controller: SubscriptionsController;
-  let service: jest.Mocked<Pick<SubscriptionsService, 'listSubscriptions' | 'getFanCreatorSubscriptionState'>>;
+  let service: jest.Mocked<
+    Pick<
+      SubscriptionsService,
+      'listSubscriptions' | 'getFanCreatorSubscriptionState'
+    >
+  >;
 
   const fan = `G${'A'.repeat(55)}`;
 
   beforeEach(async () => {
     service = {
-      listSubscriptions: jest.fn().mockReturnValue({ data: [], total: 0, page: 1, limit: 20, totalPages: 0, hasMore: false, nextCursor: null, cursor: null }),
+      listSubscriptions: jest.fn().mockReturnValue({
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+        hasMore: false,
+        nextCursor: null,
+        cursor: null,
+      }),
       getFanCreatorSubscriptionState: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot([{ name: 'short', ttl: 60000, limit: 10 }]),
+      ],
       controllers: [SubscriptionsController],
       providers: [
         { provide: SubscriptionsService, useValue: service },
@@ -260,7 +287,12 @@ describe('SubscriptionsController – listSubscriptions', () => {
   });
 
   it('passes typed SubscriptionStatus.ACTIVE to service', () => {
-    const query: ListSubscriptionsQueryDto = { fan, status: SubscriptionStatus.ACTIVE, cursor: undefined, limit: 20 };
+    const query: ListSubscriptionsQueryDto = {
+      fan,
+      status: SubscriptionStatus.ACTIVE,
+      cursor: undefined,
+      limit: 20,
+    };
     controller.listSubscriptions(query);
     expect(service.listSubscriptions).toHaveBeenCalledWith(
       fan,
@@ -272,7 +304,12 @@ describe('SubscriptionsController – listSubscriptions', () => {
   });
 
   it('passes typed SubscriptionStatus.EXPIRED to service', () => {
-    const query: ListSubscriptionsQueryDto = { fan, status: SubscriptionStatus.EXPIRED, cursor: undefined, limit: 20 };
+    const query: ListSubscriptionsQueryDto = {
+      fan,
+      status: SubscriptionStatus.EXPIRED,
+      cursor: undefined,
+      limit: 20,
+    };
     controller.listSubscriptions(query);
     expect(service.listSubscriptions).toHaveBeenCalledWith(
       fan,
@@ -284,7 +321,12 @@ describe('SubscriptionsController – listSubscriptions', () => {
   });
 
   it('passes sort=created to service', () => {
-    const query: ListSubscriptionsQueryDto = { fan, sort: 'created', cursor: undefined, limit: 20 };
+    const query: ListSubscriptionsQueryDto = {
+      fan,
+      sort: 'created',
+      cursor: undefined,
+      limit: 20,
+    };
     controller.listSubscriptions(query);
     expect(service.listSubscriptions).toHaveBeenCalledWith(
       fan,
@@ -296,7 +338,12 @@ describe('SubscriptionsController – listSubscriptions', () => {
   });
 
   it('passes sort=expiry to service', () => {
-    const query: ListSubscriptionsQueryDto = { fan, sort: 'expiry', cursor: undefined, limit: 20 };
+    const query: ListSubscriptionsQueryDto = {
+      fan,
+      sort: 'expiry',
+      cursor: undefined,
+      limit: 20,
+    };
     controller.listSubscriptions(query);
     expect(service.listSubscriptions).toHaveBeenCalledWith(
       fan,
@@ -308,7 +355,11 @@ describe('SubscriptionsController – listSubscriptions', () => {
   });
 
   it('passes cursor to service', () => {
-    const query: ListSubscriptionsQueryDto = { fan, cursor: 'some-cursor', limit: 10 };
+    const query: ListSubscriptionsQueryDto = {
+      fan,
+      cursor: 'some-cursor',
+      limit: 10,
+    };
     controller.listSubscriptions(query);
     expect(service.listSubscriptions).toHaveBeenCalledWith(
       fan,
@@ -320,7 +371,11 @@ describe('SubscriptionsController – listSubscriptions', () => {
   });
 
   it('passes undefined status when omitted', () => {
-    const query: ListSubscriptionsQueryDto = { fan, cursor: undefined, limit: 20 };
+    const query: ListSubscriptionsQueryDto = {
+      fan,
+      cursor: undefined,
+      limit: 20,
+    };
     controller.listSubscriptions(query);
     expect(service.listSubscriptions).toHaveBeenCalledWith(
       fan,

--- a/backend/src/subscriptions/subscriptions.controller.ts
+++ b/backend/src/subscriptions/subscriptions.controller.ts
@@ -11,12 +11,20 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam, ApiQuery } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
 import { Reflector } from '@nestjs/core';
 import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import { ListSubscriptionsQueryDto } from './dto/list-subscriptions-query.dto';
 import { ListCreatorSubscribersQueryDto } from './dto/list-creator-subscribers-query.dto';
 import { SubscriptionStateQueryDto } from './dto/subscription-state-query.dto';
+import { FanDashboardQueryDto } from './dto/fan-dashboard-query.dto';
 import {
   CreateCheckoutDto,
   CheckoutResponseDto,
@@ -49,7 +57,10 @@ export class SubscriptionsController {
   @Get('me/subscription-state')
   @UseGuards(FanBearerGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get subscription state between the authenticated fan and a creator' })
+  @ApiOperation({
+    summary:
+      'Get subscription state between the authenticated fan and a creator',
+  })
   @ApiResponse({ status: 200, description: 'Subscription state' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getFanCreatorSubscriptionState(
@@ -66,13 +77,23 @@ export class SubscriptionsController {
   @Deprecated({
     sunset: '2026-01-01',
     link: '/v1/subscriptions/me/subscription-state',
-    message: 'Use GET /v1/subscriptions/me/subscription-state instead. Removal date: 2026-01-01.',
+    message:
+      'Use GET /v1/subscriptions/me/subscription-state instead. Removal date: 2026-01-01.',
   })
   @UseInterceptors(new DeprecationInterceptor(new Reflector()))
-  @ApiOperation({ summary: '[Deprecated] Check if a fan is subscribed to a creator', deprecated: true })
+  @ApiOperation({
+    summary: '[Deprecated] Check if a fan is subscribed to a creator',
+    deprecated: true,
+  })
   @ApiResponse({ status: 200, description: 'Subscription check result' })
-  async checkSubscription(@Query('fan') fan: string, @Query('creator') creator: string) {
-    const isSubscriber = await this.subscriptionsService.isSubscriber(fan, creator);
+  async checkSubscription(
+    @Query('fan') fan: string,
+    @Query('creator') creator: string,
+  ) {
+    const isSubscriber = await this.subscriptionsService.isSubscriber(
+      fan,
+      creator,
+    );
     return { isSubscriber };
   }
 
@@ -80,15 +101,19 @@ export class SubscriptionsController {
   @Deprecated({
     sunset: '2026-01-01',
     link: '/v1/subscriptions/me/subscription-state',
-    message: 'Use GET /v1/subscriptions/me/subscription-state instead. Removal date: 2026-01-01.',
+    message:
+      'Use GET /v1/subscriptions/me/subscription-state instead. Removal date: 2026-01-01.',
   })
   @UseInterceptors(new DeprecationInterceptor(new Reflector()))
-  @ApiOperation({ summary: '[Deprecated] List subscriptions for a fan', deprecated: true })
+  @ApiOperation({
+    summary: '[Deprecated] List subscriptions for a fan',
+    deprecated: true,
+  })
   @ApiResponse({ status: 200, description: 'Subscriptions list' })
   listSubscriptions(@Query() query: ListSubscriptionsQueryDto) {
     return this.subscriptionsService.listSubscriptions(
       query.fan,
-      query.status as never,
+      query.status,
       query.sort,
       query.cursor,
       query.limit,
@@ -99,7 +124,8 @@ export class SubscriptionsController {
   @UseGuards(FanBearerGuard)
   @ApiBearerAuth()
   @ApiOperation({
-    summary: 'List subscriptions for the authenticated fan with status and sort filters',
+    summary:
+      'List subscriptions for the authenticated fan with status and sort filters',
     description:
       'Cursor-paginated subscription list. Pass `cursor` and `limit`; responses include `data`, `limit`, `nextCursor`, and `hasMore`.',
   })
@@ -171,9 +197,20 @@ export class SubscriptionsController {
     description:
       'Offset-paginated dashboard. Pass `page` and `limit` to control pagination.',
   })
-  @ApiQuery({ name: 'page', required: false, description: 'Page number (1-based, default 1)' })
-  @ApiQuery({ name: 'limit', required: false, description: 'Items per page (default 20, max 100)' })
-  @ApiResponse({ status: 200, description: 'Fan dashboard summary with pagination' })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    description: 'Page number (1-based, default 1)',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: 'Items per page (default 20, max 100)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Fan dashboard summary with pagination',
+  })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   getFanDashboard(
     @Req() req: RequestWithFan,
@@ -190,9 +227,20 @@ export class SubscriptionsController {
   @Throttle({ short: { limit: 10, ttl: 60000 } })
   @UseGuards(FeatureFlagGuard)
   @RequireFeatureFlag('newSubscriptionFlow')
-  @ApiOperation({ summary: 'Create a subscription checkout session', description: 'Initiates a new checkout session for subscribing to a creator plan. The session expires after 15 minutes.' })
-  @ApiResponse({ status: 201, description: 'Checkout session created', type: CheckoutResponseDto })
-  @ApiResponse({ status: 403, description: 'New subscription flow is disabled' })
+  @ApiOperation({
+    summary: 'Create a subscription checkout session',
+    description:
+      'Initiates a new checkout session for subscribing to a creator plan. The session expires after 15 minutes.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Checkout session created',
+    type: CheckoutResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'New subscription flow is disabled',
+  })
   @ApiResponse({ status: 404, description: 'Plan not found' })
   @ApiResponse({ status: 429, description: 'Too many requests' })
   createCheckout(
@@ -226,9 +274,17 @@ export class SubscriptionsController {
   }
 
   @Get('checkout/:id')
-  @ApiOperation({ summary: 'Get a checkout session by ID', description: 'Returns full checkout details including transaction hash and error if present.' })
+  @ApiOperation({
+    summary: 'Get a checkout session by ID',
+    description:
+      'Returns full checkout details including transaction hash and error if present.',
+  })
   @ApiParam({ name: 'id', description: 'Checkout session ID' })
-  @ApiResponse({ status: 200, description: 'Checkout session details', type: CheckoutResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Checkout session details',
+    type: CheckoutResponseDto,
+  })
   @ApiResponse({ status: 400, description: 'Checkout session has expired' })
   @ApiResponse({ status: 404, description: 'Checkout not found' })
   getCheckout(@Param('id') checkoutId: string) {
@@ -253,9 +309,17 @@ export class SubscriptionsController {
   }
 
   @Get('checkout/:id/plan')
-  @ApiOperation({ summary: 'Get plan summary for a checkout session', description: 'Returns creator name, asset, amount, and billing interval for the plan attached to this checkout.' })
+  @ApiOperation({
+    summary: 'Get plan summary for a checkout session',
+    description:
+      'Returns creator name, asset, amount, and billing interval for the plan attached to this checkout.',
+  })
   @ApiParam({ name: 'id', description: 'Checkout session ID' })
-  @ApiResponse({ status: 200, description: 'Plan summary', type: PlanSummaryResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Plan summary',
+    type: PlanSummaryResponseDto,
+  })
   @ApiResponse({ status: 404, description: 'Checkout or plan not found' })
   getPlanSummary(@Param('id') checkoutId: string) {
     const checkout = this.subscriptionsService.getCheckout(checkoutId);
@@ -263,18 +327,34 @@ export class SubscriptionsController {
   }
 
   @Get('checkout/:id/price')
-  @ApiOperation({ summary: 'Get price breakdown for a checkout session', description: 'Returns subtotal, platform fee, network fee, and total for the checkout.' })
+  @ApiOperation({
+    summary: 'Get price breakdown for a checkout session',
+    description:
+      'Returns subtotal, platform fee, network fee, and total for the checkout.',
+  })
   @ApiParam({ name: 'id', description: 'Checkout session ID' })
-  @ApiResponse({ status: 200, description: 'Price breakdown', type: PriceBreakdownResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Price breakdown',
+    type: PriceBreakdownResponseDto,
+  })
   @ApiResponse({ status: 404, description: 'Checkout not found' })
   getPriceBreakdown(@Param('id') checkoutId: string) {
     return this.subscriptionsService.getPriceBreakdown(checkoutId);
   }
 
   @Get('checkout/:id/wallet')
-  @ApiOperation({ summary: 'Get wallet status for a checkout session', description: 'Returns the fan wallet balances and connection status for the checkout session.' })
+  @ApiOperation({
+    summary: 'Get wallet status for a checkout session',
+    description:
+      'Returns the fan wallet balances and connection status for the checkout session.',
+  })
   @ApiParam({ name: 'id', description: 'Checkout session ID' })
-  @ApiResponse({ status: 200, description: 'Wallet status', type: WalletStatusResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Wallet status',
+    type: WalletStatusResponseDto,
+  })
   @ApiResponse({ status: 404, description: 'Checkout not found' })
   getWalletStatus(@Param('id') checkoutId: string) {
     const checkout = this.subscriptionsService.getCheckout(checkoutId);
@@ -282,9 +362,17 @@ export class SubscriptionsController {
   }
 
   @Get('checkout/:id/preview')
-  @ApiOperation({ summary: 'Get transaction preview for a checkout session', description: 'Returns a preview of the Stellar transaction including from/to addresses, asset, amount, fee, and memo.' })
+  @ApiOperation({
+    summary: 'Get transaction preview for a checkout session',
+    description:
+      'Returns a preview of the Stellar transaction including from/to addresses, asset, amount, fee, and memo.',
+  })
   @ApiParam({ name: 'id', description: 'Checkout session ID' })
-  @ApiResponse({ status: 200, description: 'Transaction preview', type: TransactionPreviewResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Transaction preview',
+    type: TransactionPreviewResponseDto,
+  })
   @ApiResponse({ status: 404, description: 'Checkout not found' })
   getTransactionPreview(@Param('id') checkoutId: string) {
     return this.subscriptionsService.getTransactionPreview(checkoutId);
@@ -292,10 +380,16 @@ export class SubscriptionsController {
 
   @Post('checkout/:id/validate')
   @Throttle({ short: { limit: 10, ttl: 60000 } })
-  @ApiOperation({ summary: 'Validate fan wallet balance for a checkout session' })
+  @ApiOperation({
+    summary: 'Validate fan wallet balance for a checkout session',
+  })
   @ApiResponse({ status: 429, description: 'Too many requests' })
   @ApiParam({ name: 'id', description: 'Checkout session ID' })
-  @ApiResponse({ status: 200, description: 'Balance validation result', type: ValidateBalanceResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Balance validation result',
+    type: ValidateBalanceResponseDto,
+  })
   @ApiResponse({ status: 404, description: 'Checkout not found' })
   validateBalance(
     @Param('id') checkoutId: string,
@@ -314,14 +408,21 @@ export class SubscriptionsController {
   @ApiOperation({ summary: 'Confirm a subscription checkout' })
   @ApiResponse({ status: 429, description: 'Too many requests' })
   @ApiParam({ name: 'id', description: 'Checkout session ID' })
-  @ApiResponse({ status: 200, description: 'Subscription confirmed', type: ConfirmSubscriptionResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Subscription confirmed',
+    type: ConfirmSubscriptionResponseDto,
+  })
   @ApiResponse({ status: 400, description: 'Checkout expired' })
   @ApiResponse({ status: 404, description: 'Checkout not found' })
   confirmSubscription(
     @Param('id') checkoutId: string,
     @Body() body: ConfirmSubscriptionDto,
   ) {
-    return this.subscriptionsService.confirmSubscription(checkoutId, body.txHash);
+    return this.subscriptionsService.confirmSubscription(
+      checkoutId,
+      body.txHash,
+    );
   }
 
   @Post('checkout/:id/fail')
@@ -331,10 +432,7 @@ export class SubscriptionsController {
   @ApiParam({ name: 'id', description: 'Checkout session ID' })
   @ApiResponse({ status: 200, description: 'Checkout marked as failed' })
   @ApiResponse({ status: 404, description: 'Checkout not found' })
-  failCheckout(
-    @Param('id') checkoutId: string,
-    @Body() body: FailCheckoutDto,
-  ) {
+  failCheckout(@Param('id') checkoutId: string, @Body() body: FailCheckoutDto) {
     return this.subscriptionsService.failCheckout(
       checkoutId,
       body.error,
@@ -348,9 +446,7 @@ export class SubscriptionsController {
   @ApiResponse({ status: 429, description: 'Too many requests' })
   @ApiResponse({ status: 200, description: 'Subscription cancelled' })
   @ApiResponse({ status: 404, description: 'Subscription not found' })
-  cancelSubscription(
-    @Body() body: CancelSubscriptionDto,
-  ) {
+  cancelSubscription(@Body() body: CancelSubscriptionDto) {
     return this.subscriptionsService.cancelSubscription(
       body.fanAddress,
       body.creatorAddress,

--- a/backend/src/subscriptions/subscriptions.throttle.spec.ts
+++ b/backend/src/subscriptions/subscriptions.throttle.spec.ts
@@ -7,6 +7,10 @@ import { FeatureFlagGuard } from '../feature-flags/feature-flag.guard';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import { FanBearerGuard } from './guards/fan-bearer.guard';
 
+// Decorator metadata lives on the unbound prototype methods, so reading it
+// back is exactly what these specs are meant to do.
+/* eslint-disable @typescript-eslint/unbound-method */
+
 describe('SubscriptionsController – rate limiting', () => {
   let controller: SubscriptionsController;
 
@@ -39,7 +43,9 @@ describe('SubscriptionsController – rate limiting', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     }),
-    validateBalance: jest.fn().mockReturnValue({ valid: true, balance: '1000' }),
+    validateBalance: jest
+      .fn()
+      .mockReturnValue({ valid: true, balance: '1000' }),
     confirmSubscription: jest.fn().mockResolvedValue({ success: true }),
     failCheckout: jest.fn().mockReturnValue({ success: false }),
     cancelSubscription: jest.fn().mockResolvedValue({ success: true }),
@@ -67,48 +73,51 @@ describe('SubscriptionsController – rate limiting', () => {
   });
 
   it('should have ThrottlerGuard applied at controller level', () => {
-    const guards = Reflect.getMetadata('__guards__', SubscriptionsController);
+    const guards = Reflect.getMetadata(
+      '__guards__',
+      SubscriptionsController,
+    ) as unknown;
     expect(guards).toBeDefined();
     expect(guards).toContain(ThrottlerGuard);
   });
 
   it('should have throttle metadata on createCheckout', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITshort',
       SubscriptionsController.prototype.createCheckout,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('should have throttle metadata on validateBalance', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITshort',
       SubscriptionsController.prototype.validateBalance,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('should have throttle metadata on confirmSubscription', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITshort',
       SubscriptionsController.prototype.confirmSubscription,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('should have throttle metadata on failCheckout', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITshort',
       SubscriptionsController.prototype.failCheckout,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
   it('should have throttle metadata on cancelSubscription', () => {
     const metadata = Reflect.getMetadata(
-      'THROTTLER:LIMIT',
+      'THROTTLER:LIMITshort',
       SubscriptionsController.prototype.cancelSubscription,
-    );
+    ) as unknown;
     expect(metadata).toBeDefined();
   });
 
@@ -119,7 +128,10 @@ describe('SubscriptionsController – rate limiting', () => {
     );
     expect(mockService.createCheckout).toHaveBeenCalled();
 
-    controller.cancelSubscription({ fanAddress: 'GFAN', creatorAddress: 'GCREATOR' });
+    controller.cancelSubscription({
+      fanAddress: 'GFAN',
+      creatorAddress: 'GCREATOR',
+    });
     expect(mockService.cancelSubscription).toHaveBeenCalled();
   });
 });

--- a/backend/src/users/1747000000000-AddRoleToUsers.spec.ts
+++ b/backend/src/users/1747000000000-AddRoleToUsers.spec.ts
@@ -1,0 +1,80 @@
+import { QueryRunner } from 'typeorm';
+import { AddRoleToUsers1747000000000 } from './1747000000000-AddRoleToUsers';
+
+describe('AddRoleToUsers1747000000000', () => {
+  let migration: AddRoleToUsers1747000000000;
+  let queries: string[];
+  let queryRunner: QueryRunner;
+
+  const normalise = (sql: string) => sql.replace(/\s+/g, ' ').trim();
+
+  beforeEach(() => {
+    migration = new AddRoleToUsers1747000000000();
+    queries = [];
+    queryRunner = {
+      query: jest.fn((sql: string) => {
+        queries.push(normalise(sql));
+        return Promise.resolve([]);
+      }),
+    } as unknown as QueryRunner;
+  });
+
+  it('is registered under its own timestamped name', () => {
+    expect(migration.name).toBe('AddRoleToUsers1747000000000');
+  });
+
+  describe('up', () => {
+    beforeEach(async () => {
+      await migration.up(queryRunner);
+    });
+
+    it('creates the role enum type only when it does not already exist', () => {
+      const create = queries.find((q) => q.includes('CREATE TYPE'));
+      expect(create).toBeDefined();
+      expect(create).toContain(
+        "IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'users_role_enum')",
+      );
+      expect(create).toContain(
+        `CREATE TYPE "users_role_enum" AS ENUM ('USER', 'CREATOR', 'ADMIN')`,
+      );
+    });
+
+    it('adds users.role as NOT NULL with a USER default', () => {
+      expect(queries).toContain(
+        `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" "users_role_enum" NOT NULL DEFAULT 'USER'`,
+      );
+    });
+
+    it('is re-runnable against a database that already has the column', () => {
+      // Every DDL statement is guarded, so a second run is a no-op rather than
+      // an error on existing databases.
+      const ddl = queries.filter(
+        (q) => q.includes('CREATE TYPE') || q.includes('ADD COLUMN'),
+      );
+      expect(ddl).toHaveLength(2);
+      ddl.forEach((q) => expect(q).toMatch(/IF NOT EXISTS/));
+    });
+
+    it('backfills creators only when the legacy is_creator column is present', () => {
+      const backfill = queries.find((q) => q.includes('UPDATE "users"'));
+      expect(backfill).toBeDefined();
+      expect(backfill).toContain(`column_name = 'is_creator'`);
+      expect(backfill).toContain(
+        `UPDATE "users" SET "role" = 'CREATOR' WHERE "is_creator" = true AND "role" = 'USER'`,
+      );
+    });
+  });
+
+  describe('down', () => {
+    beforeEach(async () => {
+      await migration.down(queryRunner);
+    });
+
+    it('drops the column before the enum type it depends on', () => {
+      expect(queries).toEqual([
+        `ALTER TABLE "users" DROP COLUMN IF EXISTS "role"`,
+        `DROP TYPE IF EXISTS "users_role_enum"`,
+      ]);
+    });
+  });
+});

--- a/backend/src/users/1747000000000-AddRoleToUsers.ts
+++ b/backend/src/users/1747000000000-AddRoleToUsers.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds the RBAC `role` column to `users` (see `UserRole`).
+ *
+ * The migration is safe to run against both fresh and existing databases:
+ *  - the enum type and the column are only created when they are absent, so a
+ *    database that already picked the column up via `synchronize` is untouched;
+ *  - the column carries a `USER` default and is `NOT NULL`, which Postgres
+ *    backfills for existing rows without a table rewrite;
+ *  - rows already flagged `is_creator` are promoted to `CREATOR` so the new
+ *    column agrees with the pre-RBAC flag.
+ */
+export class AddRoleToUsers1747000000000 implements MigrationInterface {
+  name = 'AddRoleToUsers1747000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'users_role_enum') THEN
+          CREATE TYPE "users_role_enum" AS ENUM ('USER', 'CREATOR', 'ADMIN');
+        END IF;
+      END
+      $$;
+    `);
+
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" "users_role_enum" NOT NULL DEFAULT 'USER'`,
+    );
+
+    // Pre-RBAC databases track creators with the boolean `is_creator` flag.
+    // Fresh databases created from the migrations alone do not have it yet.
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_schema = current_schema()
+            AND table_name = 'users'
+            AND column_name = 'is_creator'
+        ) THEN
+          UPDATE "users" SET "role" = 'CREATOR'
+          WHERE "is_creator" = true AND "role" = 'USER';
+        END IF;
+      END
+      $$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN IF EXISTS "role"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "users_role_enum"`);
+  }
+}

--- a/backend/src/webhook/webhook.controller.ts
+++ b/backend/src/webhook/webhook.controller.ts
@@ -1,21 +1,29 @@
+import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
 import {
-  Body,
-  Controller,
-  HttpCode,
-  Post,
-  UseGuards,
-} from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { WebhookGuard } from './webhook.guard';
 import { WebhookService } from './webhook.service';
+import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth-module/guards/roles.guard';
+import { Roles } from '../auth-module/decorators/roles.decorator';
+import { UserRole } from '../common/enums/user-role.enum';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiTags('webhook')
 @Controller({ path: 'webhook', version: '1' })
 export class WebhookController {
   constructor(private readonly webhookService: WebhookService) {}
 
-  /** Receive an incoming signed webhook event. */
+  /**
+   * Receive an incoming signed webhook event.
+   * Authenticated by the payload signature (WebhookGuard), not by a JWT.
+   */
   @Post()
+  @Public()
   @HttpCode(200)
   @UseGuards(WebhookGuard)
   @ApiOperation({ summary: 'Receive a signed webhook event' })
@@ -26,14 +34,18 @@ export class WebhookController {
   }
 
   /**
-   * Rotate the active signing secret.
+   * Rotate the active signing secret. Admin-only.
    * Body: { newSecret: string; cutoffMs?: number }
-   * In production, protect this endpoint with an admin/JWT guard.
    */
   @Post('rotate')
   @HttpCode(200)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '[Admin] Rotate the webhook signing secret' })
   @ApiResponse({ status: 200, description: 'Secret rotated' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
+  @ApiResponse({ status: 403, description: 'Caller is not an admin' })
   rotate(@Body() body: { newSecret: string; cutoffMs?: number }) {
     this.webhookService.rotate(body.newSecret, body.cutoffMs);
     const state = this.webhookService.getState();
@@ -44,11 +56,18 @@ export class WebhookController {
     };
   }
 
-  /** Immediately expire the previous secret (manual cutoff). */
+  /** Immediately expire the previous secret (manual cutoff). Admin-only. */
   @Post('expire-previous')
   @HttpCode(200)
-  @ApiOperation({ summary: '[Admin] Expire the previous webhook signing secret' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: '[Admin] Expire the previous webhook signing secret',
+  })
   @ApiResponse({ status: 200, description: 'Previous secret expired' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid access token' })
+  @ApiResponse({ status: 403, description: 'Caller is not an admin' })
   expirePrevious() {
     this.webhookService.expirePrevious();
     return { expired: true };

--- a/backend/test/rbac.e2e-spec.ts
+++ b/backend/test/rbac.e2e-spec.ts
@@ -1,0 +1,244 @@
+/**
+ * RBAC end-to-end coverage.
+ *
+ * Exercises the full guard chain the application wires globally in
+ * `AppModule`: JwtAuthGuard (honouring `@Public()`) followed by RolesGuard
+ * (enforcing `@Roles()`), against the real JWT strategy and real controllers.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  INestApplication,
+  ValidationPipe,
+  VersioningType,
+} from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { ConfigModule } from '@nestjs/config';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import request from 'supertest';
+import { App } from 'supertest/types';
+
+import { JwtAuthGuard } from '../src/auth-module/guards/jwt-auth.guard';
+import { RolesGuard } from '../src/auth-module/guards/roles.guard';
+import { JwtStrategy } from '../src/auth-module/strategies/jwt.strategy';
+import { AuthService } from '../src/auth-module/auth.service';
+import { UserRole } from '../src/common/enums/user-role.enum';
+import { ModerationController } from '../src/moderation/moderation.controller';
+import { ModerationService } from '../src/moderation/moderation.service';
+import { ModerationSlaService } from '../src/moderation/moderation-sla.service';
+import { HealthController } from '../src/health/health.controller';
+import { HealthService } from '../src/health/health.service';
+import { FeatureFlagsController } from '../src/feature-flags/feature-flags.controller';
+import { FeatureFlagsService } from '../src/feature-flags/feature-flags.service';
+
+const JWT_SECRET = 'rbac-e2e-secret-not-for-production';
+
+const ADMIN_ID = '11111111-1111-4111-8111-111111111111';
+const USER_ID = '22222222-2222-4222-8222-222222222222';
+const CREATOR_ID = '33333333-3333-4333-8333-333333333333';
+const FLAG_ID = '44444444-4444-4444-8444-444444444444';
+
+const USERS: Record<string, { id: string; email: string; role: UserRole }> = {
+  [ADMIN_ID]: {
+    id: ADMIN_ID,
+    email: 'admin@myfans.test',
+    role: UserRole.ADMIN,
+  },
+  [USER_ID]: { id: USER_ID, email: 'user@myfans.test', role: UserRole.USER },
+  [CREATOR_ID]: {
+    id: CREATOR_ID,
+    email: 'creator@myfans.test',
+    role: UserRole.CREATOR,
+  },
+};
+
+describe('RBAC (e2e)', () => {
+  let app: INestApplication<App>;
+  let jwt: JwtService;
+
+  const mockModerationService = {
+    createFlag: jest.fn().mockResolvedValue({ id: FLAG_ID }),
+    findAll: jest.fn().mockResolvedValue({ data: [], total: 0 }),
+    findOne: jest.fn().mockResolvedValue({ id: FLAG_ID }),
+    reviewFlag: jest.fn().mockResolvedValue({ id: FLAG_ID }),
+    getAuditLog: jest.fn().mockResolvedValue([]),
+  };
+  const mockSlaService = { snapshot: jest.fn().mockResolvedValue({}) };
+  const mockHealthService = {
+    getHealth: jest.fn().mockReturnValue({ status: 'up', timestamp: 'now' }),
+  };
+  const mockFeatureFlagsService = {
+    getAllFlags: jest.fn().mockReturnValue({}),
+  };
+
+  const token = (sub: string) => jwt.sign({ sub });
+  const bearer = (sub: string) => `Bearer ${token(sub)}`;
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = JWT_SECRET;
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }),
+        PassportModule,
+        JwtModule.register({
+          secret: JWT_SECRET,
+          signOptions: { expiresIn: '1h' },
+        }),
+      ],
+      controllers: [
+        ModerationController,
+        HealthController,
+        FeatureFlagsController,
+      ],
+      providers: [
+        JwtStrategy,
+        {
+          provide: AuthService,
+          useValue: {
+            validateUser: jest
+              .fn()
+              .mockImplementation((id: string) =>
+                Promise.resolve(USERS[id] ?? null),
+              ),
+          },
+        },
+        { provide: ModerationService, useValue: mockModerationService },
+        { provide: ModerationSlaService, useValue: mockSlaService },
+        { provide: HealthService, useValue: mockHealthService },
+        { provide: FeatureFlagsService, useValue: mockFeatureFlagsService },
+        { provide: APP_GUARD, useClass: JwtAuthGuard },
+        { provide: APP_GUARD, useClass: RolesGuard },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
+    await app.init();
+
+    jwt = app.get(JwtService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ── Admin-only routes ──────────────────────────────────────────────────
+
+  const ADMIN_ROUTES: [string, 'get' | 'patch', string][] = [
+    ['list flags', 'get', '/v1/moderation/flags'],
+    ['read a flag', 'get', `/v1/moderation/flags/${FLAG_ID}`],
+    ['read a flag audit trail', 'get', `/v1/moderation/flags/${FLAG_ID}/audit`],
+    ['read queue SLA metrics', 'get', '/v1/moderation/sla'],
+  ];
+
+  describe.each(ADMIN_ROUTES)('%s (%s %s)', (_name, method, path) => {
+    it('rejects an anonymous request with 401', () =>
+      request(app.getHttpServer())[method](path).expect(401));
+
+    it('rejects a USER JWT with 403', () =>
+      request(app.getHttpServer())
+        [method](path)
+        .set('Authorization', bearer(USER_ID))
+        .expect(403));
+
+    it('rejects a CREATOR JWT with 403', () =>
+      request(app.getHttpServer())
+        [method](path)
+        .set('Authorization', bearer(CREATOR_ID))
+        .expect(403));
+
+    it('accepts an ADMIN JWT with 200', () =>
+      request(app.getHttpServer())
+        [method](path)
+        .set('Authorization', bearer(ADMIN_ID))
+        .expect(200));
+  });
+
+  describe('PATCH /v1/moderation/flags/:id/review', () => {
+    const body = { status: 'under_review' };
+
+    it('rejects a USER JWT with 403', () =>
+      request(app.getHttpServer())
+        .patch(`/v1/moderation/flags/${FLAG_ID}/review`)
+        .set('Authorization', bearer(USER_ID))
+        .send(body)
+        .expect(403));
+
+    it('accepts an ADMIN JWT with 200', () =>
+      request(app.getHttpServer())
+        .patch(`/v1/moderation/flags/${FLAG_ID}/review`)
+        .set('Authorization', bearer(ADMIN_ID))
+        .send(body)
+        .expect(200));
+  });
+
+  // ── Authenticated, non-admin routes ────────────────────────────────────
+
+  describe('POST /v1/moderation/flags (any authenticated user)', () => {
+    const body = {
+      content_type: 'post',
+      content_id: FLAG_ID,
+      reason: 'spam',
+    };
+
+    it('rejects an anonymous request with 401', () =>
+      request(app.getHttpServer())
+        .post('/v1/moderation/flags')
+        .send(body)
+        .expect(401));
+
+    it('accepts a USER JWT', () =>
+      request(app.getHttpServer())
+        .post('/v1/moderation/flags')
+        .set('Authorization', bearer(USER_ID))
+        .send(body)
+        .expect(201));
+  });
+
+  // ── Public routes ──────────────────────────────────────────────────────
+
+  describe('routes marked @Public()', () => {
+    it('GET /v1/health is reachable without a JWT', () =>
+      request(app.getHttpServer())
+        .get('/v1/health')
+        .expect(200)
+        .expect((res) => {
+          expect((res.body as { status: string }).status).toBe('up');
+        }));
+
+    it('GET /v1/feature-flags is reachable without a JWT', () =>
+      request(app.getHttpServer()).get('/v1/feature-flags').expect(200));
+
+    it('GET /v1/health still works when a JWT is supplied', () =>
+      request(app.getHttpServer())
+        .get('/v1/health')
+        .set('Authorization', bearer(USER_ID))
+        .expect(200));
+
+    it('GET /v1/health is not blocked by an invalid JWT', () =>
+      request(app.getHttpServer())
+        .get('/v1/health')
+        .set('Authorization', 'Bearer not-a-real-token')
+        .expect(200));
+  });
+
+  // ── Token validity ─────────────────────────────────────────────────────
+
+  describe('token validation on protected routes', () => {
+    it('rejects a malformed bearer token with 401', () =>
+      request(app.getHttpServer())
+        .get('/v1/moderation/flags')
+        .set('Authorization', 'Bearer not-a-real-token')
+        .expect(401));
+
+    it('rejects a well-formed token for an unknown user with 401', () =>
+      request(app.getHttpServer())
+        .get('/v1/moderation/flags')
+        .set('Authorization', bearer('00000000-0000-4000-8000-000000000000'))
+        .expect(401));
+  });
+});

--- a/frontend/src/app/subscriptions/page.tsx
+++ b/frontend/src/app/subscriptions/page.tsx
@@ -85,7 +85,11 @@ export default function SubscriptionsPage() {
         }
       } catch (err) {
         console.error(err);
-        showError('NETWORK_ERROR', 'Failed to load subscription history');
+        showError('NETWORK_ERROR', {
+          message: 'Couldn’t load subscription history',
+          description:
+            'Refresh the page. If it still fails, check your internet and that the app backend is running.',
+        });
       } finally {
         if (mounted) setIsHistoryLoading(false);
       }
@@ -118,7 +122,11 @@ export default function SubscriptionsPage() {
         }
       } catch (err) {
         console.error(err);
-        showError('NETWORK_ERROR', 'Failed to load payment history');
+        showError('NETWORK_ERROR', {
+          message: 'Couldn’t load payment history',
+          description:
+            'Refresh the page. If it still fails, check your internet and that the app backend is running.',
+        });
       } finally {
         if (mounted) setIsPaymentsLoading(false);
       }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,7 +40,13 @@ export type {
   Subscription,
   CreateSubscriptionRequest,
   GetSubscriptionsResponse,
-  CreateSubscriptionResponse
+  CreateSubscriptionResponse,
+  // Subscription & payment history
+  PaginatedResponse,
+  SubscriptionHistoryItem,
+  PaymentRecord,
+  GetSubscriptionHistoryParams,
+  GetPaymentHistoryParams
 } from './api';
 
 // Subscription status — shared type + value constants usable across frontend modules


### PR DESCRIPTION
## Summary
Closes: #1354 
CI is already red on `main` before this branch. Verified against a clean `main` worktree:

| Check | `main` (before) | This branch |
|---|---|---|
| Backend build | ❌ 2 TS errors | ✅ |
| Backend tests | ❌ 82 failed / 14 suites | ✅ 1561 passed / 112 suites |
| Frontend build | ❌ type check failed | ✅ |

This PR fixes all three, plus lands the RBAC guard rollout the branch was opened for.

## RBAC rollout

- `JwtAuthGuard` and `RolesGuard` are registered globally, so every route is authenticated unless it opts out with `@Public()`. Drops the now-redundant `PublicGuard`.
- `RolesGuard` reads the shared `ROLES_KEY` and returns 403 when a role-restricted route has no authenticated principal, instead of throwing a 500 by dereferencing an undefined `user`.
- Adds the `AddRoleToUsers` migration, guard unit specs, a migration spec, and `test/rbac.e2e-spec.ts` covering the anonymous / USER / CREATOR / ADMIN matrix and the `@Public()` routes.

## Build fixes

**Backend**
- `health-response.dto.ts` — an `@ApiProperty` decorator sat on an index signature, which TypeScript rejects (TS1206). The queue map is now described on the referencing property.
- `subscriptions.controller.ts` — import the missing `FanDashboardQueryDto`.

**Frontend**
- `subscriptions/page.tsx` — `showError` takes `ToastOptions`, not a string. Now passes `{ message, description }` like every other call site.
- `types/index.ts` — re-export `PaginatedResponse`, `SubscriptionHistoryItem`, `PaymentRecord` and the history param types that `api-client.ts` already imported from `@/types`.

## Test fixes

Each of these was a test asserting against a key or behaviour that does not exist, so it could never have passed:

- **Throttler metadata keys** are name-suffixed in `@nestjs/throttler` v6 (`THROTTLER:LIMITdefault`). The bare `THROTTLER:LIMIT` lookups always read `undefined`. Note the negative assertions ("GET endpoints have no throttle metadata") were passing vacuously.
- **`@ApiBody`/`@ApiQuery`** both write into the shared `swagger/apiParameters` array and are distinguished by their `in` field — there are no `swagger/apiBody` or `swagger/apiQuery` keys.
- **The three `*-exception.filter.ts` copies** (comments, conversations, subscriptions — byte-identical) passed Nest's human reason phrase (`"Bad Request"`) straight through instead of the documented SCREAMING_SNAKE code from their own `statusToError` map, and never mapped string-response exceptions at all. Caller-supplied machine codes like `VALIDATION_FAILED` are still preserved.
- **`throttler.guard.spec.ts`** asserted the broad health exemption that 9a4308b deliberately narrowed to the liveness probe (so scanning probes can't exhaust resources on the expensive sub-checks). The spec now asserts that contract, and calls `module.init()` so the base guard's `onModuleInit` populates its throttler config.
- **Controllers guarded by `ThrottlerGuard`** need `ThrottlerModule` in their test modules to resolve `THROTTLER:MODULE_OPTIONS`.
- **`social-links.controller.spec.ts`** had an unbalanced brace and a block of duplicated, truncated tests from a bad merge — the file could not compile. Removed the dead block, kept the one assertion it uniquely covered, and replaced an unresolvable `@nestjs/swagger/dist/constants` deep import.
- **`'weekly'` is a valid `CapPeriod`**, so it cannot test enum rejection; uses `'daily'`.

## Not addressed

The **Contract** CI job is still red on `main` and is untouched here. `contract/contracts/myfans-lib/src/lib.rs` has an unclosed delimiter that fails `cargo fmt --all --check` and `cargo test`, and the surrounding test module has deeper structural damage from merge `b321e32` — several `#[test]` functions ended up nested inside other test functions, so they silently never run. That needs reconstructing the intended test module and is worth its own PR.

## Test plan

- [x] `npm test` in `backend` — 112 suites, 1561 tests, all pass
- [x] `npm run build` in `backend`
- [x] `npm run build` in `frontend`
- [x] `eslint` clean across every file touched
