### PR TITLE
Public creator discovery, persisted social links, required checkout idempotency key, bridge fan/JWT auth

### DIFF
--- a/backend/docs/AUTH_MODES.md
+++ b/backend/docs/AUTH_MODES.md
@@ -1,0 +1,46 @@
+# Auth Modes — Stellar Bearer vs. Passport JWT
+
+## Overview
+
+The backend currently has two independent auth mechanisms with no stored
+link between the identities they produce:
+
+| Mode | Guard | Credential | Identity | Used by |
+|------|-------|-----------|----------|---------|
+| Stellar bearer | `FanBearerGuard` | `Authorization: Bearer base64(G-address)` | Stellar address (`req.fanAddress`) | Subscription/fan routes |
+| Passport JWT | `JwtAuthGuard` | `Authorization: Bearer <JWT>`, `sub` = platform user UUID | Platform user (`req.user`) | Social routes (creators, posts, comments, conversations, ...) |
+
+There is no `users` column or table linking a platform user UUID to a
+Stellar wallet address, so a caller authenticated via one mode has no way
+to be resolved into the other mode's identity today.
+
+## Bridge, not unification
+
+`HybridFanAuthGuard` (`src/subscriptions/guards/hybrid-fan-auth.guard.ts`)
+accepts *either* credential type on the same endpoint and normalizes the
+result onto the request:
+
+- Stellar bearer → `req.fanAddress` set, `req.authMode = 'stellar-bearer'`
+- Passport JWT → `req.user` set, `req.authMode = 'jwt'`
+
+Handlers that require a resolved Stellar address (e.g. subscription/chain
+checks, spending caps) must check `req.authMode === 'stellar-bearer'`
+explicitly and reject otherwise — the guard authenticates the request, it
+does not fabricate a Stellar address for a JWT-authenticated user. See
+`SpendingCapController`'s `requireFanAddress` helper for the pattern.
+
+## Where this applies today
+
+`HybridFanAuthGuard` is wired into `SpendingCapController`. The main
+`SubscriptionsController` checkout/lifecycle routes remain on
+`FanBearerGuard` only, since they are payment-critical and a broader swap
+needs its own verification pass.
+
+## Future work: true unification
+
+Unifying the two identities (one platform user ↔ one or more linked
+Stellar addresses) requires a wallet-linking feature: a table associating
+`users.id` with verified Stellar addresses, plus a flow for a
+JWT-authenticated user to prove ownership of an address (e.g. a signed
+challenge, same pattern as `src/auth/wallet-auth.service.ts`). That is out
+of scope for this bridge.

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -23,6 +23,7 @@ import { IdempotencyMiddleware } from './idempotency/idempotency.middleware';
 import { FeatureFlagsModule } from './feature-flags/feature-flags.module';
 import { ReferralModule } from './referral/referral.module';
 import { CsrfModule } from './csrf/csrf.module';
+import { SocialLinksModule } from './social-link/social-links.module';
 import { CsrfMiddleware } from './common/middleware/csrf.middleware';
 import { CorrelationExceptionFilter } from './common/filters/correlation-exception.filter';
 import { RequestContextService } from './common/services/request-context.service';
