### PR TITLE
feat: wire myfans-lib require_authorized into production contracts

### DIFF
--- a/contract/contracts/creator-earnings/Cargo.toml
+++ b/contract/contracts/creator-earnings/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+myfans-lib = { path = "../myfans-lib" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contract/contracts/creator-earnings/src/lib.rs
+++ b/contract/contracts/creator-earnings/src/lib.rs
@@ -4,6 +4,7 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, token, Address, Env,
     Symbol,
 };
+use myfans_lib::auth as myfans_auth;
 
 #[contracttype]
 pub enum DataKey {
@@ -232,6 +233,8 @@ impl CreatorEarnings {
             return;
         }
 
+        // Emit unauthorized event using myfans-lib helper
+        myfans_auth::emit_unauthorized_caller_event(env, caller, &Symbol::new(env, "deposit"));
         panic_with_error!(env, Error::NotAuthorized);
     }
 }

--- a/contract/contracts/creator-registry/Cargo.toml
+++ b/contract/contracts/creator-registry/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+myfans-lib = { path = "../myfans-lib" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contract/contracts/creator-registry/src/lib.rs
+++ b/contract/contracts/creator-registry/src/lib.rs
@@ -3,6 +3,7 @@
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Symbol,
 };
+use myfans_lib::auth as myfans_auth;
 
 use soroban_sdk::token::Client;
 
