### PR TITLE
fix: resolve content-likes DataKey migration, Vec bound, and creator-deposits auth/re-init guard

### DIFF
--- a/contract/contracts/content-likes/ACCEPTANCE.md
+++ b/contract/contracts/content-likes/ACCEPTANCE.md
@@ -65,9 +65,11 @@
 ### Gas & Scalability
 
 #### Storage Model
-- **Like Set**: `("likes", content_id)` → Set<Address>
-- **Like Count**: `("count", content_id)` → u32
-- **Rationale**: Separate count enables O(1) queries; Set enables O(1) membership checks
+- **Like Map**: `DataKey::LikesMap(content_id)` → Map<Address, bool>
+- **Like Count**: `DataKey::Count(content_id)` → u32
+- **User Likes**: `DataKey::UserLikes(user)` → Vec<u32>
+- **Max Likes Per User**: 100 (`MAX_USER_LIKES`)
+- **Rationale**: Separate count enables O(1) queries; Map enables O(log n) membership checks; DataKey enum follows project conventions
 
 #### Complexity Analysis
 - `like()`: O(log n) where n = likes on content (Set insert)

--- a/contract/contracts/content-likes/IMPLEMENTATION_SUMMARY.md
+++ b/contract/contracts/content-likes/IMPLEMENTATION_SUMMARY.md
@@ -9,13 +9,15 @@ Successfully implemented an on-chain content likes contract for the MyFans platf
 ### Architecture
 
 **Storage Model:**
-- `LikeMap(content_id)`: Map<Address, bool> storing user likes per content
-- `LikeCount(content_id)`: u32 storing aggregate like count
+- `DataKey::LikesMap(content_id)`: Map<Address, bool> storing user likes per content
+- `DataKey::Count(content_id)`: u32 storing aggregate like count
+- `DataKey::UserLikes(user)`: Vec<u32> storing content IDs liked by user (pagination)
 
 **Rationale:**
 - Map enables O(1) membership checks for `has_liked()` queries
 - Separate count storage enables O(1) `like_count()` queries
-- Composite keys `("likes", content_id)` and `("count", content_id)` isolate data per content
+- DataKey enum isolates data per content / per user
+- MAX_USER_LIKES (100) bound prevents unbounded Vec growth
 
 ### Core Functions
 

--- a/contract/contracts/content-likes/README.md
+++ b/contract/contracts/content-likes/README.md
@@ -16,6 +16,8 @@ This contract manages user likes for content items, storing:
 | Code | Variant | Description |
 |------|---------|-------------|
 | 1 | `NotLiked` | User has not liked this content; `unlike` was called without a prior `like` |
+| 2 | `AlreadyInitialized` | Contract was already initialized |
+| 3 | `CapacityExceeded` | User has reached the maximum number of likes (100) |
 
 ---
 
@@ -165,10 +167,10 @@ if next1 > 0 {
 
 ## Storage Model
 
-**Keys:**
-- `("likes", content_id)` → `Map<Address, bool>` — Set of users who liked this content
-- `("count", content_id)` → `u32` — Aggregate count of likes
-- `("user_likes", user)` → `Vec<u32>` — List of content IDs liked by user (for pagination)
+**Keys (DataKey enum):**
+- `DataKey::LikesMap(content_id)` → `Map<Address, bool>` — Set of users who liked this content
+- `DataKey::Count(content_id)` → `u32` — Aggregate count of likes
+- `DataKey::UserLikes(user)` → `Vec<u32>` — List of content IDs liked by user (for pagination, max 100 per user)
 
 **Rationale:**
 - Separate count storage enables O(1) `like_count()` queries
@@ -228,6 +230,7 @@ assert_eq!(client.like_count(&content_id), 0);
 **Current Limits:**
 - Soroban storage: ~1MB per contract instance
 - Map operations: O(log n) complexity
+- Per-user like list: max 100 items (`MAX_USER_LIKES`)
 - Recommended: < 100k total likes per contract instance
 
 ---

--- a/contract/contracts/content-likes/src/lib.rs
+++ b/contract/contracts/content-likes/src/lib.rs
@@ -9,12 +9,21 @@ use events::{LikedEvent, UnlikedEvent, TOPIC_LIKED, TOPIC_UNLIKED};
 
 const MAX_PAGE_LIMIT: u32 = 100;
 
+/// Maximum number of content items a single user may like.
+const MAX_USER_LIKES: u32 = 100;
+
 /// Storage keys for content likes contract
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     /// Admin address
     Admin,
+    /// Map of users who liked a content item, keyed by content_id
+    LikesMap(u32),
+    /// Like count for a content item, keyed by content_id
+    Count(u32),
+    /// List of content IDs liked by a user, keyed by user address
+    UserLikes(Address),
 }
 
 /// Per-contract error codes for the **content-likes** contract.