@@ -59,6 +60,7 @@ const IDEMPOTENCY_ROUTES = [
     FeatureFlagsModule,
     ReferralModule,
     CsrfModule,
+    SocialLinksModule,
   ],
   controllers: [AppController, OpenAPIController],
   providers: [

--- a/backend/src/creators/creators.controller.ts
+++ b/backend/src/creators/creators.controller.ts
@@ -82,6 +82,7 @@ export class CreatorsController {
   }
 
   @Get('username/:username')
+  @Public()
   @ApiOperation({
     summary: 'Get a single public creator profile by exact username',
     description:

--- a/backend/src/idempotency/idempotency.middleware.ts
+++ b/backend/src/idempotency/idempotency.middleware.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   Injectable,
   Logger,
@@ -14,6 +15,14 @@ export const IDEMPOTENCY_KEY_HEADER = 'idempotency-key';
 /** Maximum allowed key length to prevent abuse. */
 const MAX_KEY_LENGTH = 255;
 
+/**
+ * Checkout/payment routes where the Idempotency-Key header is mandatory
+ * (not just tracked-if-present). A missing key on these routes is rejected
+ * with 400 rather than silently allowed through, since a retried payment
+ * mutation without a key can double-charge or double-create a subscription.
+ */
+const REQUIRED_IDEMPOTENCY_PATH_PREFIXES = ['/v1/subscriptions/checkout'];
+
 @Injectable()
 export class IdempotencyMiddleware implements NestMiddleware {
   private readonly logger = new Logger(IdempotencyMiddleware.name);
@@ -23,9 +32,15 @@ export class IdempotencyMiddleware implements NestMiddleware {
   async use(req: Request, res: Response, next: NextFunction): Promise<void> {
     const rawKey = req.headers[IDEMPOTENCY_KEY_HEADER] as string | undefined;
 
-    // No key supplied — pass through (key is optional; callers that want
-    // idempotency protection must supply it).
     if (!rawKey) {
+      if (this.isRequiredRoute(req.path)) {
+        throw new BadRequestException(
+          `Idempotency-Key header is required for ${req.method} ${req.path}.`,
+        );
+      }
+      // No key supplied on a non-payment route — pass through (key is
+      // optional there; callers that want idempotency protection must
+      // supply it).
       return next();
     }
 
@@ -98,6 +113,16 @@ export class IdempotencyMiddleware implements NestMiddleware {
     };
 
     next();
+  }
+
+  /**
+   * Whether the given request path is a checkout/payment route on which
+   * the Idempotency-Key header is mandatory rather than opt-in.
+   */
+  private isRequiredRoute(path: string): boolean {
+    return REQUIRED_IDEMPOTENCY_PATH_PREFIXES.some((prefix) =>
+      path.startsWith(prefix),
+    );
   }
 
   /**

--- a/backend/src/migration.datasource.ts
+++ b/backend/src/migration.datasource.ts
@@ -11,6 +11,7 @@ import { CreateReferralTables1745000000000 } from './referral/1745000000000-Crea
 import { AddDigestColumnsToNotifications1745100000000 } from './notifications/1745100000000-AddDigestColumnsToNotifications';
 import { AddOnboardingStateToUsers1745200000000 } from './users/1745200000000-AddOnboardingStateToUsers';
 import { AddRoleToUsers1747000000000 } from './users/1747000000000-AddRoleToUsers';
+import { CreateSocialLinksTable1748000000000 } from './social-link/1748000000000-CreateSocialLinksTable';
 
 export const migrationDataSource = new DataSource({
   type: 'postgres',
@@ -31,5 +32,6 @@ export const migrationDataSource = new DataSource({
     AddDigestColumnsToNotifications1745100000000,
     AddOnboardingStateToUsers1745200000000,
     AddRoleToUsers1747000000000,
+    CreateSocialLinksTable1748000000000,
   ],
 });

--- a/backend/src/social-link/1748000000000-CreateSocialLinksTable.ts
+++ b/backend/src/social-link/1748000000000-CreateSocialLinksTable.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateSocialLinksTable1748000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'social_links',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'gen_random_uuid()',
+          },
+          { name: 'website_url', type: 'varchar', length: '500', isNullable: true, default: null },
+          { name: 'twitter_handle', type: 'varchar', length: '50', isNullable: true, default: null },
+          { name: 'instagram_handle', type: 'varchar', length: '50', isNullable: true, default: null },
+          { name: 'other_link', type: 'varchar', length: '500', isNullable: true, default: null },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('social_links', true);
+  }
+}

--- a/backend/src/social-link/social-link.entity.ts
+++ b/backend/src/social-link/social-link.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('social_links')
+export class SocialLink {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'website_url', type: 'varchar', length: 500, nullable: true, default: null })
+  websiteUrl: string | null;
+
+  @Column({ name: 'twitter_handle', type: 'varchar', length: 50, nullable: true, default: null })
+  twitterHandle: string | null;
+
+  @Column({ name: 'instagram_handle', type: 'varchar', length: 50, nullable: true, default: null })
+  instagramHandle: string | null;
+
+  @Column({ name: 'other_link', type: 'varchar', length: 500, nullable: true, default: null })
+  otherLink: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/social-link/social-links.module.ts
+++ b/backend/src/social-link/social-links.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { SocialLinksService } from './social-links.service';
 import { SocialLinkController } from './social-links.controller';
+import { SocialLink } from './social-link.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([SocialLink])],
   controllers: [SocialLinkController],
   providers: [SocialLinksService],
   exports: [SocialLinksService],

--- a/backend/src/social-link/social-links.service.ts
+++ b/backend/src/social-link/social-links.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { PaginationDto, PaginatedResponseDto } from '../common/dto';
 import { SocialLinksDto } from './social-links.dto';
 import { SocialLinksResponseDto, SocialLinksListItemDto } from './user-profile.dto';
+import { SocialLink } from './social-link.entity';
 import {
   isAllowedDomain,
   getAllowedDomains,
@@ -30,8 +33,10 @@ export type SocialLinksListItem = SocialLinksListItemDto;
  */
 @Injectable()
 export class SocialLinksService {
-  private readonly records = new Map<string, SocialLinksListItem>();
-  private nextId = 1;
+  constructor(
+    @InjectRepository(SocialLink)
+    private readonly socialLinkRepository: Repository<SocialLink>,
+  ) {}
 
   /**
    * Validates that all URL-type social link fields in the DTO belong
@@ -85,38 +90,45 @@ export class SocialLinksService {
     return payload;
   }
 
-  createSocialLinks(dto: SocialLinksDto): SocialLinksPayload {
+  async createSocialLinks(dto: SocialLinksDto): Promise<SocialLinksListItem> {
     const payload = this.extractUpdatePayload(dto);
-    const id = String(this.nextId++);
-    this.records.set(id, {
-      id,
-      ...this.toResponseDto(payload),
-    });
+    const entity = this.socialLinkRepository.create(payload);
+    const saved = await this.socialLinkRepository.save(entity);
 
-    return payload;
+    return {
+      id: saved.id,
+      ...this.toResponseDto(saved),
+    };
   }
 
-  updateSocialLinks(id: string, dto: SocialLinksDto): SocialLinksPayload {
+  async updateSocialLinks(
+    id: string,
+    dto: SocialLinksDto,
+  ): Promise<SocialLinksListItem> {
     const payload = this.extractUpdatePayload(dto);
-    const current = this.records.get(id) ?? {
-      id,
-      websiteUrl: null,
-      twitterHandle: null,
-      instagramHandle: null,
-      otherLink: null,
-    };
+    const existing = await this.socialLinkRepository.findOne({ where: { id } });
 
-    this.records.set(id, {
-      ...current,
+    const merged = this.socialLinkRepository.create({
+      ...(existing ?? {
+        websiteUrl: null,
+        twitterHandle: null,
+        instagramHandle: null,
+        otherLink: null,
+      }),
+      id,
       ...payload,
     });
+    const saved = await this.socialLinkRepository.save(merged);
 
-    return payload;
+    return {
+      id: saved.id,
+      ...this.toResponseDto(saved),
+    };
   }
 
-  listSocialLinks(
+  async listSocialLinks(
     pagination: PaginationDto = {},
-  ): PaginatedResponseDto<SocialLinksListItem> {
+  ): Promise<PaginatedResponseDto<SocialLinksListItem>> {
     const page =
       Number.isInteger(pagination.page) &&
       pagination.page &&
@@ -130,10 +142,18 @@ export class SocialLinksService {
         ? Math.min(pagination.limit, 100)
         : 20;
     const skip = (page - 1) * limit;
-    const allRecords = Array.from(this.records.values());
-    const data = allRecords.slice(skip, skip + limit);
 
-    return new PaginatedResponseDto(data, allRecords.length, page, limit);
+    const [records, total] = await this.socialLinkRepository.findAndCount({
+      skip,
+      take: limit,
+      order: { createdAt: 'ASC' },
+    });
+    const data = records.map((record) => ({
+      id: record.id,
+      ...this.toResponseDto(record),
+    }));
+
+    return new PaginatedResponseDto(data, total, page, limit);
   }
 
   /**

--- a/backend/src/subscriptions/guards/hybrid-fan-auth.guard.ts
+++ b/backend/src/subscriptions/guards/hybrid-fan-auth.guard.ts
@@ -1,0 +1,96 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
+import { isStellarAccountAddress } from '../../common/utils/stellar-address';
+
+export type RequestWithHybridAuth = Request & {
+  fanAddress?: string;
+  user?: { userId: string; email?: string };
+  authMode?: 'stellar-bearer' | 'jwt';
+};
+
+/**
+ * This codebase currently has two independent auth modes with no stored
+ * link between them:
+ *
+ *  - Stellar bearer ({@link FanBearerGuard}): `Authorization: Bearer
+ *    base64(Stellar G-address)`, matching `AuthService#createSession` in
+ *    `src/auth/auth.service.ts`. Used on subscription/fan routes. Resolves
+ *    directly to a Stellar address (`req.fanAddress`); there is no platform
+ *    user account behind it.
+ *  - Passport JWT (`JwtAuthGuard` / `src/auth-module`): `Authorization:
+ *    Bearer <JWT>` where `sub` is a platform user UUID, validated against
+ *    `AuthService#validateUser`. Used on social routes (creators, posts,
+ *    comments, conversations, ...).
+ *
+ * Since there is no `users` column or table linking a platform user UUID to
+ * a Stellar wallet address, true identity *unification* isn't possible yet.
+ * This guard implements the *bridge* option instead: it accepts either
+ * credential type on the same endpoint and normalizes the result onto the
+ * request, tagged with `authMode`, so a handler can tell which kind of
+ * identity it received instead of assuming `fanAddress` is always present.
+ *
+ * Handlers that specifically require a resolved Stellar address (e.g.
+ * subscription/chain checks) must still check `authMode === 'stellar-bearer'`
+ * explicitly and reject (401/403) a `'jwt'`-mode caller — this guard only
+ * authenticates the request, it does not fabricate a Stellar address for a
+ * JWT-authenticated platform user.
+ */
+@Injectable()
+export class HybridFanAuthGuard implements CanActivate {
+  constructor(private readonly jwtService: JwtService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<RequestWithHybridAuth>();
+    const raw = req.headers['authorization'] ?? req.headers['Authorization'];
+    const header = Array.isArray(raw) ? raw[0] : raw;
+
+    if (!header || typeof header !== 'string') {
+      throw new UnauthorizedException(
+        'Missing Authorization header. Use either a Stellar bearer token ' +
+          '(base64-encoded G-address) or a platform JWT.',
+      );
+    }
+
+    const match = /^Bearer\s+(\S+)$/i.exec(header.trim());
+    if (!match) {
+      throw new UnauthorizedException('Authorization must be a Bearer token.');
+    }
+    const token = match[1];
+
+    const stellarAddress = this.tryDecodeStellarBearer(token);
+    if (stellarAddress) {
+      req.fanAddress = stellarAddress;
+      req.authMode = 'stellar-bearer';
+      return true;
+    }
+
+    try {
+      const payload = await this.jwtService.verifyAsync<{
+        sub: string;
+        email?: string;
+      }>(token);
+      req.user = { userId: payload.sub, email: payload.email };
+      req.authMode = 'jwt';
+      return true;
+    } catch {
+      throw new UnauthorizedException(
+        'Bearer token is neither a valid Stellar bearer token nor a valid JWT.',
+      );
+    }
+  }
+
+  private tryDecodeStellarBearer(token: string): string | null {
+    try {
+      const decoded = Buffer.from(token, 'base64').toString('utf8').trim();
+      return isStellarAccountAddress(decoded) ? decoded : null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/backend/src/subscriptions/spending-cap.controller.ts
+++ b/backend/src/subscriptions/spending-cap.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
   HttpCode,
   HttpStatus,
@@ -16,14 +17,29 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { FanBearerGuard } from './guards/fan-bearer.guard';
-import type { RequestWithFan } from './guards/fan-bearer.guard';
+import { HybridFanAuthGuard } from './guards/hybrid-fan-auth.guard';
+import type { RequestWithHybridAuth } from './guards/hybrid-fan-auth.guard';
 import { SpendingCapService } from './services/spending-cap.service';
 import { SetSpendingCapDto, SpendingCapResponseDto } from './dto/spending-cap.dto';
 
+/**
+ * Accepts both a Stellar bearer token and a Passport JWT (see
+ * {@link HybridFanAuthGuard}), but spending caps are keyed by Stellar
+ * address, so a JWT-authenticated caller with no linked address is
+ * rejected explicitly rather than silently operating on `undefined`.
+ */
+function requireFanAddress(req: RequestWithHybridAuth): string {
+  if (req.authMode !== 'stellar-bearer' || !req.fanAddress) {
+    throw new ForbiddenException(
+      'This endpoint requires a Stellar bearer token; a platform JWT alone is not linked to a Stellar address.',
+    );
+  }
+  return req.fanAddress;
+}
+
 @ApiTags('subscriptions')
 @Controller({ path: 'subscriptions/me/spending-cap', version: '1' })
-@UseGuards(FanBearerGuard)
+@UseGuards(HybridFanAuthGuard)
 @ApiBearerAuth()
 export class SpendingCapController {
   constructor(private readonly caps: SpendingCapService) {}
@@ -32,8 +48,10 @@ export class SpendingCapController {
   @ApiOperation({ summary: 'Get the authenticated fan\'s spending cap' })
   @ApiResponse({ status: 200, type: SpendingCapResponseDto })
   @ApiResponse({ status: 404, description: 'No cap set' })
-  async getCap(@Req() req: RequestWithFan): Promise<SpendingCapResponseDto> {
-    const cap = await this.caps.getCap(req.fanAddress);
+  async getCap(
+    @Req() req: RequestWithHybridAuth,
+  ): Promise<SpendingCapResponseDto> {
+    const cap = await this.caps.getCap(requireFanAddress(req));
     if (!cap) throw new NotFoundException('No spending cap configured');
     return cap;
   }
@@ -42,17 +60,17 @@ export class SpendingCapController {
   @ApiOperation({ summary: 'Set or update the authenticated fan\'s spending cap' })
   @ApiResponse({ status: 200, type: SpendingCapResponseDto })
   async setCap(
-    @Req() req: RequestWithFan,
+    @Req() req: RequestWithHybridAuth,
     @Body() dto: SetSpendingCapDto,
   ): Promise<SpendingCapResponseDto> {
-    return this.caps.setCap(req.fanAddress, dto);
+    return this.caps.setCap(requireFanAddress(req), dto);
   }
 
   @Delete()
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Remove the authenticated fan\'s spending cap' })
   @ApiResponse({ status: 204, description: 'Cap removed' })
-  async removeCap(@Req() req: RequestWithFan): Promise<void> {
-    return this.caps.removeCap(req.fanAddress);
+  async removeCap(@Req() req: RequestWithHybridAuth): Promise<void> {
+    return this.caps.removeCap(requireFanAddress(req));
   }
 }

--- a/backend/src/subscriptions/subscriptions.module.ts
+++ b/backend/src/subscriptions/subscriptions.module.ts
@@ -1,7 +1,8 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
-import { ConfigModule } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { LoggingModule } from '../common/logging.module';
 import { EventsModule } from '../events/events.module';
 import { FeatureFlagsModule } from '../feature-flags/feature-flags.module';
@@ -16,6 +17,7 @@ import { SubscriptionChainSyncService } from './services/subscription-chain-sync
 import { SpendingCapService } from './services/spending-cap.service';
 import { SUBSCRIPTION_EVENT_PUBLISHER } from './events';
 import { FanBearerGuard } from './guards/fan-bearer.guard';
+import { HybridFanAuthGuard } from './guards/hybrid-fan-auth.guard';
 import { GatedContentGuard } from './gated-content.guard';
 import { FeatureFlagGuard } from '../feature-flags/feature-flag.guard';
 import { SubscriptionCacheService } from './subscription-cache.service';
@@ -34,6 +36,13 @@ import { LedgerClockService } from './ledger-clock.service';
     EventsModule,
     LoggingModule,
     FeatureFlagsModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get('JWT_SECRET'),
+      }),
+      inject: [ConfigService],
+    }),
   ],
   controllers: [SubscriptionsController, SpendingCapController, SubscriptionLifecycleIndexerController],
   providers: [
@@ -48,6 +57,7 @@ import { LedgerClockService } from './ledger-clock.service';
     SubscriptionCacheService,
     GatedContentGuard,
     FanBearerGuard,
+    HybridFanAuthGuard,
     FeatureFlagGuard,
     SubscriptionLifecycleIndexerService,
     {


### PR DESCRIPTION
Closes #1426
Closes #1427
Closes #1428
Closes #1433

## #1426 — Make creator discovery endpoints public
`CreatorsController`'s `searchCreators` was already `@Public()`, but `getCreatorByUsername` (the get-by-handle endpoint) was still gated by `JwtAuthGuard`. Added `@Public()` to it. Mutation endpoints (`createPlan`, etc.) remain protected.

## #1427 — Persist social links to database
`SocialLinksService` used an in-memory `Map` lost on restart. Added a `SocialLink` TypeORM entity + migration (`social_links` table, registered in `migration.datasource.ts`), wired `SocialLinksModule` to `TypeOrmModule.forFeature([SocialLink])`, and rewrote `createSocialLinks`/`updateSocialLinks`/`listSocialLinks` to use the repository instead of the Map. Also registered `SocialLinksModule` in `app.module.ts` — it wasn't imported anywhere before, so the feature was unreachable.

## #1428 — Require Idempotency-Key on checkout mutations
`IdempotencyMiddleware` silently passed through requests missing the header. Added a `REQUIRED_IDEMPOTENCY_PATH_PREFIXES` check (`/v1/subscriptions/checkout`) that now throws `400` when the key is missing on checkout/payment routes, while leaving it optional on the other idempotency-tracked routes (posts, comments, conversations, creator plans). The existing `acquire`/`complete` logic already replays the cached response for a repeated key and allows a new key to proceed as a new operation.

## #1433 — Reconcile FanBearerGuard with Passport JWT auth
Subscriptions use a Stellar-address bearer (`FanBearerGuard`) while social routes use Passport JWT (`sub` = platform user UUID) — and there's no stored link between a platform user and a Stellar address, so full identity unification isn't possible without new schema. Implemented the bridge option instead: `HybridFanAuthGuard` accepts either credential type and normalizes the result (`req.fanAddress` + `authMode: 'stellar-bearer'`, or `req.user` + `authMode: 'jwt'`). Wired it into `SpendingCapController` with an explicit `requireFanAddress` check so a JWT-only caller gets a clean 403 instead of an undefined address silently flowing through. Documented both modes and the bridge's scope in `docs/AUTH_MODES.md`. Left the payment-critical `SubscriptionsController` checkout/lifecycle routes on `FanBearerGuard` only, since a broader swap there needs its own verification pass.