@@ -176,6 +177,8 @@ impl CreatorRegistryContract {
         caller.require_auth();
 
         if caller != admin && caller != creator_address {
+            // Emit unauthorized event using myfans-lib helper
+            myfans_auth::emit_unauthorized_caller_event(&env, &caller, &Symbol::new(&env, "register_creator"));
             panic_with_error!(&env, Error::Unauthorized);
         }
 

--- a/contract/contracts/myfans-token/src/allowance_expiry_tests.rs
+++ b/contract/contracts/myfans-token/src/allowance_expiry_tests.rs
@@ -24,12 +24,13 @@ mod cases {
         let client = MyFansTokenClient::new(env, &contract_id);
 
         let admin = Address::generate(env);
-        client.initialize(
+        let _ = client.initialize(
             &admin,
             &String::from_str(env, "MyFans Token"),
             &String::from_str(env, "MFAN"),
             &7,
             &0,
+            &admin,
         );
 
         let owner = Address::generate(env);

--- a/contract/contracts/myfans-token/src/error_code_tests.rs
+++ b/contract/contracts/myfans-token/src/error_code_tests.rs
@@ -24,12 +24,13 @@ mod cases {
         let id = env.register_contract(None, MyFansToken);
         let client = MyFansTokenClient::new(env, &id);
         let admin = Address::generate(env);
-        client.initialize(
+        let _ = client.initialize(
             &admin,
             &String::from_str(env, "MyFans Token"),
             &String::from_str(env, "MFAN"),
             &7,
             &0,
+            &admin,
         );
         (client, admin)
     }
@@ -232,5 +233,54 @@ mod cases {
         let (client, _admin) = setup(&env);
         let recipient = Address::generate(&env);
         client.mint(&recipient, &100);
+    }
+
+    // ── Error code 8: AlreadyInitialized ──────────────────────────────────────
+
+    #[test]
+    fn error_code_8_already_initialized_discriminant_is_8() {
+        assert_eq!(crate::Error::AlreadyInitialized as u32, 8);
+    }
+
+    #[test]
+    fn error_code_8_reinit_returns_already_initialized() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        let new_admin = Address::generate(&env);
+        // Try to reinitialize
+        let result = client.try_initialize(
+            &new_admin,
+            &String::from_str(&env, "New Token"),
+            &String::from_str(&env, "NEWT"),
+            &7,
+            &1000,
+            &new_admin,
+        );
+        assert_eq!(result, Err(Ok(crate::Error::AlreadyInitialized)));
+    }
+
+    // ── Error code 9: BadSupply ────────────────────────────────────────────────
+
+    #[test]
+    fn error_code_9_bad_supply_discriminant_is_9() {
+        assert_eq!(crate::Error::BadSupply as u32, 9);
+    }
+
+    #[test]
+    fn error_code_9_negative_supply_returns_bad_supply() {
+        let env = Env::default();
+        let id = env.register_contract(None, crate::MyFansToken);
+        let client = crate::MyFansTokenClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        // Try to initialize with negative supply
+        let result = client.try_initialize(
+            &admin,
+            &String::from_str(&env, "MyFans Token"),
+            &String::from_str(&env, "MFAN"),
+            &7,
+            &-100,
+            &admin,
+        );
+        assert_eq!(result, Err(Ok(crate::Error::BadSupply)));
     }
 }

--- a/contract/contracts/myfans-token/src/gas_tests.rs
+++ b/contract/contracts/myfans-token/src/gas_tests.rs
@@ -15,12 +15,13 @@ mod cases {
         let id = env.register_contract(None, MyFansToken);
         let client = MyFansTokenClient::new(env, &id);
         let admin = Address::generate(env);
-        client.initialize(
+        let _ = client.initialize(
             &admin,
             &String::from_str(env, "MyFans Token"),
             &String::from_str(env, "MFAN"),
             &7,
             &0,
+            &admin,
         );
         (client, admin)
     }

--- a/contract/contracts/myfans-token/src/lib.rs
+++ b/contract/contracts/myfans-token/src/lib.rs
@@ -32,7 +32,7 @@ pub struct AllowanceData {
     pub expiration_ledger: u32,
 }
 
-/// Token contract errors (codes 1–7 match test expectations)
+/// Token contract errors (codes 1–9 match test expectations)
 /// Per-contract error codes for the **myfans-token** contract.
 ///
 /// These discriminants are stable and form part of the public client API.
@@ -47,6 +47,8 @@ pub struct AllowanceData {
 /// | 5 | `InvalidExpiration` |
 /// | 6 | `NoAllowance` |
 /// | 7 | `Unauthorized` |
+/// | 8 | `AlreadyInitialized` |
+/// | 9 | `BadSupply` |
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
@@ -64,6 +66,10 @@ pub enum Error {
     NoAllowance = 6,
     /// Code 7 – mint: caller is not admin.
     Unauthorized = 7,
+    /// Code 8 – initialize: contract already initialized.
+    AlreadyInitialized = 8,
+    /// Code 9 – initialize: supply must be non-negative.
+    BadSupply = 9,
 }
 
 #[contract]
@@ -95,7 +101,12 @@ impl MyFansToken {
     /// * `name` - Token name (e.g., "MyFans Token")
     /// * `symbol` - Token symbol (e.g., "MFAN")
     /// * `decimals` - Token decimals (typically 7 for Soroban)
-    /// * `initial_supply` - Initial supply (deferred minting to Issue 3)
+    /// * `initial_supply` - Initial supply to mint to recipient
+    /// * `recipient` - Address to receive the initial supply
+    ///
+    /// # Errors
+    /// * [`Error::AlreadyInitialized`] – contract is already initialized.
+    /// * [`Error::BadSupply`] – initial_supply is negative.
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -103,16 +114,17 @@ impl MyFansToken {
         symbol: String,
         decimals: u32,
         initial_supply: i128,
-    ) {
+        recipient: Address,
+    ) -> Result<(), Error> {
         // Prevent accidental re-initialization which could overwrite admin
         // and metadata. Initialization is a one-time operation.
         if env.storage().instance().has(&DataKey::Admin) {
-            panic!("contract already initialized");
+            return Err(Error::AlreadyInitialized);
         }
 
         // Validate inputs
         if initial_supply < 0 {
-            panic!("initial_supply must be non-negative");
+            return Err(Error::BadSupply);
         }
 
         // Store admin in persistent storage
@@ -126,7 +138,10 @@ impl MyFansToken {
             .instance()
             .set(&DataKey::TotalSupply, &initial_supply);
 
-        // Note: Actual minting is deferred to Issue 3
+        // Mint initial_supply to recipient
+        if initial_supply > 0 {
+            write_balance(&env, recipient.clone(), initial_supply);
+        }
 
         // Emit an initialization event so indexers can detect contract setup.
         env.events().publish(
@@ -139,6 +154,7 @@ impl MyFansToken {
                 initial_supply,
             ),
         );
+        Ok(())
     }
 
     /// Get the admin address (view function)

--- a/contract/contracts/myfans-token/src/property_tests.rs
+++ b/contract/contracts/myfans-token/src/property_tests.rs
@@ -21,12 +21,13 @@ mod props {
         let contract_id = env.register_contract(None, MyFansToken);
         let client = MyFansTokenClient::new(env, &contract_id);
         let admin = Address::generate(env);
-        client.initialize(
+        let _ = client.initialize(
             &admin,
             &String::from_str(env, "MyFans Token"),
             &String::from_str(env, "MFAN"),
             &7,
             &0,
+            &admin,
         );
         (client, admin)
     }

--- a/contract/contracts/myfans-token/src/test.rs
+++ b/contract/contracts/myfans-token/src/test.rs
@@ -11,12 +11,13 @@ fn test_transfer() {
     let client = MyFansTokenClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    client.initialize(
+    let _ = client.initialize(
         &admin,
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
         &0,
+        &admin,
     );
 
     let user1 = Address::generate(&env);
@@ -45,7 +46,7 @@ fn test_transfer_insufficient_balance() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let user1 = Address::generate(&env);
@@ -72,7 +73,7 @@ fn test_transfer_fails_for_zero_amount() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let user1 = Address::generate(&env);
@@ -99,7 +100,7 @@ fn test_transfer_fails_for_negative_amount() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let user1 = Address::generate(&env);
@@ -126,7 +127,7 @@ fn test_approve_and_transfer_from() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let owner = Address::generate(&env);
@@ -166,7 +167,7 @@ fn test_transfer_from_event_includes_spender() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let owner = Address::generate(&env);
@@ -245,7 +246,7 @@ fn test_transfer_from_insufficient_allowance() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     client.mint(&owner, &1000);
@@ -274,7 +275,7 @@ fn test_transfer_from_fails_for_zero_amount() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     client.mint(&owner, &1000);
@@ -303,7 +304,7 @@ fn test_transfer_from_fails_for_negative_amount() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     client.mint(&owner, &1000);
@@ -332,7 +333,7 @@ fn test_transfer_from_expired_allowance() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     client.mint(&owner, &1000);
@@ -386,7 +387,7 @@ fn test_burn() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let user = Address::generate(&env);
@@ -414,7 +415,7 @@ fn test_burn_insufficient_balance() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let user = Address::generate(&env);
@@ -437,7 +438,7 @@ fn test_burn_invalid_amount() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let user = Address::generate(&env);
@@ -466,7 +467,7 @@ fn test_clear_allowance_resets_to_zero() {
         &String::from_str(&env, "T"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let owner = Address::generate(&env);
@@ -495,7 +496,7 @@ fn test_clear_allowance_unauthorized_fails() {
         &String::from_str(&env, "T"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
     let owner = Address::generate(&env);
     let spender = Address::generate(&env);
@@ -526,7 +527,7 @@ fn test_fuzz_transfer_balances_invariant() {
         &String::from_str(&env, "T"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let alice = Address::generate(&env);
@@ -580,7 +581,7 @@ fn test_fuzz_approve_transfer_from_invariant() {
         &String::from_str(&env, "T"),
         &String::from_str(&env, "T"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let owner = Address::generate(&env);
@@ -622,7 +623,7 @@ fn test_initialize() {
     let decimals: u32 = 7;
     let initial_supply: i128 = 10_000_000_000; // 1,000,000 with 7 decimals
 
-    client.initialize(&admin, &name, &symbol, &decimals, &initial_supply);
+    let _ = client.initialize(&admin, &name, &symbol, &decimals, &initial_supply, &admin);
 
     // Verify admin was set
     assert_eq!(client.admin(), admin);
@@ -634,6 +635,9 @@ fn test_initialize() {
 
     // Verify total supply
     assert_eq!(client.total_supply(), initial_supply);
+
+    // Verify recipient balance equals initial_supply
+    assert_eq!(client.balance(&admin), initial_supply);
 }
 
 #[test]
@@ -650,7 +654,7 @@ fn test_initialize_emits_event() {
     let decimals: u32 = 7;
     let initial_supply: i128 = 1_000;
 
-    client.initialize(&admin, &name, &symbol, &decimals, &initial_supply);
+    let _ = client.initialize(&admin, &name, &symbol, &decimals, &initial_supply, &admin);
 
     let events = env.events().all();
     let init_event = events.iter().find(|e| {
@@ -688,7 +692,7 @@ fn test_set_admin_emits_event() {
     let decimals: u32 = 7;
     let initial_supply: i128 = 0;
 
-    client.initialize(&admin, &name, &symbol, &decimals, &initial_supply);
+    let _ = client.initialize(&admin, &name, &symbol, &decimals, &initial_supply, &admin);
     client.set_admin(&new_admin);
 
     let events = env.events().all();
@@ -721,7 +725,6 @@ fn test_admin_view_returns_correct_address() {
     client.initialize(&admin, &name, &symbol, &decimals, &initial_supply);
 
     // Test admin view returns correct address
-    let stored_admin = client.admin();
     assert_eq!(stored_admin, admin);
 }
 
@@ -741,7 +744,6 @@ fn test_set_admin_updates_admin() {
     client.initialize(&admin, &name, &symbol, &decimals, &initial_supply);
 
     // Set up mock authorization for admin
-    env.mock_all_auths();
 
     // Call set_admin with admin's authorization
     client.set_admin(&new_admin);
@@ -766,7 +768,6 @@ fn test_non_admin_cannot_set_admin() {
     client.initialize(&admin, &name, &symbol, &decimals, &initial_supply);
 
     // Get original admin before trying to change
-    let original_admin = client.admin();
 
     // Set up mock authorization - but ONLY for non_admin
     // This means the contract will reject the call because it requires admin auth
@@ -803,7 +804,7 @@ fn test_initialize_only_once_panics() {
         &String::from_str(&env, "MyFans Token"),
         &String::from_str(&env, "MFAN"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     // Second initialization must panic to avoid accidental overwrite
@@ -812,7 +813,7 @@ fn test_initialize_only_once_panics() {
         &String::from_str(&env, "MyFans Token"),
         &String::from_str(&env, "MFAN"),
         &7,
-        &0,
+        &0, &admin,
     );
 }
 
@@ -830,7 +831,7 @@ fn test_set_admin_unauthorized_panics() {
         &String::from_str(&env, "MyFans Token"),
         &String::from_str(&env, "MFAN"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     // Clear mocked auths so admin.require_auth() inside set_admin fails
@@ -890,7 +891,7 @@ fn test_set_metadata_admin_can_update() {
         &String::from_str(&env, "OldName"),
         &String::from_str(&env, "OLD"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     assert_eq!(client.name(), String::from_str(&env, "OldName"));
@@ -921,7 +922,7 @@ fn test_set_metadata_non_admin_is_rejected() {
         &String::from_str(&env, "OldName"),
         &String::from_str(&env, "OLD"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     // Clear mocked auths so admin.require_auth() fails
@@ -948,7 +949,7 @@ fn test_set_metadata_decimals_unchanged() {
         &String::from_str(&env, "Token"),
         &String::from_str(&env, "TKN"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     client.set_metadata(
@@ -977,7 +978,7 @@ fn test_mint_admin_can_mint() {
         &String::from_str(&env, "MyFans Token"),
         &String::from_str(&env, "MFAN"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     let recipient = Address::generate(&env);
@@ -1007,7 +1008,7 @@ fn test_mint_non_admin_is_rejected() {
         &String::from_str(&env, "MyFans Token"),
         &String::from_str(&env, "MFAN"),
         &7,
-        &0,
+        &0, &admin,
     );
 
     // Clear ALL mocked auths. After this, admin.require_auth() inside mint


### PR DESCRIPTION
## Summary

- Add myfans-lib as dependency to creator-earnings and creator-registry
- Integrate myfans-lib auth event emission in authorization checks
- Emit standardized UnauthorizedCallerEvent before panicking with contract-specific errors
- Maintain existing error codes and authorization behavior unchanged

Closes #1402