### PR TITLE
Wire treasury property tests and document content-likes error codes

### DIFF
--- a/contract/contracts/myfans-lib/src/error_codes.rs
+++ b/contract/contracts/myfans-lib/src/error_codes.rs
@@ -42,8 +42,14 @@ pub mod content_access {
 }
 
 /// Error codes for the **content-likes** contract.
+///
+/// | Code | Constant | Contract variant |
+/// |------|----------|-------------------|
+/// | 1 | `NOT_LIKED` | `Error::NotLiked` |
+/// | 2 | `ALREADY_INITIALIZED` | `Error::AlreadyInitialized` |
 pub mod content_likes {
     pub const NOT_LIKED: u32 = 1;
+    pub const ALREADY_INITIALIZED: u32 = 2;
 }
 
 /// Error codes for the **creator-registry** contract.

--- a/contract/contracts/test-consumer/src/lib.rs
+++ b/contract/contracts/test-consumer/src/lib.rs
@@ -719,6 +719,24 @@ mod test {
         }
     }
 
+    // ── content-likes integration (Issue #1409) ──────────────────────────────
+
+    mod content_likes_integration {
+        use content_likes::Error as LikesError;
+        use myfans_lib::error_codes::content_likes as likes_err;
+
+        /// content-likes contract error discriminants must match the stable
+        /// constants published in `myfans_lib::error_codes::content_likes`.
+        #[test]
+        fn content_likes_error_codes_match_stable_constants() {
+            assert_eq!(LikesError::NotLiked as u32, likes_err::NOT_LIKED);
+            assert_eq!(
+                LikesError::AlreadyInitialized as u32,
+                likes_err::ALREADY_INITIALIZED
+            );
+        }
+    }
+
     // ── creator-earnings integration ───────────────────────────────────────
 
     mod creator_earnings_integration {

--- a/contract/contracts/treasury/src/lib.rs
+++ b/contract/contracts/treasury/src/lib.rs
@@ -175,3 +175,6 @@ mod error_tests;
 
 #[cfg(test)]
 mod gas_benchmarks;
+
+#[cfg(test)]
+mod property_tests;


### PR DESCRIPTION
Closes #1384
Closes #1409

## #1384 — treasury property tests for min_balance boundaries
The property test module (`contract/contracts/treasury/src/property_tests.rs`) already existed in the repo from a prior PR, but was never declared as a module in `treasury/src/lib.rs` — meaning it was dead code that never actually compiled or ran as part of `cargo test -p treasury`. Added the missing `#[cfg(test)] mod property_tests;` declaration so the existing proptest suite (deposit monotonicity, withdraw deduction, deposit-withdraw symmetry, non-negativity, overdraft rejection, min_balance boundary rejection, paused-state rejection) actually runs. `proptest` was already a workspace dev-dependency for this crate, so no Cargo.toml change was needed.

## #1409 — content-likes error codes in myfans-lib catalog
`myfans-lib::error_codes::content_likes` only exported `NOT_LIKED`. The actual `content-likes` contract's `Error` enum has exactly one more variant, `AlreadyInitialized = 2`, which was undocumented. Added `ALREADY_INITIALIZED: u32 = 2` to the catalog (existing `NOT_LIKED` numeric value left unchanged for stability), added a doc-comment table listing both codes against their contract variants, and added an integration test in `test-consumer` asserting the catalog constants match the real `content_likes::Error` discriminants going forward.