### PR TITLE
fix(subscription): validate create_plan amount and interval_days

### DIFF
--- a/contract/contracts/subscription/README.md
+++ b/contract/contracts/subscription/README.md
@@ -45,6 +45,7 @@ pub struct Subscription {
 | 7 | `InvalidFeeBps` | Fee basis points exceed 10 000 (100%) |
 | 8 | `InvalidTokenAddress` | Token address is the Stellar null/burn address |
 | 9 | `InvalidPrice` | Subscription price must be strictly positive |
+| 11 | `InvalidPlanParams` | Plan `amount` must be strictly positive and `interval_days` non-zero |
 
 ---
 
@@ -83,7 +84,8 @@ pub fn create_plan(
 ```
 
 Registers a new billing plan for `creator`. Returns the assigned `plan_id` (auto-incremented from 1).
-Requires `creator` authorization. Panics with `Paused` if the contract is paused.
+Requires `creator` authorization. Panics with `Paused` if the contract is paused, or
+`InvalidPlanParams` if `amount <= 0` or `interval_days == 0`.
 
 **Event** `plan_created` — topics: `(name, creator)`, data: `plan_id`
 

--- a/contract/contracts/subscription/src/lib.rs
+++ b/contract/contracts/subscription/src/lib.rs
@@ -69,6 +69,7 @@ impl DataKey {
 /// | 8 | `InvalidTokenAddress` |
 /// | 9 | `InvalidPrice` |
 /// | 10 | `PlanNotFound` |
+/// | 11 | `InvalidPlanParams` |
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -92,6 +93,8 @@ pub enum Error {
     InvalidPrice = 9,
     /// Code 10 – plan ID does not exist; never created or out of range.
     PlanNotFound = 10,
+    /// Code 11 – plan `amount` must be strictly positive and `interval_days` non-zero.
+    InvalidPlanParams = 11,
 }
 
 /// Stellar "null" account (GAAA...WHF) — not a valid fee recipient.
@@ -180,6 +183,9 @@ impl MyfansContract {
             .unwrap_or(false);
         if paused {
             panic_with_error!(&env, Error::Paused);
+        }
+        if amount <= 0 || interval_days == 0 {
+            panic_with_error!(&env, Error::InvalidPlanParams);
         }
 
         let count: u32 = env

--- a/contract/contracts/subscription/src/test.rs
+++ b/contract/contracts/subscription/src/test.rs
@@ -1792,3 +1792,68 @@ fn test_cancel_paused_returns_typed_error() {
         Err(Ok(SorobanError::from_contract_error(Error::Paused as u32)))
     );
 }
+
+// ── create_plan parameter validation ─────────────────────────────────────────
+
+/// create_plan rejects a zero amount with a typed InvalidPlanParams error.
+#[test]
+fn test_create_plan_rejects_zero_amount() {
+    let (env, client, admin, token, _token_admin) = setup_test();
+    let fee_recipient = Address::generate(&env);
+    client.init(&admin, &500, &fee_recipient, &token.address, &1000);
+    let creator = Address::generate(&env);
+
+    let result = client.try_create_plan(&creator, &token.address, &0, &30);
+    assert_eq!(
+        result,
+        Err(Ok(SorobanError::from_contract_error(
+            Error::InvalidPlanParams as u32,
+        )))
+    );
+}
+
+/// create_plan rejects a negative amount with a typed InvalidPlanParams error.
+#[test]
+fn test_create_plan_rejects_negative_amount() {
+    let (env, client, admin, token, _token_admin) = setup_test();
+    let fee_recipient = Address::generate(&env);
+    client.init(&admin, &500, &fee_recipient, &token.address, &1000);
+    let creator = Address::generate(&env);
+
+    let result = client.try_create_plan(&creator, &token.address, &-1, &30);
+    assert_eq!(
+        result,
+        Err(Ok(SorobanError::from_contract_error(
+            Error::InvalidPlanParams as u32,
+        )))
+    );
+}
+
+/// create_plan rejects a zero interval_days with a typed InvalidPlanParams error.
+#[test]
+fn test_create_plan_rejects_zero_interval_days() {
+    let (env, client, admin, token, _token_admin) = setup_test();
+    let fee_recipient = Address::generate(&env);
+    client.init(&admin, &500, &fee_recipient, &token.address, &1000);
+    let creator = Address::generate(&env);
+
+    let result = client.try_create_plan(&creator, &token.address, &1000, &0);
+    assert_eq!(
+        result,
+        Err(Ok(SorobanError::from_contract_error(
+            Error::InvalidPlanParams as u32,
+        )))
+    );
+}
+
+/// A valid plan (positive amount, non-zero interval_days) still succeeds.
+#[test]
+fn test_create_plan_accepts_valid_params() {
+    let (env, client, admin, token, _token_admin) = setup_test();
+    let fee_recipient = Address::generate(&env);
+    client.init(&admin, &500, &fee_recipient, &token.address, &1000);
+    let creator = Address::generate(&env);
+
+    let plan_id = client.create_plan(&creator, &token.address, &1000, &30);
+    assert_eq!(plan_id, 1);
+}


### PR DESCRIPTION
## Summary

closes #1377

`MyfansContract::create_plan()` accepted any `i128` amount and `u32` interval_days with no validation, so a zero/negative amount or a zero-day interval plan could be created (a zero interval would make `subscribe`'s expiry math a no-op, effectively creating a permanently-non-expiring or degenerate plan).

- Added `Error::InvalidPlanParams` (code 11) to the subscription contract's `#[contracterror]` enum, appended after `PlanNotFound` (code 10) per the "do not renumber existing variants" rule on the enum.
- `create_plan()` now rejects `amount <= 0` or `interval_days == 0` with `panic_with_error!(&env, Error::InvalidPlanParams)`, checked right after the existing `Paused` guard and before any storage writes.
- Documented the new error code and the updated `create_plan` panic conditions in the subscription README.
- Added four unit tests: zero amount, negative amount, zero `interval_days` (each asserting the typed error via `try_create_plan`), and a control test confirming a valid plan (`amount = 1000`, `interval_days = 30`) still succeeds.

Verified every existing `create_plan` call site across `src/test.rs`, `tests/auth_matrix.rs`, and `tests/contract_integration.rs` already uses a positive amount (typically `1000`) and non-zero `interval_days` (`1` or `30`), so none of them are affected by the new validation.

## Testing/validation performed

- Manual review of all `create_plan` call sites in the crate to confirm none pass a zero/negative amount or zero interval_days.
- **Note:** this sandbox has no Rust toolchain available, so I could not run `cargo test -p subscription`, `cargo fmt --check`, or the wasm build locally. Please confirm CI (`cargo test -p subscription`) passes before merging.