@@ -26,6 +35,7 @@ pub enum DataKey {
 /// |------|---------|
 /// | 1 | `NotLiked` |
 /// | 2 | `AlreadyInitialized` |
+/// | 3 | `CapacityExceeded` |
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -33,6 +43,8 @@ pub enum Error {
     NotLiked = 1,
     /// Code 2 – contract was already initialized.
     AlreadyInitialized = 2,
+    /// Code 3 – user has reached the maximum number of likes.
+    CapacityExceeded = 3,
 }
 
 #[contract]
@@ -75,14 +87,11 @@ impl ContentLikes {
     pub fn like(env: Env, user: Address, content_id: u32) {
         user.require_auth();
 
-        let like_map_key = ("likes", content_id);
-        let count_key = ("count", content_id);
-
         // Get existing like map or create new one
         let mut likes: Map<Address, bool> = env
             .storage()
             .instance()
-            .get(&like_map_key)
+            .get(&DataKey::LikesMap(content_id))
             .unwrap_or_else(|| Map::new(&env));
 
         // Check if already liked (idempotent); cache result to avoid redundant storage operations
@@ -91,23 +100,28 @@ impl ContentLikes {
         if !already_liked {
             // Add user to map
             likes.set(user.clone(), true);
-            env.storage().instance().set(&like_map_key, &likes);
+            env.storage().instance().set(&DataKey::LikesMap(content_id), &likes);
 
             // Increment count
-            let current_count: u32 = env.storage().instance().get(&count_key).unwrap_or(0);
+            let current_count: u32 = env.storage().instance().get(&DataKey::Count(content_id)).unwrap_or(0);
             env.storage()
                 .instance()
-                .set(&count_key, &(current_count + 1));
+                .set(&DataKey::Count(content_id), &(current_count + 1));
 
             // Maintain user_likes index for list_likes_by_user
-            let user_likes_key = ("user_likes", user.clone());
             let mut list: Vec<u32> = env
                 .storage()
                 .instance()
-                .get(&user_likes_key)
+                .get(&DataKey::UserLikes(user.clone()))
                 .unwrap_or_else(|| Vec::new(&env));
+
+            // Bound check: reject if user already reached the maximum
+            if list.len() >= MAX_USER_LIKES {
+                panic_with_error!(&env, Error::CapacityExceeded);
+            }
+
             list.push_back(content_id);
-            env.storage().instance().set(&user_likes_key, &list);
+            env.storage().instance().set(&DataKey::UserLikes(user.clone()), &list);
 
             // Publish event
             env.events().publish(
@@ -140,14 +154,11 @@ impl ContentLikes {
     pub fn unlike(env: Env, user: Address, content_id: u32) {
         user.require_auth();
 
-        let like_map_key = ("likes", content_id);
-        let count_key = ("count", content_id);
-
         // Get existing like map
         let mut likes: Map<Address, bool> = env
             .storage()
             .instance()
-            .get(&like_map_key)
+            .get(&DataKey::LikesMap(content_id))
             .unwrap_or_else(|| Map::new(&env));
 
         // Verify user has liked (revert early if not, avoiding redundant writes)
@@ -157,22 +168,21 @@ impl ContentLikes {
 
         // Remove user from map
         likes.remove(user.clone());
-        env.storage().instance().set(&like_map_key, &likes);
+        env.storage().instance().set(&DataKey::LikesMap(content_id), &likes);
 
         // Decrement count
-        let current_count: u32 = env.storage().instance().get(&count_key).unwrap_or(0);
+        let current_count: u32 = env.storage().instance().get(&DataKey::Count(content_id)).unwrap_or(0);
         if current_count > 0 {
             env.storage()
                 .instance()
-                .set(&count_key, &(current_count - 1));
+                .set(&DataKey::Count(content_id), &(current_count - 1));
         }
 
         // Maintain user_likes index: remove content_id from user's list
-        let user_likes_key = ("user_likes", user.clone());
         let list: Vec<u32> = env
             .storage()
             .instance()
-            .get(&user_likes_key)
+            .get(&DataKey::UserLikes(user.clone()))
             .unwrap_or_else(|| Vec::new(&env));
         let mut new_list = Vec::new(&env);
         for i in 0..list.len() {
@@ -181,7 +191,7 @@ impl ContentLikes {
                 new_list.push_back(id);
             }
         }
-        env.storage().instance().set(&user_likes_key, &new_list);
+        env.storage().instance().set(&DataKey::UserLikes(user.clone()), &new_list);
 
         // Publish event
         env.events().publish(
@@ -205,8 +215,7 @@ impl ContentLikes {
     /// # Gas optimization
     /// - Single storage read; O(1) operation
     pub fn like_count(env: Env, content_id: u32) -> u32 {
-        let count_key = ("count", content_id);
-        env.storage().instance().get(&count_key).unwrap_or(0)
+        env.storage().instance().get(&DataKey::Count(content_id)).unwrap_or(0)
     }
 
     /// Check if a user has liked a content item
@@ -219,11 +228,10 @@ impl ContentLikes {
     /// # Returns
     /// true if user has liked the content, false otherwise
     pub fn has_liked(env: Env, user: Address, content_id: u32) -> bool {
-        let like_map_key = ("likes", content_id);
         let likes: Map<Address, bool> = env
             .storage()
             .instance()
-            .get(&like_map_key)
+            .get(&DataKey::LikesMap(content_id))
             .unwrap_or_else(|| Map::new(&env));
 
         likes.get(user).is_some()
@@ -241,11 +249,10 @@ impl ContentLikes {
     /// (page of content_ids, next_cursor) — `next_cursor` is 0 when there is no next page
     pub fn list_likes_by_user(env: Env, user: Address, cursor: u32, limit: u32) -> (Vec<u32>, u32) {
         let limit = core::cmp::min(limit, MAX_PAGE_LIMIT);
-        let user_likes_key = ("user_likes", user);
         let list: Vec<u32> = env
             .storage()
             .instance()
-            .get(&user_likes_key)
+            .get(&DataKey::UserLikes(user))
             .unwrap_or_else(|| Vec::new(&env));
 
         let len = list.len();
@@ -706,6 +713,62 @@ mod test {
             result.is_err(),
             "unlike() must reject when caller is not the user parameter"
         );
+    }
+
+    #[test]
+    fn test_like_capacity_exceeded() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ContentLikes);
+        let client = ContentLikesClient::new(&env, &contract_id);
+
+        let user = Address::generate(&env);
+
+        // Like MAX_USER_LIKES distinct content items (100 items)
+        for content_id in 0..MAX_USER_LIKES {
+            client.like(&user, &content_id);
+        }
+
+        // Verify count
+        assert_eq!(client.like_count(&0), 1);
+        let (page, next) = client.list_likes_by_user(&user, &0, &200);
+        assert_eq!(page.len(), MAX_USER_LIKES);
+        assert_eq!(next, 0);
+
+        // Next like should fail with CapacityExceeded
+        let result = client.try_like(&user, &MAX_USER_LIKES);
+        assert_eq!(
+            result,
+            Err(Ok(SorobanError::from_contract_error(
+                Error::CapacityExceeded as u32,
+            )))
+        );
+    }
+
+    #[test]
+    fn test_like_capacity_exceeded_allows_unlike_and_relike() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ContentLikes);
+        let client = ContentLikesClient::new(&env, &contract_id);
+
+        let user = Address::generate(&env);
+
+        // Like MAX_USER_LIKES distinct content items to fill the list
+        for content_id in 0..MAX_USER_LIKES {
+            client.like(&user, &content_id);
+        }
+
+        // Unlike one item
+        client.unlike(&user, &0);
+
+        // Now we should be able to like a new item (capacity freed)
+        client.like(&user, &MAX_USER_LIKES);
+
+        // Verify the list still has MAX_USER_LIKES items
+        let (page, next) = client.list_likes_by_user(&user, &0, &200);
+        assert_eq!(page.len(), MAX_USER_LIKES);
+        assert_eq!(next, 0);
     }
 }
 

--- a/contract/contracts/creator-deposits/README.md
+++ b/contract/contracts/creator-deposits/README.md
@@ -20,8 +20,9 @@ pub fn init(env: Env, admin: Address, platform_fee_bps: u32, platform_treasury: 
 One-time contract setup. Stores the admin address, the platform fee in basis points,
 and the treasury address that receives platform fees.
 
+- Requires `admin` authorization (panics if not authorized).
+- Panics with `AlreadyInitialized` (code 6) if the contract has already been initialized.
 - `platform_fee_bps` must be less than 10 000 (100 %); panics with `InvalidFeeBps` (code 1) otherwise.
-- Requires `admin` authorization.
 - Does **not** emit an event. (No event is defined for initialization.)
 
 ---
@@ -108,6 +109,7 @@ No authorization required.
 | 3 | `AdminNotInitialized` | Admin key not present; contract was never initialized |
 | 4 | `PlatformFeeNotInitialized` | Platform fee not set; contract init was incomplete |
 | 5 | `PlatformTreasuryNotInitialized` | Platform treasury not set; contract init was incomplete |
+| 6 | `AlreadyInitialized` | Contract was already initialized; re-initialization is not allowed |
 
 Error discriminants are stable and form part of the public client API. Do not renumber
 existing variants; add new ones at the end.
@@ -163,6 +165,8 @@ cargo build --package creator-deposits --target wasm32-unknown-unknown --release
 | `test_unauthorized_withdraw_reverts` | Non-creator cannot withdraw; balance unchanged |
 | `test_admin_not_initialized_error` | `AdminNotInitialized` error when calling admin functions before init |
 | `test_deposit_without_init_returns_error` | Deposit fails when contract is not initialized |
+| `test_reinitialization_rejected` | `AlreadyInitialized` error on second `init` call |
+| `test_init_requires_admin_auth` | `init` fails when admin does not authorize |
 
 ---
 

--- a/contract/contracts/creator-deposits/src/lib.rs
+++ b/contract/contracts/creator-deposits/src/lib.rs
@@ -52,6 +52,8 @@ pub enum Error {
     PlatformFeeNotInitialized = 4,
     /// Code 5 – platform treasury not set; contract init was incomplete.
     PlatformTreasuryNotInitialized = 5,
+    /// Code 6 – contract was already initialized; re-initialization is not allowed.
+    AlreadyInitialized = 6,
 }
 
 #[contract]
@@ -60,6 +62,10 @@ pub struct CreatorDeposits;
 #[contractimpl]
 impl CreatorDeposits {
     pub fn init(env: Env, admin: Address, platform_fee_bps: u32, platform_treasury: Address) {
+        admin.require_auth();
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic_with_error!(&env, Error::AlreadyInitialized);
+        }
         if platform_fee_bps >= 10000 {
             panic_with_error!(&env, Error::InvalidFeeBps);
         }
@@ -195,7 +201,7 @@ mod test {
         token::StellarAssetClient,
         vec,
         xdr::{ScAddress, SorobanAuthorizationEntry},
-        Env, IntoVal, Symbol, TryFromVal, TryIntoVal,
+        Env, Error as SorobanError, IntoVal, Symbol, TryFromVal, TryIntoVal,
     };
 
     const EMPTY_AUTHS: &[SorobanAuthorizationEntry] = &[];
@@ -729,25 +735,41 @@ mod test {
     }
 
     #[test]
-    fn test_idempotent_init_multiple_events() {
+    fn test_reinitialization_rejected() {
         let (env, admin, treasury, _, _) = setup();
         let contract_id = env.register_contract(None, CreatorDeposits);
         let client = CreatorDepositsClient::new(&env, &contract_id);
 
         env.mock_all_auths();
         client.init(&admin, &500, &treasury);
-        client.init(&admin, &1000, &treasury);
 
-        let events = env.events().all();
-        let init_count = events
-            .iter()
-            .filter(|e| {
-                e.1.first().is_some_and(|t| {
-                    t.try_into_val(&env).ok() == Some(Symbol::new(&env, TOPIC_INITIALIZED))
-                })
-            })
-            .count();
-        assert_eq!(init_count, 2);
+        // Second init should fail with AlreadyInitialized
+        let result = client.try_init(&admin, &1000, &treasury);
+        assert_eq!(
+            result,
+            Err(Ok(SorobanError::from_contract_error(
+                Error::AlreadyInitialized as u32,
+            )))
+        );
+    }
+
+    #[test]
+    fn test_init_requires_admin_auth() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, CreatorDeposits);
+        let client = CreatorDepositsClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+
+        // Strip all auth so that require_auth() fails
+        env.set_auths(&[]);
+
+        let result = client.try_init(&admin, &500, &treasury);
+        assert!(
+            result.is_err(),
+            "init() must reject when admin does not authorize"
+        );
     }
 
     // ── Issue #934: Snapshot / restore consistency test ─────────────


### PR DESCRIPTION
## Closes #1390 
##Closes #1391
##Closes #1392  
##Closes #1393 

### What does this PR do?
* **Issue #1390**: Replace content-likes tuple keys with DataKey enum variants (LikesMap, Count, UserLikes) to align with project storage conventions
* **Issue #1391**: Bound content-likes user_likes Vec growth with MAX_USER_LIKES (100) and CapacityExceeded error to prevent unbounded per-user list growth
* **Issue #1392**: Reject creator-deposits re-initialization by adding AlreadyInitialized error and guard check on init
* **Issue #1393**: Require admin auth on creator-deposits init by adding admin.require_auth() call
* Updated all documentation (README, ACCEPTANCE.md, IMPLEMENTATION_SUMMARY.md) to reflect the changes
* Added new test coverage for all four issues

### How was this tested?
* Unit tests added for each change:
  - test_reinitialization_rejected (creator-deposits)
  - test_init_requires_admin_auth (creator-deposits)
  - test_like_capacity_exceeded (content-likes)
  - test_like_capacity_exceeded_allows_unlike_and_relike (content-likes)
* All existing tests continue to compile and pass with the refactored DataKey storage

