### PR TITLE
feat: adopt myfans-lib require_authorized helper in production contracts

### DIFF
--- a/contract/contracts/subscription/src/lib.rs
+++ b/contract/contracts/subscription/src/lib.rs
@@ -3,6 +3,7 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, token, Address, Env,
     String, Symbol,
 };
+use myfans_lib::auth;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -445,7 +446,8 @@ impl MyfansContract {
             .instance()
             .get(&DataKey::Admin)
             .unwrap_or_else(|| panic_with_error!(&env, Error::AdminNotInitialized));
-        admin.require_auth();
+        let caller = env.invoker();
+        auth::require_authorized(&env, &caller, &admin, &Symbol::new(&env, "pause"));
 
         env.storage().instance().set(&DataKey::Paused, &true);
         env.events().publish((Symbol::new(&env, "paused"),), admin);
@@ -459,7 +461,8 @@ impl MyfansContract {
             .instance()
             .get(&DataKey::Admin)
             .unwrap_or_else(|| panic_with_error!(&env, Error::AdminNotInitialized));
-        admin.require_auth();
+        let caller = env.invoker();
+        auth::require_authorized(&env, &caller, &admin, &Symbol::new(&env, "unpause"));
 
         env.storage().instance().set(&DataKey::Paused, &false);
         env.events()
@@ -477,7 +480,8 @@ impl MyfansContract {
             .instance()
             .get(&DataKey::Admin)
             .unwrap_or_else(|| panic_with_error!(&env, Error::AdminNotInitialized));
-        admin.require_auth();
+        let caller = env.invoker();
+        auth::require_authorized(&env, &caller, &admin, &Symbol::new(&env, "set_fee_recipient"));
 
         require_valid_fee_recipient(&env, &new_fee_recipient);
 
@@ -510,7 +514,8 @@ impl MyfansContract {
             .instance()
             .get(&DataKey::Admin)
             .unwrap_or_else(|| panic_with_error!(&env, Error::AdminNotInitialized));
-        admin.require_auth();
+        let caller = env.invoker();
+        auth::require_authorized(&env, &caller, &admin, &Symbol::new(&env, "set_fee_bps"));
 
         require_valid_fee_bps(&env, new_fee_bps);
 

--- a/contract/contracts/treasury/src/lib.rs
+++ b/contract/contracts/treasury/src/lib.rs
@@ -3,6 +3,7 @@ pub mod errors;
 
 pub use errors::TreasuryError as Error;
 use soroban_sdk::{contract, contractimpl, panic_with_error, token, Address, Env, Symbol};
+use myfans_lib::auth;
 
 const ADMIN: &str = "ADMIN";
 const TOKEN: &str = "TOKEN";
@@ -42,7 +43,8 @@ impl Treasury {
     /// Requires authorization from the admin.
     pub fn set_paused(env: Env, paused: bool) {
         let admin = Self::get_admin(&env);
-        admin.require_auth();
+        let caller = env.invoker();
+        auth::require_authorized(&env, &caller, &admin, &Symbol::new(&env, "set_paused"));
         env.storage().instance().set(&PAUSED, &paused);
 
         env.events()


### PR DESCRIPTION
## Summary

- Import auth module from myfans_lib in subscription and treasury contracts
- Replace admin.require_auth() with auth::require_authorized() in 5 production functions:
  * subscription: pause, unpause, set_fee_recipient, set_fee_bps
  * treasury: set_paused
- Provides consistent authorization logging and event emission across contracts
- Removes code duplication and improves maintenance

## Validation

- Auth behavior remains unchanged
- Authorization events are now emitted consistently via the shared helper
- Workspace tests pass

Closes #1402