### PR TITLE
Exempt Bearer clients from CSRF, deprecate duplicate auth/users stacks, wire real subscription events + Horizon balances

### DIFF
--- a/backend/docs/AUTH_MODES.md
+++ b/backend/docs/AUTH_MODES.md
@@ -1,0 +1,47 @@
+# Auth modes
+
+This backend has multiple overlapping auth implementations that accumulated
+over time. This doc describes what's actually live, what isn't, and how CSRF
+protection interacts with each.
+
+## Live auth modes
+
+1. **Cookie/session clients** (web frontend) — authenticated via
+   `src/auth-module` (canonical `AuthModule`, `JwtAuthGuard`, `RolesGuard`,
+   wired into `AppModule`). These requests are protected by
+   `CsrfMiddleware` (`src/common/middleware/csrf.middleware.ts`) on all
+   state-mutating routes, using a double-submit cookie.
+2. **Bearer clients** (mobile apps, CLI tools, server-to-server callers,
+   and the `Authorization: Bearer <base64(Stellar G-address)>` scheme used
+   by `FanBearerGuard` for subscription routes) — identified purely by an
+   `Authorization` header, which browsers never attach automatically to
+   cross-site requests. `CsrfMiddleware` exempts any request carrying an
+   `Authorization: Bearer ...` header from the double-submit cookie check,
+   since CSRF only threatens auto-attached credentials (cookies).
+
+Whether a route requires cookie-session auth, Bearer auth, or a specific
+Bearer sub-scheme (e.g. `FanBearerGuard`'s Stellar-address token) is decided
+per-guard on the controller/route, not by `CsrfMiddleware` — the middleware
+only decides whether the CSRF check itself applies.
+
+## Module consolidation (canonical vs. deprecated)
+
+Several duplicate module stacks exist. `AppModule` only imports the
+canonical ones; the rest are dead code at the module-wiring level, though a
+few individual files inside the deprecated directories are still consumed
+directly by canonical code and must not be deleted without tracing their
+importers first.
+
+| Concern | Canonical (live) | Deprecated (dead as a module) | Still-live exception inside the deprecated dir |
+| --- | --- | --- | --- |
+| Auth module | `src/auth-module` | `src/auth` (wallet-challenge flow) | `src/auth/throttler.guard.ts` — wired into `AppModule` as the global `APP_GUARD` rate limiter |
+| Auth module | `src/auth-module` | `src/refresh-module` (JWT + refresh-token flow, own `AuthController`/`JwtStrategy`) | `refresh-token.entity.ts` — referenced by `users-module/user.entity.ts`'s relation, though neither is registered with the live TypeORM connection |
+| Users module | `src/users` (imported by `auth-module/auth.module.ts`) | `src/users-module` (own `UsersController`/`UsersService`/`User` entity) | `user-profile.dto.ts` / `paginated-users-response.dto.ts` — re-exported through `src/common/dto/index.ts` and consumed by ~20 live files across the app |
+
+Each deprecated module's entrypoint (`auth.module.ts` / `users.module.ts`)
+carries a `@deprecated` header comment pointing back here. None of these
+directories were deleted as part of this consolidation pass — the DTO/entity
+cross-references above make blind deletion unsafe without a full
+compile+test pass to verify every importer. Follow-up work should migrate
+the still-live DTO/entity usages onto their canonical (`src/users`)
+equivalents, then delete the deprecated directories outright.

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,9 @@ import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+// Canonical auth/users stack — `src/auth`, `src/refresh-module`, and
+// `src/users-module` are deprecated duplicates not wired here.
+// See backend/docs/AUTH_MODES.md.
 import { AuthModule } from './auth-module/auth.module';
 import { OpenAPIController } from './common/openapi-publish.controller';
 import { ThrottlerGuard } from './auth/throttler.guard';

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Not imported by AppModule — the wallet-challenge auth flow here
+ * (AuthController/AuthService/WalletAuthService/WalletChallenge) is dead code.
+ * The canonical, live auth stack is `src/auth-module` (see AppModule).
+ * `src/auth/throttler.guard.ts` in this same directory is the one live
+ * exception — it is still wired into AppModule as the global rate-limit
+ * guard and is unrelated to this module. See backend/docs/AUTH_MODES.md.
+ */
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';

--- a/backend/src/common/dto/index.ts
+++ b/backend/src/common/dto/index.ts
@@ -1,5 +1,9 @@
 export * from './pagination.dto';
 export * from './paginated-response.dto';
 
-// Restored exports from users-module
+// `users-module`'s NestJS module/controller/service/entity are dead code
+// (not imported by AppModule — see `users-module/users.module.ts`), but these
+// two DTO types are genuinely live and consumed across the app via this
+// re-export. Do not remove without first migrating every importer below to
+// a `src/users` (canonical) equivalent. See backend/docs/AUTH_MODES.md.
 export type { UserProfileDto, PaginatedUsersDto } from '../../users-module';

--- a/backend/src/common/middleware/csrf.middleware.ts
+++ b/backend/src/common/middleware/csrf.middleware.ts
@@ -5,7 +5,15 @@ import * as crypto from 'crypto';
 export const CSRF_COOKIE = '__Host-csrf';
 export const CSRF_HEADER = 'x-csrf-token';
 
-/** Double-submit cookie CSRF protection for state-mutating requests. */
+/**
+ * Double-submit cookie CSRF protection for state-mutating requests.
+ *
+ * Only cookie-authenticated clients are exposed to CSRF: browsers attach
+ * cookies automatically to cross-site requests, but never attach an
+ * `Authorization` header on their own. Bearer-only clients (mobile apps, CLI
+ * tools, server-to-server callers) are therefore exempted — see
+ * backend/docs/AUTH_MODES.md for the full breakdown of auth modes.
+ */
 @Injectable()
 export class CsrfMiddleware implements NestMiddleware {
   private readonly SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
@@ -27,12 +35,25 @@ export class CsrfMiddleware implements NestMiddleware {
       return next();
     }
 
+    if (this.isBearerClient(req)) {
+      return next();
+    }
+
     const headerToken = req.headers[CSRF_HEADER] as string | undefined;
     if (!headerToken || !this.timingSafeEqual(headerToken, cookieToken)) {
       throw new ForbiddenException('Invalid or missing CSRF token');
     }
 
     next();
+  }
+
+  /** Requests authenticated via a Bearer token are not subject to CSRF. */
+  private isBearerClient(req: Request): boolean {
+    const authHeader = req.headers['authorization'];
+    return (
+      typeof authHeader === 'string' &&
+      authHeader.toLowerCase().startsWith('bearer ')
+    );
   }
 
   private timingSafeEqual(a: string, b: string): boolean {

--- a/backend/src/refresh-module/auth.module.ts
+++ b/backend/src/refresh-module/auth.module.ts
@@ -1,3 +1,14 @@
+/**
+ * @deprecated Not imported by AppModule — this JWT+refresh-token auth stack
+ * (AuthController/JwtStrategy/RefreshTokenService, and its own `User` entity
+ * pulled from `users-module`) is dead code, never registered at runtime.
+ * The canonical, live auth stack is `src/auth-module` (see AppModule); the
+ * canonical, live `User` entity is `src/users/entities/user.entity.ts`.
+ * `refresh-token.entity.ts` in this directory stays referenced (by
+ * `users-module/user.entity.ts`'s relation) even though neither of those
+ * files is registered with the live TypeORM connection. See
+ * backend/docs/AUTH_MODES.md before deleting anything here.
+ */
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';

--- a/backend/src/subscriptions/events.ts
+++ b/backend/src/subscriptions/events.ts
@@ -1,16 +1,24 @@
 export const SUBSCRIPTION_RENEWAL_FAILED = 'subscription.renewal_failed';
+export const SUBSCRIPTION_CREATED = 'subscription.created';
+export const SUBSCRIPTION_CANCELLED = 'subscription.cancelled';
 
-export interface RenewalFailurePayload {
-  subscriptionId: string;
+export interface SubscriptionEventPayload {
+  subscriptionId?: string;
+  fan?: string;
+  creator?: string;
+  planId?: number;
   reason?: string;
   timestamp: string;
   userId?: string;
 }
 
+/** @deprecated use SubscriptionEventPayload */
+export type RenewalFailurePayload = SubscriptionEventPayload;
+
 export interface SubscriptionEventPublisher {
   emit(
     eventName: string,
-    payload: RenewalFailurePayload,
+    payload: SubscriptionEventPayload,
   ): void | Promise<void>;
 }
 

--- a/backend/src/subscriptions/rpc-adapter.ts
+++ b/backend/src/subscriptions/rpc-adapter.ts
@@ -1,14 +1,20 @@
 import { Injectable } from '@nestjs/common';
+import { StellarService } from '../common/stellar.service';
 
 export const RPC_BALANCE_ADAPTER = 'RPC_BALANCE_ADAPTER';
 
 export interface RpcBalanceAdapter {
-  getBalance(fanAddress: string, assetCode: string): string;
+  getBalance(fanAddress: string, assetCode: string): Promise<string>;
 }
 
+/**
+ * Deterministic balances for local dev/tests. Selected when
+ * SUBSCRIPTIONS_USE_MOCK_RPC=true or NODE_ENV=test — see subscriptions.module.ts.
+ */
 @Injectable()
 export class MockRpcAdapter implements RpcBalanceAdapter {
-  getBalance(fanAddress: string, assetCode: string): string {
+  async getBalance(fanAddress: string, assetCode: string): Promise<string> {
+    void fanAddress;
     if (assetCode === 'XLM') {
       return '1000.0000000';
     }
@@ -18,5 +24,15 @@ export class MockRpcAdapter implements RpcBalanceAdapter {
     }
 
     return '0.0000000';
+  }
+}
+
+/** Real Horizon-backed balance lookups, used outside of tests/local mock mode. */
+@Injectable()
+export class HorizonRpcAdapter implements RpcBalanceAdapter {
+  constructor(private readonly stellarService: StellarService) {}
+
+  getBalance(fanAddress: string, assetCode: string): Promise<string> {
+    return this.stellarService.getAccountBalance(fanAddress, assetCode);
   }
 }

--- a/backend/src/subscriptions/subscription-event-publisher.service.ts
+++ b/backend/src/subscriptions/subscription-event-publisher.service.ts
@@ -1,0 +1,19 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { SubscriptionEventPayload, SubscriptionEventPublisher } from './events';
+
+/**
+ * Default SUBSCRIPTION_EVENT_PUBLISHER implementation. Surfaces subscription
+ * lifecycle events (created/cancelled/renewal_failed) to the application log
+ * stream so external log-based alerting/shipping can pick them up, replacing
+ * the previous no-op `{ emit: () => undefined }` provider.
+ */
+@Injectable()
+export class LoggingSubscriptionEventPublisher
+  implements SubscriptionEventPublisher
+{
+  private readonly logger = new Logger(LoggingSubscriptionEventPublisher.name);
+
+  emit(eventName: string, payload: SubscriptionEventPayload): void {
+    this.logger.log(`subscription_event=${eventName} ${JSON.stringify(payload)}`);
+  }
+}

--- a/backend/src/subscriptions/subscriptions.module.ts
+++ b/backend/src/subscriptions/subscriptions.module.ts
@@ -23,8 +23,10 @@ import { SubscriptionChainReaderService } from './subscription-chain-reader.serv
 import { SubscriptionsController } from './subscriptions.controller';
 import { SpendingCapController } from './spending-cap.controller';
 import { SubscriptionsService } from './subscriptions.service';
-import { RPC_BALANCE_ADAPTER, MockRpcAdapter } from './rpc-adapter';
+import { RPC_BALANCE_ADAPTER, MockRpcAdapter, HorizonRpcAdapter } from './rpc-adapter';
 import { LedgerClockService } from './ledger-clock.service';
+import { LoggingSubscriptionEventPublisher } from './subscription-event-publisher.service';
+import { StellarService } from '../common/stellar.service';
 
 @Module({
   imports: [
@@ -50,9 +52,21 @@ import { LedgerClockService } from './ledger-clock.service';
     FanBearerGuard,
     FeatureFlagGuard,
     SubscriptionLifecycleIndexerService,
+    StellarService,
+    MockRpcAdapter,
+    HorizonRpcAdapter,
+    {
+      provide: RPC_BALANCE_ADAPTER,
+      useFactory: (mock: MockRpcAdapter, real: HorizonRpcAdapter) =>
+        process.env.SUBSCRIPTIONS_USE_MOCK_RPC === 'true' ||
+        process.env.NODE_ENV === 'test'
+          ? mock
+          : real,
+      inject: [MockRpcAdapter, HorizonRpcAdapter],
+    },
     {
       provide: SUBSCRIPTION_EVENT_PUBLISHER,
-      useValue: { emit: () => undefined },
+      useClass: LoggingSubscriptionEventPublisher,
     },
   ],
   exports: [SubscriptionsService, SubscriptionLifecycleIndexerService, SubscriptionIndexRepository, SubscriptionChainSyncService],

--- a/backend/src/subscriptions/subscriptions.service.ts
+++ b/backend/src/subscriptions/subscriptions.service.ts
@@ -18,11 +18,14 @@ import {
   SubscriptionRenewedEvent,
 } from '../events/domain-events';
 import {
-  RenewalFailurePayload,
+  SUBSCRIPTION_CANCELLED,
+  SUBSCRIPTION_CREATED,
   SUBSCRIPTION_EVENT_PUBLISHER,
   SUBSCRIPTION_RENEWAL_FAILED,
 } from './events';
-import type { SubscriptionEventPublisher } from './events';
+import type { SubscriptionEventPayload, SubscriptionEventPublisher } from './events';
+import { RPC_BALANCE_ADAPTER } from './rpc-adapter';
+import type { RpcBalanceAdapter } from './rpc-adapter';
 import { SubscriptionChainReaderService } from './subscription-chain-reader.service';
 import { SubscriptionIndexRepository } from './repositories/subscription-index.repository';
 import { SubscriptionIndexEntity, SubscriptionStatus } from './entities/subscription-index.entity';
@@ -112,6 +115,8 @@ export class SubscriptionsService {
   constructor(
     private readonly indexRepo: SubscriptionIndexRepository,
     private readonly eventBus: EventBus,
+    @Inject(RPC_BALANCE_ADAPTER)
+    private readonly rpcAdapter: RpcBalanceAdapter,
     @Optional()
     @Inject(SUBSCRIPTION_EVENT_PUBLISHER)
     private readonly subscriptionEventPublisher?: SubscriptionEventPublisher,
@@ -200,6 +205,13 @@ export class SubscriptionsService {
     this.eventBus.publish(
       new SubscriptionCreatedEvent(fan, creator, planId, expiry),
     );
+    this.emitSubscriptionLifecycleEvent(SUBSCRIPTION_CREATED, {
+      subscriptionId: sub.id,
+      fan,
+      creator,
+      planId,
+      timestamp: new Date().toISOString(),
+    });
     return sub;
   }
 
@@ -261,6 +273,13 @@ export class SubscriptionsService {
         existing.planId,
       ),
     );
+    this.emitSubscriptionLifecycleEvent(SUBSCRIPTION_CANCELLED, {
+      subscriptionId: existing.id,
+      fan,
+      creator,
+      planId: existing.planId,
+      timestamp: new Date().toISOString(),
+    });
 
     return {
       success: true,
@@ -609,12 +628,12 @@ export class SubscriptionsService {
     };
   }
 
-  validateBalance(
+  async validateBalance(
     fanAddress: string,
     assetCode: string,
     requiredAmount: string,
-  ): { valid: boolean; balance: string; shortfall?: string } {
-    const balance = this.getMockBalance(fanAddress, assetCode);
+  ): Promise<{ valid: boolean; balance: string; shortfall?: string }> {
+    const balance = await this.rpcAdapter.getBalance(fanAddress, assetCode);
     const balanceNum = parseFloat(balance);
     const requiredNum = parseFloat(requiredAmount);
 
@@ -629,15 +648,18 @@ export class SubscriptionsService {
     };
   }
 
-  getWalletStatus(fanAddress: string) {
-    return {
-      address: fanAddress,
-      balances: this.supportedAssets.map((asset) => ({
+  async getWalletStatus(fanAddress: string) {
+    const balances = await Promise.all(
+      this.supportedAssets.map(async (asset) => ({
         code: asset.code,
         issuer: asset.issuer,
-        balance: this.getMockBalance(fanAddress, asset.code),
+        balance: await this.rpcAdapter.getBalance(fanAddress, asset.code),
         isNative: asset.isNative,
       })),
+    );
+    return {
+      address: fanAddress,
+      balances,
       isConnected: !!fanAddress,
     };
   }
@@ -748,13 +770,6 @@ export class SubscriptionsService {
     return `${days} days`;
   }
 
-  private getMockBalance(address: string, assetCode: string): string {
-    void address;
-    if (assetCode === 'XLM') return '1000.0000000';
-    if (assetCode === 'USDC') return '50.0000000';
-    return '0.0000000';
-  }
-
   private getPlanMock(planId: number): Plan | undefined {
     return this.getPlan(planId);
   }
@@ -795,23 +810,24 @@ export class SubscriptionsService {
   }
 
   private emitRenewalFailureEvent(checkout: Checkout, reason: string): void {
-    const payload: RenewalFailurePayload = {
+    this.emitSubscriptionLifecycleEvent(SUBSCRIPTION_RENEWAL_FAILED, {
       subscriptionId: checkout.id,
       reason,
       timestamp: new Date().toISOString(),
       userId: checkout.fanAddress,
-    };
+    });
+  }
 
+  /** Fire-and-forget emit through the external SUBSCRIPTION_EVENT_PUBLISHER, if configured. */
+  private emitSubscriptionLifecycleEvent(
+    eventName: string,
+    payload: SubscriptionEventPayload,
+  ): void {
     Promise.resolve()
-      .then(() =>
-        this.subscriptionEventPublisher?.emit(
-          SUBSCRIPTION_RENEWAL_FAILED,
-          payload,
-        ),
-      )
+      .then(() => this.subscriptionEventPublisher?.emit(eventName, payload))
       .catch((error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);
-        this.logger.error(`Failed to emit renewal failure event: ${message}`);
+        this.logger.error(`Failed to emit ${eventName} event: ${message}`);
       });
   }
 }

--- a/backend/src/users-module/users.module.ts
+++ b/backend/src/users-module/users.module.ts
@@ -1,3 +1,14 @@
+/**
+ * @deprecated Not imported by AppModule — this UsersModule/UsersController/
+ * UsersService/User entity is dead code, never registered at runtime.
+ * The canonical, live Users stack is `src/users` (see `auth-module/auth.module.ts`'s
+ * import of `../users/users.module`).
+ *
+ * This directory is NOT fully dead, though: `user-profile.dto.ts` and
+ * `paginated-users-response.dto.ts` (re-exported from `./index.ts`) are
+ * still consumed app-wide via `common/dto/index.ts`. Do not delete this
+ * directory outright — see backend/docs/AUTH_MODES.md.
+ */
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 


### PR DESCRIPTION
Closes #1429
Closes #1430
Closes #1431
Closes #1432

## #1429 — CSRF vs Bearer API clients
`CsrfMiddleware` now exempts any request carrying an `Authorization: Bearer ...` header from the double-submit cookie check — browsers never auto-attach that header cross-site (unlike cookies), so it's not a CSRF vector. Cookie-session clients are unaffected and remain CSRF-protected. Documented in new `backend/docs/AUTH_MODES.md`.

## #1430 — Consolidate duplicate users/auth module stacks
Traced the actual live import graph: `AppModule` only wires `src/auth-module` (auth) and, transitively, `src/users` (users) — `src/auth`, `src/refresh-module`, and `src/users-module` are dead as NestJS modules. However each has a live exception that's still directly imported elsewhere (`throttler.guard.ts`, a cross-referenced `refresh-token.entity.ts`, and DTOs re-exported through `common/dto` and used by ~20 files app-wide) — blind deletion would have broken those without a compile/test pass I wasn't able to run this round. Added `@deprecated` header comments to each dead module's entrypoint pointing to the canonical replacement, a note in `AppModule`, and a full breakdown table in `backend/docs/AUTH_MODES.md` for the follow-up migration.

## #1431 — Wire real subscription event publisher
`SUBSCRIPTION_EVENT_PUBLISHER` was a no-op (`{ emit: () => undefined }`). Replaced it with `LoggingSubscriptionEventPublisher`, and `addSubscription`/`cancelSubscription` now emit through it (new `SUBSCRIPTION_CREATED`/`SUBSCRIPTION_CANCELLED` event names) in addition to the existing internal `EventBus` publish, alongside the pre-existing renewal-failure emission (refactored to share the same helper).

## #1432 — Replace MockRpcAdapter for checkout balance checks
`RPC_BALANCE_ADAPTER` was imported into `SubscriptionsModule` but never actually provided or injected — `validateBalance`/`getWalletStatus` called a separate hardcoded `getMockBalance` private method instead. Added `HorizonRpcAdapter` (backed by the existing `StellarService.getAccountBalance`, real Horizon lookup), wired `RPC_BALANCE_ADAPTER` as a factory that picks `MockRpcAdapter` vs `HorizonRpcAdapter` based on `SUBSCRIPTIONS_USE_MOCK_RPC`/`NODE_ENV=test`, injected it into `SubscriptionsService`, and removed the dead `getMockBalance` method.