### PR TITLE
security: sanitize wallet address input against injection

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Headers,
@@ -15,6 +14,7 @@ import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { WalletAuthService } from './wallet-auth.service';
 import { RequestChallengeDto, VerifyChallengeDto } from './wallet-auth.dto';
+import { WalletAddressDto } from './wallet-address.dto';
 import { Deprecated, DeprecationInterceptor } from '../common/deprecation';
 import { PublicGuard } from '../auth-module/guards/public.guard';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
@@ -51,15 +51,11 @@ export class AuthController {
   @ApiResponse({ status: 201, description: 'Session created' })
   @ApiResponse({ status: 400, description: 'Invalid Stellar address' })
   async login(
-    @Body() body: { address?: string },
+    @Body() body: WalletAddressDto,
     @Headers('x-network') requestNetwork?: string,
   ) {
     this.assertNetworkMatch(requestNetwork);
-    const address = body.address ?? '';
-    if (!this.authService.validateStellarAddress(address)) {
-      throw new BadRequestException('Invalid Stellar address');
-    }
-    return this.authService.createSession(body.address!);
+    return this.authService.createSession(body.address);
   }
 
   @Post('register')
@@ -74,15 +70,11 @@ export class AuthController {
   @ApiResponse({ status: 201, description: 'Session created' })
   @ApiResponse({ status: 400, description: 'Invalid Stellar address' })
   async register(
-    @Body() body: { address?: string },
+    @Body() body: WalletAddressDto,
     @Headers('x-network') requestNetwork?: string,
   ) {
     this.assertNetworkMatch(requestNetwork);
-    const address = body.address ?? '';
-    if (!this.authService.validateStellarAddress(address)) {
-      throw new BadRequestException('Invalid Stellar address');
-    }
-    return this.authService.createSession(body.address!);
+    return this.authService.createSession(body.address);
   }
 
   /**

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,16 +1,20 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { EventBus } from '../events/event-bus';
 import { UserLoggedInEvent } from '../events/domain-events';
+import { isStellarAccountAddress } from '../common/utils/stellar-address';
 
 @Injectable()
 export class AuthService {
   constructor(private readonly eventBus: EventBus) {}
 
   validateStellarAddress(address: string): boolean {
-    return address.startsWith('G') && address.length === 56;
+    return isStellarAccountAddress(address);
   }
 
   async createSession(stellarAddress: string) {
+    if (!isStellarAccountAddress(stellarAddress)) {
+      throw new BadRequestException('Invalid Stellar address');
+    }
     const session = {
       userId: stellarAddress,
       token: Buffer.from(stellarAddress).toString('base64'),

--- a/backend/src/auth/wallet-address.dto.ts
+++ b/backend/src/auth/wallet-address.dto.ts
@@ -1,0 +1,8 @@
+import { IsString } from 'class-validator';
+import { IsStellarAddress } from '../common/utils/stellar-address';
+
+export class WalletAddressDto {
+  @IsString()
+  @IsStellarAddress()
+  address: string;
+}

--- a/backend/src/common/utils/stellar-address.spec.ts
+++ b/backend/src/common/utils/stellar-address.spec.ts
@@ -1,0 +1,89 @@
+import { isStellarAccountAddress, sanitizeStellarAddress } from './stellar-address';
+
+const VALID = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+
+describe('isStellarAccountAddress', () => {
+  it('accepts a valid G-strkey', () => {
+    expect(isStellarAccountAddress(VALID)).toBe(true);
+  });
+
+  it('rejects address not starting with G', () => {
+    expect(isStellarAccountAddress('SAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN')).toBe(false);
+  });
+
+  it('rejects address shorter than 56 chars', () => {
+    expect(isStellarAccountAddress('GAAZI4TCR3')).toBe(false);
+  });
+
+  it('rejects address longer than 56 chars', () => {
+    expect(isStellarAccountAddress(VALID + 'A')).toBe(false);
+  });
+
+  it('rejects SQL injection payload', () => {
+    expect(isStellarAccountAddress("' OR '1'='1")).toBe(false);
+  });
+
+  it('rejects NoSQL injection payload', () => {
+    expect(isStellarAccountAddress('{"$gt":""}')).toBe(false);
+  });
+
+  it('rejects null byte injection', () => {
+    expect(isStellarAccountAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN\0')).toBe(false);
+  });
+
+  it('rejects chars outside base-32 alphabet (lowercase)', () => {
+    expect(isStellarAccountAddress(VALID.toLowerCase())).toBe(false);
+  });
+
+  it('rejects non-string input', () => {
+    expect(isStellarAccountAddress(null)).toBe(false);
+    expect(isStellarAccountAddress(undefined)).toBe(false);
+    expect(isStellarAccountAddress(123456)).toBe(false);
+  });
+});
+
+describe('sanitizeStellarAddress', () => {
+  it('returns the address unchanged when already valid', () => {
+    expect(sanitizeStellarAddress(VALID)).toBe(VALID);
+  });
+
+  it('returns null for SQL injection payload', () => {
+    expect(sanitizeStellarAddress("' OR '1'='1")).toBeNull();
+  });
+
+  it('returns null for non-string input', () => {
+    expect(sanitizeStellarAddress(null)).toBeNull();
+    expect(sanitizeStellarAddress(42)).toBeNull();
+  });
+
+  it('returns null when stripped result is not a valid address', () => {
+    expect(sanitizeStellarAddress('not-an-address')).toBeNull();
+  });
+});
+
+import { AuthService } from '../auth/auth.service';
+import { BadRequestException } from '@nestjs/common';
+
+describe('AuthService.createSession', () => {
+  let service: AuthService;
+
+  beforeEach(() => { service = new AuthService(null as any); });
+
+  it('returns session for valid address', async () => {
+    const result = await service.createSession(VALID);
+    expect(result.userId).toBe(VALID);
+    expect(result.token).toBeTruthy();
+  });
+
+  it('throws BadRequestException for SQL injection', async () => {
+    await expect(service.createSession("' OR '1'='1")).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws BadRequestException for oversized input', async () => {
+    await expect(service.createSession('G' + 'A'.repeat(200))).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws BadRequestException for empty string', async () => {
+    await expect(service.createSession('')).rejects.toThrow(BadRequestException);
+  });
+});

--- a/backend/src/common/utils/stellar-address.ts
+++ b/backend/src/common/utils/stellar-address.ts
@@ -1,7 +1,39 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+
 /**
- * Minimal Stellar **account** address check (G-strkey, 56 chars).
- * Does not validate checksum; good enough for API guardrails.
+ * Strict Stellar account address (G-strkey).
+ * Allowlist: exactly 'G' followed by 55 uppercase base-32 chars [A-Z2-7].
+ * Rejects null bytes, control chars, SQL/NoSQL metacharacters, oversized input.
  */
-export function isStellarAccountAddress(value: string): boolean {
-  return typeof value === 'string' && value.startsWith('G') && value.length === 56;
+const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+
+export function isStellarAccountAddress(value: unknown): boolean {
+  return typeof value === 'string' && STELLAR_ADDRESS_RE.test(value);
+}
+
+/**
+ * Strips every character outside the valid G-strkey alphabet.
+ * Returns null when the result is not a valid address so callers
+ * reject rather than silently accept a mutated value.
+ */
+export function sanitizeStellarAddress(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const cleaned = value.replace(/[^A-Z2-7]/g, '');
+  return STELLAR_ADDRESS_RE.test(cleaned) ? cleaned : null;
+}
+
+/** class-validator decorator for any DTO field holding a wallet address. */
+export function IsStellarAddress(options?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isStellarAddress',
+      target: object.constructor,
+      propertyName,
+      options: {
+        message: `${propertyName} must be a valid Stellar account address (G-strkey, 56 chars, base-32)`,
+        ...options,
+      },
+      validator: { validate: isStellarAccountAddress },
+    });
+  };
 }


### PR DESCRIPTION
## Summary

Hardens Stellar wallet address validation in the backend to prevent injection attacks (SQL, NoSQL, null bytes, oversized input).

## Changes

- `common/utils/stellar-address.ts` — strict `/^G[A-Z2-7]{55}$/` regex, `sanitizeStellarAddress()`, `IsStellarAddress()` class-validator decorator
- `common/utils/stellar-address.spec.ts` — 14 tests covering injection vectors
- `auth/wallet-address.dto.ts` — typed DTO with `@IsStellarAddress()`
- `auth/auth.controller.ts` — uses `WalletAddressDto` on login/register; removes manual validation
- `auth/auth.service.ts` — strict regex via `isStellarAccountAddress`; throws `BadRequestException` on invalid address

## Closes

Closes #1410
Closes #1411
Closes #1412