### PR TITLE
fix(earnings): guard record() against i128 overflow with checked_add

### DIFF
--- a/contract/contracts/earnings/src/lib.rs
+++ b/contract/contracts/earnings/src/lib.rs
@@ -20,11 +20,14 @@ enum DataKey {
 /// | Code | Variant |
 /// |------|---------|
 /// | 1 | `AlreadyInitialized` |
+/// | 2 | `Overflow` |
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Code 1 – contract was already initialized.
     AlreadyInitialized = 1,
+    /// Code 2 – recorded earnings would overflow i128.
+    Overflow = 2,
 }
 
 #[contract]
@@ -52,9 +55,10 @@ impl Earnings {
         // GAS: Cache the DataKey to minimize cloning of creator address.
         let earnings_key = DataKey::Earnings(creator.clone());
         let current: i128 = env.storage().instance().get(&earnings_key).unwrap_or(0);
-        env.storage()
-            .instance()
-            .set(&earnings_key, &(current + amount));
+        let updated = current
+            .checked_add(amount)
+            .unwrap_or_else(|| panic_with_error!(&env, Error::Overflow));
+        env.storage().instance().set(&earnings_key, &updated);
     }
 
     pub fn get_earnings(env: Env, creator: Address) -> i128 {

--- a/contract/contracts/earnings/src/test.rs
+++ b/contract/contracts/earnings/src/test.rs
@@ -141,6 +141,27 @@ fn test_get_earnings_defaults_to_zero() {
     assert_eq!(client.get_earnings(&creator), 0);
 }
 
+/// record() reverts with a typed Overflow error instead of silently wrapping
+/// when current + amount would exceed i128::MAX.
+#[test]
+fn test_record_overflow_reverts_typed() {
+    let env = Env::default();
+    let (_admin, creator, client) = setup(&env);
+
+    client.record(&creator, &i128::MAX);
+
+    let result = client.try_record(&creator, &1);
+    assert_eq!(
+        result,
+        Err(Ok(SorobanError::from_contract_error(Error::Overflow as u32)))
+    );
+    assert_eq!(
+        client.get_earnings(&creator),
+        i128::MAX,
+        "a rejected overflow must not change the recorded balance"
+    );
+}
+
 // ── #297 – withdrawal feature ─────────────────────────────────────────────────
 
 /// Valid withdrawal reduces the recorded balance by the withdrawn amount.


### PR DESCRIPTION
## Summary

closes #1375

`Earnings::record()` computed `current + amount` with plain arithmetic, which can silently wrap on `i128` overflow instead of reverting. Since `record` is admin-authorized (not user-facing per transaction amount), this is a defense-in-depth guard against a corrupted/overflowed balance rather than a directly user-triggerable exploit, but it closes a real correctness gap.

- Added `Error::Overflow` (code 2) to the earnings contract's `#[contracterror]` enum, appended after `AlreadyInitialized` (code 1) per the "do not renumber existing variants" numbering rule on the enum.
- `record()` now computes the new balance with `checked_add` and reverts via `panic_with_error!(&env, Error::Overflow)` instead of wrapping when the addition would overflow.
- Added `test_record_overflow_reverts_typed`, which records `i128::MAX` for a creator, attempts to record `1` more, asserts the typed `Overflow` error is returned, and confirms the balance is left unchanged.

**Note on error code numbering:** issue #1374 (also touching this file's `Error` enum) is being opened as a separate PR in parallel. Both PRs independently add discriminant `2` to the enum (`NotInitialized` in #1374, `Overflow` here) since neither branch is aware of the other. Whichever of the two merges second will need a one-line renumber (`2` → `3`) to avoid a discriminant collision — flagging this explicitly for the merging reviewer.

## Testing/validation performed

- Manual code review; `checked_add` mirrors the standard Rust/Soroban i128 overflow-guard idiom used elsewhere in this codebase.
- **Note:** this sandbox has no Rust toolchain available, so I could not run `cargo test -p earnings`, `cargo fmt --check`, or the wasm build locally. Please confirm CI (`cargo test -p earnings`) passes before merging.