### PR TITLE
refactor(myfans-lib): add missing error codes for contracts

### DIFF
--- a/contract/contracts/myfans-lib/src/error_codes.rs
+++ b/contract/contracts/myfans-lib/src/error_codes.rs
@@ -39,6 +39,9 @@ pub mod content_access {
     pub const PURCHASE_EXPIRED: u32 = 4;
     // Note: code 5 is intentionally unassigned (reserved gap).
     pub const NOT_BUYER: u32 = 6;
+    pub const INVALID_PRICE: u32 = 7;
+    pub const PRICE_EXCEEDS_MAX: u32 = 8;
+    pub const INVALID_MAX_PRICE: u32 = 9;
 }
 
 /// Error codes for the **content-likes** contract.
@@ -85,6 +88,9 @@ pub mod creator_earnings {
 pub mod creator_deposits {
     pub const INVALID_FEE_BPS: u32 = 1;
     pub const INSUFFICIENT_BALANCE: u32 = 2;
+    pub const ADMIN_NOT_INITIALIZED: u32 = 3;
+    pub const PLATFORM_FEE_NOT_INITIALIZED: u32 = 4;
+    pub const PLATFORM_TREASURY_NOT_INITIALIZED: u32 = 5;
 }
 
 /// Error codes for the **myfans-contract** (main contract).
@@ -95,6 +101,8 @@ pub mod myfans_contract {
     pub const PAUSED: u32 = 4;
     pub const SUBSCRIPTION_DOES_NOT_EXIST: u32 = 5;
     pub const ADMIN_NOT_INITIALIZED: u32 = 6;
+    pub const ALREADY_INITIALIZED: u32 = 7;
+    pub const PLAN_NOT_FOUND: u32 = 8;
 }
 
 /// Error codes for the **myfans-token** contract.


### PR DESCRIPTION
## Summary

- Add missing error codes for content-access: INVALID_PRICE (7), PRICE_EXCEEDS_MAX (8), INVALID_MAX_PRICE (9)
- Add missing error codes for creator-deposits: ADMIN_NOT_INITIALIZED (3), PLATFORM_FEE_NOT_INITIALIZED (4), PLATFORM_TREASURY_NOT_INITIALIZED (5)
- Add new error codes for myfans-contract: ALREADY_INITIALIZED (7), PLAN_NOT_FOUND (8)
- All codes match their respective contract Error enums

## Validation

- Error codes are complete and stable
- No duplicate code numbers across contracts
- Ready for client consumption (TypeScript SDK, backend, frontend)

Closes #1403