### PR TITLE
fix(subscription): require admin auth on init

### DIFF
--- a/contract/AUTH_MATRIX.md
+++ b/contract/AUTH_MATRIX.md
@@ -51,7 +51,7 @@ Contracts covered here (deployed by `contract/scripts/deploy.sh`):
 
 | Method | Required signer(s) | Valid invocation example | Invalid invocation example |
 | --- | --- | --- | --- |
-| `init(env, admin, fee_bps, fee_recipient, token, price)` | `none` | Any caller initializes once with config values. | Re-initialization attempt after already initialized. |
+| `init(env, admin, fee_bps, fee_recipient, token, price)` | `admin` | `admin` signs and initializes once with config values. | Non-admin caller initializes without `admin` signature. |
 | `create_plan(env, creator, asset, amount, interval_days)` | `creator` | `creator` signs and creates a plan. | Non-creator caller submits plan for `creator`. |
 | `subscribe(env, fan, plan_id, _token)` | `fan` | `fan` signs and subscribes to `plan_id`. | Another address tries to subscribe using `fan` as parameter without `fan` auth. |
 | `is_subscriber(env, fan, creator)` | `none` | Any caller checks subscription status. | Expecting signer/auth to be required for read. |

--- a/contract/contracts/subscription/README.md
+++ b/contract/contracts/subscription/README.md
@@ -65,6 +65,8 @@ pub fn init(
 
 One-time contract initialization. Stores admin, fee configuration, token address, and base subscription price.
 
+**Requires `admin` authorization.**
+
 **Panics** with `AlreadyInitialized` if called again, `InvalidFeeBps` if `fee_bps > 10_000`,
 `InvalidTokenAddress` if `token` is the Stellar null address, or `InvalidPrice` if `price <= 0`.
 

--- a/contract/contracts/subscription/src/lib.rs
+++ b/contract/contracts/subscription/src/lib.rs
@@ -128,6 +128,8 @@ pub struct MyfansContract;
 impl MyfansContract {
     /// Initialize the subscription contract once.
     ///
+    /// Requires `admin` to authorize the call.
+    ///
     /// Validates:
     /// * `fee_bps` must be ≤ 10000 (100%).
     /// * `token` must be a valid non-null address.
@@ -143,6 +145,7 @@ impl MyfansContract {
         if env.storage().instance().has(&DataKey::Admin) {
             panic_with_error!(&env, Error::AlreadyInitialized);
         }
+        admin.require_auth();
         require_valid_fee_recipient(&env, &fee_recipient);
         require_valid_fee_bps(&env, fee_bps);
         require_valid_token_address(&env, &token);

--- a/contract/contracts/subscription/src/test.rs
+++ b/contract/contracts/subscription/src/test.rs
@@ -115,6 +115,32 @@ fn test_init_rejects_non_positive_price() {
     );
 }
 
+/// init() requires the supplied admin to authorize the call; a rejected
+/// attempt leaves the contract uninitialized, allowing a later valid init.
+#[test]
+fn test_init_requires_admin_auth_without_persisting_state() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let token_address = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_client = token::Client::new(&env, &token_address.address());
+    let contract_id = env.register_contract(None, MyfansContract);
+    let client = MyfansContractClient::new(&env, &contract_id);
+    let fee_recipient = Address::generate(&env);
+
+    let empty: &[SorobanAuthorizationEntry] = &[];
+    env.set_auths(empty);
+    assert!(
+        client
+            .try_init(&admin, &500u32, &fee_recipient, &token_client.address, &1000i128)
+            .is_err(),
+        "init must require admin auth"
+    );
+
+    env.mock_all_auths();
+    client.init(&admin, &500u32, &fee_recipient, &token_client.address, &1000i128);
+    assert_eq!(client.admin(), admin);
+}
+
 #[test]
 fn test_init_succeeds_sets_admin_and_configuration() {
     let (env, client, admin, token, _token_admin) = setup_test();

--- a/contract/contracts/subscription/tests/auth_matrix.rs
+++ b/contract/contracts/subscription/tests/auth_matrix.rs
@@ -450,9 +450,9 @@ fn sub_setup(
     (sub, token, admin, creator, fan)
 }
 
-/// init – no auth required; any caller initializes once.
+/// init – admin signs and initializes once.
 #[test]
-fn sub_init_valid_any_caller() {
+fn sub_init_valid_admin_signs() {
     let env = base_env();
     let (token, admin) = setup_token(&env);
     let fee_recipient = Address::generate(&env);
@@ -460,6 +460,22 @@ fn sub_init_valid_any_caller() {
     let client = MyfansContractClient::new(&env, &id);
     client.init(&admin, &500u32, &fee_recipient, &token.address, &1000i128);
     assert_eq!(client.admin(), admin);
+}
+
+/// init – non-admin (no auth) is rejected.
+#[test]
+fn sub_init_invalid_non_admin_rejected() {
+    let env = base_env();
+    let (token, admin) = setup_token(&env);
+    let fee_recipient = Address::generate(&env);
+    let id = env.register_contract(None, MyfansContract);
+    let client = MyfansContractClient::new(&env, &id);
+    env.set_auths(EMPTY_AUTHS);
+    let result = client.try_init(&admin, &500u32, &fee_recipient, &token.address, &1000i128);
+    assert!(
+        result.is_err(),
+        "non-admin must not initialize subscription contract"
+    );
 }
 
 /// init – re-initialization is rejected.


### PR DESCRIPTION
## Summary

closes #1376

`MyfansContract::init()` stored the supplied `admin` address with no signature verification at all — any caller could initialize the contract and name themselves (or anyone else) admin, since only the "already initialized" state was checked.

- `init()` now calls `admin.require_auth()` immediately after the already-initialized guard and before any other validation/storage writes, so only the address that will become the stored admin can perform initialization.
- Updated `contract/AUTH_MATRIX.md`'s subscription `init` row: signer requirement changed from `none` to `admin`, with matching valid/invalid invocation examples.
- Updated `contract/contracts/subscription/README.md` to document that `init` requires admin authorization.
- Added `test_init_requires_admin_auth_without_persisting_state` (in `src/test.rs`), mirroring the existing, identical pattern already used for the `earnings` contract's `init`: an unauthorized attempt is rejected and leaves the contract uninitialized, then a properly authorized `init` succeeds.
- Added `sub_init_invalid_non_admin_rejected` to the `AUTH_MATRIX.md` compliance suite (`tests/auth_matrix.rs`), and renamed `sub_init_valid_any_caller` to `sub_init_valid_admin_signs` to reflect the new requirement (all existing callers of this test already mock all auths, so its assertions are unaffected).

All other existing `init` tests (`test_init_succeeds_sets_admin_and_configuration`, `test_init_rejects_*`, property tests, `contract_integration.rs`, etc.) already call `env.mock_all_auths()` in their setup, so they are unaffected by this change.

## Testing/validation performed

- Manual review of every call site that invokes `MyfansContract::init` across `src/test.rs`, `tests/auth_matrix.rs`, `tests/contract_integration.rs`, and `src/property_tests.rs` to confirm each already runs under `mock_all_auths()` and will not break.
- **Note:** this sandbox has no Rust toolchain available, so I could not run `cargo test -p subscription`, `cargo fmt --check`, or the wasm build locally. Please confirm CI (`cargo test -p subscription`) passes before merging.

## Issue

https://github.com/MyFanss/MyFans/issues/1376