### PR TITLE
fix(earnings): replace admin() unwrap with typed NotInitialized error

### DIFF
--- a/contract/contracts/earnings/src/lib.rs
+++ b/contract/contracts/earnings/src/lib.rs
@@ -20,11 +20,14 @@ enum DataKey {
 /// | Code | Variant |
 /// |------|---------|
 /// | 1 | `AlreadyInitialized` |
+/// | 2 | `NotInitialized` |
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Code 1 – contract was already initialized.
     AlreadyInitialized = 1,
+    /// Code 2 – admin key not present; contract was never initialized.
+    NotInitialized = 2,
 }
 
 #[contract]
@@ -42,7 +45,10 @@ impl Earnings {
     }
 
     pub fn admin(env: Env) -> Address {
-        env.storage().instance().get(&DataKey::Admin).unwrap()
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, Error::NotInitialized))
     }
 
     pub fn record(env: Env, creator: Address, amount: i128) {

--- a/contract/contracts/earnings/src/test.rs
+++ b/contract/contracts/earnings/src/test.rs
@@ -78,6 +78,23 @@ fn test_init_requires_admin_auth_without_persisting_state() {
     assert_eq!(client.admin(), admin);
 }
 
+/// Calling admin() before init() returns a typed NotInitialized error instead
+/// of panicking on an unwrap of empty storage.
+#[test]
+fn test_admin_returns_not_initialized_before_init() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, Earnings);
+    let client = EarningsClient::new(&env, &contract_id);
+
+    let result = client.try_admin();
+    assert_eq!(
+        result,
+        Err(Ok(SorobanError::from_contract_error(
+            Error::NotInitialized as u32,
+        )))
+    );
+}
+
 // ── #319 – non-admin record reverts ──────────────────────────────────────────
 
 /// Non-admin caller (no admin auth) must not be able to record earnings.


### PR DESCRIPTION
## Summary

closes #1374

`Earnings::admin()` panicked with a raw `unwrap()` on empty instance storage when the contract had never been initialized, instead of returning a typed contract error. This surfaces as an opaque host panic rather than a decodable Soroban contract error for callers.

- Added `Error::NotInitialized` (code 2) to the earnings contract's `#[contracterror]` enum, appended after the existing `AlreadyInitialized` (code 1) per the "do not renumber existing variants" rule documented on the enum.
- `admin()` now uses `.unwrap_or_else(|| panic_with_error!(&env, Error::NotInitialized))`, mirroring the exact pattern already used by `subscription::MyfansContract::admin()`.
- Added `test_admin_returns_not_initialized_before_init`, which calls `try_admin()` on a freshly-registered, uninitialized contract and asserts the typed error is returned.

## Testing/validation performed

- Manual code review against the existing `subscription` contract's identical `admin()` error-typing pattern for consistency.
- **Note:** this sandbox has no Rust toolchain available, so I could not run `cargo test -p earnings`, `cargo fmt --check`, or the wasm build locally. The change is a minimal, mechanical mirror of an existing, already-tested pattern in `subscription::admin()`, but please confirm CI (`cargo test -p earnings`) passes before merging.

## Issue

https://github.com/MyFanss/MyFans/issues/1374