### PR TITLE
Centralize frontend API base URL + sync creator-registry on-chain ID

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,6 +56,31 @@ Or open `http://localhost:3001/v1/health` in your browser.
 
 ---
 
+## Frontend API base URL (`NEXT_PUBLIC_API_URL`)
+
+All frontend API clients resolve the backend origin through the shared
+`getApiBaseUrl()` helper in `frontend/src/lib/api/base-url.ts`, instead of
+each module hardcoding its own `localhost` host/port fallback.
+
+- Set `NEXT_PUBLIC_API_URL` to override the backend origin, e.g. in
+  `frontend/.env.local`:
+  ```bash
+  NEXT_PUBLIC_API_URL=http://localhost:3001
+  ```
+- When unset, it defaults to `http://localhost:3001` (matching the backend's
+  `docker-compose.yml`/`docker-compose.dev.yml` port), so local dev works out
+  of the box without any frontend env file.
+- `NEXT_PUBLIC_API_URL` should be the bare origin (protocol + host + optional
+  port) — individual clients append their own resource paths (e.g. `/v1/...`,
+  `/api/v1/...`, `/favorites`) on top of it. Do not include a trailing slash.
+- If you add a new frontend module that calls the backend, import
+  `getApiBaseUrl()` (or `getConfiguredApiBaseUrl()` if you need a different
+  fallback than the shared absolute default, e.g. a same-origin relative URL)
+  from `@/lib/api/base-url` rather than reading
+  `process.env.NEXT_PUBLIC_API_URL` directly.
+
+---
+
 ## Contract Development
 
 Contracts are in the `contract/` directory and use Soroban SDK.

--- a/backend/docs/CREATOR_REGISTRY_SYNC.md
+++ b/backend/docs/CREATOR_REGISTRY_SYNC.md
@@ -1,0 +1,45 @@
+# Creator Registry Sync (#1454)
+
+Keeps the off-chain `CreatorProfile` (`creators` table) in sync with the
+numeric `creator_id` registered on-chain in the
+[`creator-registry`](../../contract/docs/interfaces/creator-registry.md)
+Soroban contract, via a new `creator_onchain_mappings` table.
+
+## Why
+
+The on-chain registry (`register_creator(caller, creator_address, creator_id)`)
+and the backend's `CreatorProfile` are independent sources of truth keyed
+differently (Stellar address vs. internal UUID). Without an explicit mapping
++ drift check, the two can silently diverge (e.g. a creator re-registers with
+a new `creator_id`, or a registration transaction fails after the backend
+already recorded it as successful).
+
+## Components
+
+- **Entity**: `backend/src/creators/entities/creator-onchain-mapping.entity.ts`
+  — one row per creator: `creator_id` (FK → `creators.id`), `stellar_address`,
+  `onchain_creator_id`, `last_synced_at`, `drift_detected_at`.
+- **Migration**: `backend/src/creators/1749000000000-CreateCreatorOnchainMappings.ts`.
+- **Service**: `backend/src/creators/creator-registry-sync.service.ts`
+  (`CreatorRegistrySyncService`):
+  - `syncOnOnboard(creatorId, stellarAddress, onchainCreatorId)` — upserts the
+    mapping. Call this right after `creator-registry.register_creator`
+    succeeds during onboarding.
+  - `reconcile(dryRun?)` — re-checks every mapped creator's on-chain
+    `creator_id` and flags rows where it disagrees with what's stored
+    (`drift_detected_at`). Runs hourly via `@Cron` (see
+    `CREATOR_REGISTRY_RECONCILER_DRY_RUN` env var to run without persisting),
+    mirroring `SubscriptionReconcilerService`.
+- **Endpoint**: `POST /v1/creators/:creatorId/onchain-sync` — thin wrapper
+  around `syncOnOnboard` for the onboarding flow.
+
+## Current limitation
+
+`CreatorRegistrySyncService.queryOnchainCreatorId()` is currently a stub
+(always returns `null`), matching the same convention as
+`SubscriptionReconcilerService.queryChainExpiry()`. Wiring it up to a real
+Soroban contract read (via `SorobanRpcService`, following the pattern in
+`SubscriptionChainReaderService`) against the deployed `creator-registry`
+contract's `get_creator_id` is tracked as follow-up work — until then,
+`reconcile()` will flag every mapped creator as drifted, so treat its output
+as informational rather than actionable in production.

--- a/backend/src/creators/1749000000000-CreateCreatorOnchainMappings.ts
+++ b/backend/src/creators/1749000000000-CreateCreatorOnchainMappings.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates `creator_onchain_mappings`, tracking the creator-registry
+ * contract's `creator_id` (u64) against the off-chain `creators` row that
+ * registered it (#1454).
+ *
+ * Safe to run against both fresh and existing databases — every statement is
+ * conditional (`IF NOT EXISTS`) so a database that already picked up the
+ * table via `synchronize` is left untouched.
+ */
+export class CreateCreatorOnchainMappings1749000000000 implements MigrationInterface {
+  name = 'CreateCreatorOnchainMappings1749000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "creator_onchain_mappings" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "creator_id" uuid NOT NULL,
+        "stellar_address" varchar(56) NOT NULL,
+        "onchain_creator_id" varchar NOT NULL,
+        "last_synced_at" TIMESTAMPTZ NOT NULL,
+        "drift_detected_at" TIMESTAMPTZ,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_creator_onchain_mappings" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_creator_onchain_mappings_creator_id" UNIQUE ("creator_id"),
+        CONSTRAINT "FK_creator_onchain_mappings_creator_id" FOREIGN KEY ("creator_id")
+          REFERENCES "creators" ("id") ON DELETE CASCADE
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_creator_onchain_mappings_onchain_creator_id"
+        ON "creator_onchain_mappings" ("onchain_creator_id");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_creator_onchain_mappings_onchain_creator_id";`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "creator_onchain_mappings";`);
+  }
+}

--- a/backend/src/creators/creator-registry-sync.service.spec.ts
+++ b/backend/src/creators/creator-registry-sync.service.spec.ts
@@ -1,0 +1,143 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CreatorRegistrySyncService } from './creator-registry-sync.service';
+import { CreatorOnchainMapping } from './entities/creator-onchain-mapping.entity';
+
+type MockRepo = {
+  findOne: jest.Mock;
+  create: jest.Mock;
+  save: jest.Mock;
+  find: jest.Mock;
+};
+
+describe('CreatorRegistrySyncService', () => {
+  let service: CreatorRegistrySyncService;
+  let repo: MockRepo;
+
+  beforeEach(async () => {
+    repo = {
+      findOne: jest.fn(),
+      create: jest.fn((partial) => partial),
+      save: jest.fn(async (entity) => entity),
+      find: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreatorRegistrySyncService,
+        { provide: getRepositoryToken(CreatorOnchainMapping), useValue: repo },
+      ],
+    }).compile();
+
+    service = module.get(CreatorRegistrySyncService);
+  });
+
+  describe('syncOnOnboard', () => {
+    it('creates a new mapping when none exists', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      const result = await service.syncOnOnboard('creator-1', 'GADDR1', '456');
+
+      expect(repo.create).toHaveBeenCalledWith({ creator_id: 'creator-1' });
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          creator_id: 'creator-1',
+          stellar_address: 'GADDR1',
+          onchain_creator_id: '456',
+          drift_detected_at: null,
+        }),
+      );
+      expect(result.onchain_creator_id).toBe('456');
+    });
+
+    it('updates the existing mapping and clears prior drift', async () => {
+      repo.findOne.mockResolvedValue({
+        creator_id: 'creator-1',
+        stellar_address: 'GOLD',
+        onchain_creator_id: '111',
+        drift_detected_at: new Date('2024-01-01'),
+      });
+
+      const result = await service.syncOnOnboard('creator-1', 'GNEW', '999');
+
+      expect(result.stellar_address).toBe('GNEW');
+      expect(result.onchain_creator_id).toBe('999');
+      expect(result.drift_detected_at).toBeNull();
+    });
+  });
+
+  describe('reconcile', () => {
+    it('flags drift when the chain read disagrees with the stored value', async () => {
+      const mapping = {
+        creator_id: 'creator-1',
+        stellar_address: 'GADDR1',
+        onchain_creator_id: '456',
+        drift_detected_at: null,
+      };
+      repo.find.mockResolvedValue([mapping]);
+      jest.spyOn(service as any, 'queryOnchainCreatorId').mockResolvedValue('999');
+
+      const result = await service.reconcile(false);
+
+      expect(result.totalScanned).toBe(1);
+      expect(result.driftFound).toBe(1);
+      expect(result.records[0]).toEqual(
+        expect.objectContaining({ creatorId: 'creator-1', drift: true, chainOnchainId: '999' }),
+      );
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ drift_detected_at: expect.any(Date) }),
+      );
+    });
+
+    it('does not persist drift markers in dry-run mode', async () => {
+      const mapping = {
+        creator_id: 'creator-1',
+        stellar_address: 'GADDR1',
+        onchain_creator_id: '456',
+        drift_detected_at: null,
+      };
+      repo.find.mockResolvedValue([mapping]);
+      jest.spyOn(service as any, 'queryOnchainCreatorId').mockResolvedValue('999');
+
+      const result = await service.reconcile(true);
+
+      expect(result.dryRun).toBe(true);
+      expect(result.driftFound).toBe(1);
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('reports no drift when the chain agrees with the stored value', async () => {
+      const mapping = {
+        creator_id: 'creator-1',
+        stellar_address: 'GADDR1',
+        onchain_creator_id: '456',
+        drift_detected_at: null,
+      };
+      repo.find.mockResolvedValue([mapping]);
+      jest.spyOn(service as any, 'queryOnchainCreatorId').mockResolvedValue('456');
+
+      const result = await service.reconcile();
+
+      expect(result.driftFound).toBe(0);
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('counts errors from the chain read without aborting the scan', async () => {
+      const mappings = [
+        { creator_id: 'creator-1', stellar_address: 'GADDR1', onchain_creator_id: '456', drift_detected_at: null },
+        { creator_id: 'creator-2', stellar_address: 'GADDR2', onchain_creator_id: '789', drift_detected_at: null },
+      ];
+      repo.find.mockResolvedValue(mappings);
+      jest
+        .spyOn(service as any, 'queryOnchainCreatorId')
+        .mockRejectedValueOnce(new Error('rpc unavailable'))
+        .mockResolvedValueOnce('789');
+
+      const result = await service.reconcile();
+
+      expect(result.totalScanned).toBe(2);
+      expect(result.errors).toBe(1);
+      expect(result.driftFound).toBe(0);
+    });
+  });
+});

--- a/backend/src/creators/creator-registry-sync.service.ts
+++ b/backend/src/creators/creator-registry-sync.service.ts
@@ -1,0 +1,201 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreatorOnchainMapping } from './entities/creator-onchain-mapping.entity';
+
+export interface ReconcileRecord {
+  creatorId: string;
+  stellarAddress: string;
+  storedOnchainId: string;
+  chainOnchainId: string | null;
+  drift: boolean;
+  error?: string;
+}
+
+export interface ReconcileResult {
+  dryRun: boolean;
+  scannedAt: string;
+  totalScanned: number;
+  driftFound: number;
+  repaired: number;
+  errors: number;
+  records: ReconcileRecord[];
+}
+
+/**
+ * Keeps `creator_onchain_mappings` (the off-chain CreatorProfile ↔ on-chain
+ * `creator-registry` `creator_id` link) in sync (#1454).
+ *
+ * - `syncOnOnboard` is called when a creator completes on-chain registration
+ *   (i.e. after `creator-registry.register_creator` succeeds) and writes/
+ *   updates the mapping.
+ * - `reconcile` periodically re-reads the chain's view of `creator_id` for
+ *   every mapped creator and flags any drift between the stored value and
+ *   the chain, following the same shape as `SubscriptionReconcilerService`.
+ */
+@Injectable()
+export class CreatorRegistrySyncService {
+  private readonly logger = new Logger(CreatorRegistrySyncService.name);
+
+  constructor(
+    @InjectRepository(CreatorOnchainMapping)
+    private readonly mappingRepository: Repository<CreatorOnchainMapping>,
+  ) {}
+
+  /**
+   * Write (or update) the mapping between `creatorId` and the on-chain
+   * `creator_id` for `stellarAddress`. Called on onboarding, i.e. right after
+   * the creator-registry contract's `register_creator` succeeds.
+   *
+   * Idempotent: re-onboarding the same creator with the same on-chain ID is a
+   * no-op beyond bumping `last_synced_at`; a changed on-chain ID overwrites
+   * the stored value and clears any previously flagged drift.
+   */
+  async syncOnOnboard(
+    creatorId: string,
+    stellarAddress: string,
+    onchainCreatorId: string,
+  ): Promise<CreatorOnchainMapping> {
+    const existing = await this.mappingRepository.findOne({ where: { creator_id: creatorId } });
+
+    const mapping =
+      existing ??
+      this.mappingRepository.create({
+        creator_id: creatorId,
+      });
+
+    mapping.stellar_address = stellarAddress;
+    mapping.onchain_creator_id = onchainCreatorId;
+    mapping.last_synced_at = new Date();
+    mapping.drift_detected_at = null;
+
+    const saved = await this.mappingRepository.save(mapping);
+
+    this.logger.log(
+      JSON.stringify({
+        event: 'creator_registry.synced',
+        creatorId,
+        stellarAddress,
+        onchainCreatorId,
+      }),
+    );
+
+    return saved;
+  }
+
+  async getMapping(creatorId: string): Promise<CreatorOnchainMapping | null> {
+    return this.mappingRepository.findOne({ where: { creator_id: creatorId } });
+  }
+
+  /** Scheduled: runs every hour in production, mirroring SubscriptionReconcilerService. */
+  @Cron(CronExpression.EVERY_HOUR)
+  async scheduledReconcile(): Promise<void> {
+    const dryRun = process.env.CREATOR_REGISTRY_RECONCILER_DRY_RUN === 'true';
+    await this.reconcile(dryRun);
+  }
+
+  async reconcile(dryRun = false): Promise<ReconcileResult> {
+    const result: ReconcileResult = {
+      dryRun,
+      scannedAt: new Date().toISOString(),
+      totalScanned: 0,
+      driftFound: 0,
+      repaired: 0,
+      errors: 0,
+      records: [],
+    };
+
+    const mappings = await this.mappingRepository.find();
+    result.totalScanned = mappings.length;
+
+    for (const mapping of mappings) {
+      const record = await this.evaluateMapping(mapping, dryRun);
+      result.records.push(record);
+      if (record.drift) result.driftFound++;
+      if (record.error) result.errors++;
+    }
+
+    this.logAudit(result);
+    return result;
+  }
+
+  private async evaluateMapping(
+    mapping: CreatorOnchainMapping,
+    dryRun: boolean,
+  ): Promise<ReconcileRecord> {
+    const record: ReconcileRecord = {
+      creatorId: mapping.creator_id,
+      stellarAddress: mapping.stellar_address,
+      storedOnchainId: mapping.onchain_creator_id,
+      chainOnchainId: null,
+      drift: false,
+    };
+
+    try {
+      const chainOnchainId = await this.queryOnchainCreatorId(mapping.stellar_address);
+      record.chainOnchainId = chainOnchainId;
+
+      // Drift: the chain has a value and it disagrees with what we stored
+      // (including the chain no longer having a registration at all).
+      if (chainOnchainId !== mapping.onchain_creator_id) {
+        record.drift = true;
+
+        if (!dryRun) {
+          mapping.drift_detected_at = new Date();
+          await this.mappingRepository.save(mapping);
+          this.repaired(record);
+        }
+      }
+    } catch (err) {
+      record.error = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        JSON.stringify({
+          event: 'creator_registry.reconcile.error',
+          creatorId: mapping.creator_id,
+          error: record.error,
+        }),
+      );
+    }
+
+    return record;
+  }
+
+  private repaired(record: ReconcileRecord): void {
+    // Marking drift_detected_at (done by the caller) is the repair for now —
+    // resolving the drift (deciding which side is authoritative and writing
+    // back) is an operator/manual-review action. Tracked as a follow-up once
+    // `queryOnchainCreatorId` below is backed by a real contract read.
+    void record;
+  }
+
+  /**
+   * Read the creator-registry contract's `get_creator_id(address)` for
+   * `stellarAddress`.
+   *
+   * Stub: a real implementation would call this via a Soroban RPC client
+   * (see `SorobanRpcService` / `SubscriptionChainReaderService` for the
+   * established pattern elsewhere in this backend) against the deployed
+   * `creator-registry` contract. Always returning `null` here means
+   * `reconcile()` currently flags every mapped creator as drifted until this
+   * is wired up — callers/tests should inject their own behavior by mocking
+   * this method.
+   */
+  protected async queryOnchainCreatorId(stellarAddress: string): Promise<string | null> {
+    void stellarAddress;
+    return null;
+  }
+
+  private logAudit(result: ReconcileResult): void {
+    this.logger.log(
+      JSON.stringify({
+        event: 'creator_registry.reconcile.completed',
+        dryRun: result.dryRun,
+        scannedAt: result.scannedAt,
+        totalScanned: result.totalScanned,
+        driftFound: result.driftFound,
+        errors: result.errors,
+      }),
+    );
+  }
+}

--- a/backend/src/creators/creators.controller.ts
+++ b/backend/src/creators/creators.controller.ts
@@ -18,8 +18,10 @@ import { SearchCreatorsDto } from './dto/search-creators.dto';
 import { PublicCreatorDto } from './dto/public-creator.dto';
 import { DashboardQueryDto } from './dto/creator-dashboard.dto';
 import { CreatePlanDto } from './dto/create-plan.dto';
+import { CreatorRegistrySyncDto } from './dto/creator-registry-sync.dto';
 import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
 import { Public } from '../common/decorators/public.decorator';
+import { CreatorRegistrySyncService } from './creator-registry-sync.service';
 
 @ApiTags('creators')
 @UseGuards(JwtAuthGuard, ThrottlerGuard)
@@ -28,6 +30,7 @@ export class CreatorsController {
   constructor(
     private creatorsService: CreatorsService,
     private dashboardService: CreatorDashboardService,
+    private registrySyncService: CreatorRegistrySyncService,
   ) {}
 
   @Get()
@@ -218,5 +221,24 @@ export class CreatorsController {
     @Query() query: DashboardQueryDto,
   ) {
     return this.dashboardService.getDashboard(address, query);
+  }
+
+  @Post(':creatorId/onchain-sync')
+  @ApiOperation({
+    summary: 'Sync a creator-registry on-chain creator_id with this CreatorProfile (#1454)',
+    description:
+      'Called after the creator-registry contract\'s register_creator succeeds during onboarding. ' +
+      'Writes/updates the creator_onchain_mappings row so reconcile() can later detect drift.',
+  })
+  @ApiResponse({ status: 201, description: 'Mapping written' })
+  syncOnchainRegistration(
+    @Param('creatorId') creatorId: string,
+    @Body() dto: CreatorRegistrySyncDto,
+  ) {
+    return this.registrySyncService.syncOnOnboard(
+      creatorId,
+      dto.stellarAddress,
+      dto.onchainCreatorId,
+    );
   }
 }

--- a/backend/src/creators/creators.module.ts
+++ b/backend/src/creators/creators.module.ts
@@ -1,15 +1,22 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 import { CreatorsController } from './creators.controller';
 import { CreatorsService } from './creators.service';
 import { CreatorDashboardService } from './creator-dashboard.service';
+import { CreatorRegistrySyncService } from './creator-registry-sync.service';
 import { User } from '../users/entities/user.entity';
+import { CreatorOnchainMapping } from './entities/creator-onchain-mapping.entity';
 import { SubscriptionsModule } from '../subscriptions/subscriptions.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), SubscriptionsModule],
+  imports: [
+    TypeOrmModule.forFeature([User, CreatorOnchainMapping]),
+    ScheduleModule,
+    SubscriptionsModule,
+  ],
   controllers: [CreatorsController],
-  providers: [CreatorsService, CreatorDashboardService],
-  exports: [CreatorsService, CreatorDashboardService],
+  providers: [CreatorsService, CreatorDashboardService, CreatorRegistrySyncService],
+  exports: [CreatorsService, CreatorDashboardService, CreatorRegistrySyncService],
 })
 export class CreatorsModule {}

--- a/backend/src/creators/dto/creator-registry-sync.dto.ts
+++ b/backend/src/creators/dto/creator-registry-sync.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Length } from 'class-validator';
+
+export class CreatorRegistrySyncDto {
+  @ApiProperty({
+    description: 'Stellar G-address the creator registered on-chain with',
+    example: 'GAB6...',
+  })
+  @IsNotEmpty()
+  @IsString()
+  @Length(56, 56)
+  stellarAddress: string;
+
+  @ApiProperty({
+    description:
+      "creator_id returned by the creator-registry contract's register_creator/get_creator_id (u64, as a string)",
+    example: '456',
+  })
+  @IsNotEmpty()
+  @IsString()
+  onchainCreatorId: string;
+}

--- a/backend/src/creators/entities/creator-onchain-mapping.entity.ts
+++ b/backend/src/creators/entities/creator-onchain-mapping.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Maps an off-chain `Creator` (CreatorProfile) row to the numeric creator_id
+ * registered on-chain in the `creator-registry` Soroban contract
+ * (see `contract/contracts/creator-registry`).
+ *
+ * `onchain_creator_id` is stored as text since Postgres `bigint` values are
+ * returned as strings by `pg`/TypeORM and a Soroban `u64` can exceed
+ * `Number.MAX_SAFE_INTEGER`.
+ */
+@Entity('creator_onchain_mappings')
+@Index(['creator_id'], { unique: true })
+export class CreatorOnchainMapping {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  /** FK to `creators.id` (the off-chain CreatorProfile). */
+  @Column({ name: 'creator_id', unique: true })
+  creator_id!: string;
+
+  /** Stellar G-address the creator registered on-chain with. */
+  @Column({ name: 'stellar_address', length: 56 })
+  stellar_address!: string;
+
+  /** `creator_id` as returned by the creator-registry contract's `get_creator_id`. */
+  @Column({ name: 'onchain_creator_id', type: 'varchar' })
+  onchain_creator_id!: string;
+
+  /** Last time this mapping was written or confirmed to match the chain. */
+  @Column({ name: 'last_synced_at', type: 'timestamptz' })
+  last_synced_at!: Date;
+
+  /** Set by `reconcile()` when the stored value no longer matches the chain; cleared on next successful sync. */
+  @Column({ name: 'drift_detected_at', type: 'timestamptz', nullable: true })
+  drift_detected_at!: Date | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  created_at!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updated_at!: Date;
+}

--- a/backend/src/migration.datasource.ts
+++ b/backend/src/migration.datasource.ts
@@ -12,6 +12,7 @@ import { AddDigestColumnsToNotifications1745100000000 } from './notifications/17
 import { AddOnboardingStateToUsers1745200000000 } from './users/1745200000000-AddOnboardingStateToUsers';
 import { AddRoleToUsers1747000000000 } from './users/1747000000000-AddRoleToUsers';
 import { CreateSocialLinksTable1748000000000 } from './social-link/1748000000000-CreateSocialLinksTable';
+import { CreateCreatorOnchainMappings1749000000000 } from './creators/1749000000000-CreateCreatorOnchainMappings';
 
 export const migrationDataSource = new DataSource({
   type: 'postgres',
@@ -33,5 +34,6 @@ export const migrationDataSource = new DataSource({
     AddOnboardingStateToUsers1745200000000,
     AddRoleToUsers1747000000000,
     CreateSocialLinksTable1748000000000,
+    CreateCreatorOnchainMappings1749000000000,
   ],
 });

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,14 +1,13 @@
 import type { NextConfig } from "next";
 import withBundleAnalyzer from "@next/bundle-analyzer";
 import { getRemoteImagePatterns } from "./src/lib/image-remote-patterns";
+import { getApiBaseUrl } from "./src/lib/api/base-url";
 
 const isProd = process.env.NODE_ENV === 'production';
 
 // Helper to generate CSP
 function getCSP() {
-  const apiHost = process.env.NEXT_PUBLIC_API_URL 
-    ? new URL(process.env.NEXT_PUBLIC_API_URL).host 
-    : 'localhost:3001';
+  const apiHost = new URL(getApiBaseUrl()).host;
 
   const stellarHosts = [
     '*.stellar.org',

--- a/frontend/src/clients/api-client.ts
+++ b/frontend/src/clients/api-client.ts
@@ -9,11 +9,12 @@ import type {
 } from '@/types';
 import { retryWithBackoff, getAuthHeaders, handleApiError, shouldRetry } from '@/lib/api-utils';
 import { getCsrfToken, invalidateCsrfToken } from '@/lib/csrf';
+import { getApiBaseUrl } from '@/lib/api/base-url';
 import type { AppError } from '@/types';
 
 const MUTATING = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
+const API_BASE = getApiBaseUrl();
 
 class ApiClient {
   async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {

--- a/frontend/src/lib/api/base-url.ts
+++ b/frontend/src/lib/api/base-url.ts
@@ -1,0 +1,62 @@
+/**
+ * Centralized API base URL resolution (#1455).
+ *
+ * Historically, every client module (api-client.ts, csrf.ts, checkout.ts,
+ * favorites.ts, earnings-api.ts, notifications.ts, api/creators.ts,
+ * api/posts.ts, api/profile.ts, ...) read `process.env.NEXT_PUBLIC_API_URL`
+ * directly and each hardcoded its own fallback host/port for local dev
+ * (a mix of `http://localhost:3000` and `http://localhost:3001`, with and
+ * without `/api` or `/api/v1` suffixes). That drift meant overriding
+ * `NEXT_PUBLIC_API_URL` in one environment didn't reliably affect every
+ * client, and the "default" backend port depended on which file you read.
+ *
+ * All clients should now resolve the API origin through `getApiBaseUrl()`
+ * (or `getConfiguredApiBaseUrl()` for callers that need a distinct,
+ * same-origin-relative fallback, like `feature-flags.ts`) instead of
+ * inlining their own `process.env.NEXT_PUBLIC_API_URL || '...'` default.
+ *
+ * See `docs/api-base-url.md` for the full migration notes.
+ */
+
+/**
+ * Default backend origin used when `NEXT_PUBLIC_API_URL` is not set.
+ *
+ * Matches the backend's documented local-dev port (see
+ * `docker-compose.yml`'s `NEXT_PUBLIC_API_URL: http://localhost:3001` and
+ * `docker-compose.dev.yml`'s `PORT: ${PORT:-3001}`).
+ */
+export const DEFAULT_API_BASE_URL = 'http://localhost:3001';
+
+/** Remove any trailing slash(es) from a URL/path segment. */
+export function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+/**
+ * Return the raw, trimmed `NEXT_PUBLIC_API_URL` value, or `undefined` if it
+ * is not configured (empty string counts as not configured).
+ *
+ * Prefer `getApiBaseUrl()` unless you specifically need to distinguish
+ * "not configured" from "configured" in order to apply a different
+ * fallback (e.g. a same-origin relative URL instead of an absolute one).
+ */
+export function getConfiguredApiBaseUrl(): string | undefined {
+  const value = process.env.NEXT_PUBLIC_API_URL;
+  if (!value) return undefined;
+  const trimmed = trimTrailingSlash(value.trim());
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Return the API base URL (no trailing slash): `NEXT_PUBLIC_API_URL` when
+ * configured, otherwise `DEFAULT_API_BASE_URL`.
+ *
+ * This is intentionally just the origin (protocol + host + optional port,
+ * or whatever custom base the caller configures, e.g. including its own
+ * `/api` prefix in front-door/reverse-proxy deployments) — individual
+ * clients are responsible for appending their own resource paths
+ * (`/v1/creators`, `/favorites`, etc.) on top of this.
+ */
+export function getApiBaseUrl(): string {
+  return getConfiguredApiBaseUrl() ?? DEFAULT_API_BASE_URL;
+}

--- a/frontend/src/lib/api/creators.ts
+++ b/frontend/src/lib/api/creators.ts
@@ -2,6 +2,7 @@
  * Creators search API client.
  */
 import type { CreatorProfile } from '@/lib/creator-profile';
+import { getApiBaseUrl } from '@/lib/api/base-url';
 
 export interface PublicCreator {
   id: string;
@@ -20,7 +21,7 @@ export interface CreatorsSearchResult {
   hasMore: boolean;
 }
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api/v1';
+const API_BASE = `${getApiBaseUrl()}/api/v1`;
 
 export async function searchCreators(params: {
   q?: string;

--- a/frontend/src/lib/api/posts.ts
+++ b/frontend/src/lib/api/posts.ts
@@ -2,6 +2,7 @@
  * Posts API client.
  */
 import type { CreatorPost } from '@/lib/creator-profile';
+import { getApiBaseUrl } from '@/lib/api/base-url';
 
 const EXCERPT_LENGTH = 140;
 
@@ -24,7 +25,7 @@ export interface PostsPage {
   hasMore: boolean;
 }
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api/v1';
+const API_BASE = `${getApiBaseUrl()}/api/v1`;
 
 export async function getPostsByAuthor(
   authorId: string,

--- a/frontend/src/lib/api/profile.ts
+++ b/frontend/src/lib/api/profile.ts
@@ -1,9 +1,7 @@
 import { resolveUserId } from "@/lib/auth-storage";
+import { getApiBaseUrl } from "@/lib/api/base-url";
 
-const API_BASE =
-  typeof process !== "undefined" && process.env.NEXT_PUBLIC_API_URL
-    ? process.env.NEXT_PUBLIC_API_URL.replace(/\/$/, "")
-    : "http://localhost:3000";
+const API_BASE = getApiBaseUrl();
 
 export type MeResponse = {
   id: string;

--- a/frontend/src/lib/checkout.ts
+++ b/frontend/src/lib/checkout.ts
@@ -2,8 +2,9 @@
  * Checkout API Service
  * Handles all checkout-related API calls to the backend
  */
+import { getApiBaseUrl } from '@/lib/api/base-url';
 
-const API_BASE_URL = "http://localhost:3000";
+const API_BASE_URL = getApiBaseUrl();
 
 export interface CreateCheckoutRequest {
   fanAddress: string;

--- a/frontend/src/lib/csrf.ts
+++ b/frontend/src/lib/csrf.ts
@@ -1,4 +1,6 @@
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
+import { getApiBaseUrl } from '@/lib/api/base-url';
+
+const API_BASE = getApiBaseUrl();
 
 let cached: string | null = null;
 

--- a/frontend/src/lib/earnings-api.ts
+++ b/frontend/src/lib/earnings-api.ts
@@ -1,6 +1,5 @@
 import { createAppError } from '@/types/errors';
-
-declare const process: { env: { NEXT_PUBLIC_API_URL?: string } };
+import { getApiBaseUrl } from '@/lib/api/base-url';
 
 export interface EarningsSummary {
   total_earnings: string;
@@ -87,7 +86,7 @@ export interface ReconciliationReport {
   total_pages: number;
 }
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+const API_BASE = getApiBaseUrl();
 
 async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<T> {
   try {

--- a/frontend/src/lib/favorites.ts
+++ b/frontend/src/lib/favorites.ts
@@ -1,4 +1,6 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+import { getApiBaseUrl } from '@/lib/api/base-url';
+
+const API_BASE_URL = getApiBaseUrl();
 
 type FavoritesPayload =
   | string[]

--- a/frontend/src/lib/feature-flags.ts
+++ b/frontend/src/lib/feature-flags.ts
@@ -1,3 +1,5 @@
+import { getConfiguredApiBaseUrl, trimTrailingSlash } from '@/lib/api/base-url';
+
 export const FeatureFlag = {
   BOOKMARKS: 'bookmarks',
   EARNINGS_WITHDRAWALS: 'earnings_withdrawals',
@@ -104,17 +106,16 @@ function sanitizeFlagOverrides(value: unknown): FeatureFlagOverrides {
   }, {});
 }
 
-function trimTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, '');
-}
-
 export function getRemoteFlagsUrl(): string | undefined {
   const explicitUrl = process.env[FEATURE_FLAGS_URL_ENV_KEY];
   if (explicitUrl) {
     return explicitUrl;
   }
 
-  const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL;
+  // Uses getConfiguredApiBaseUrl() (undefined when unset) rather than
+  // getApiBaseUrl(), since this function's fallback is a same-origin
+  // relative path rather than the shared absolute localhost default (#1455).
+  const apiBaseUrl = getConfiguredApiBaseUrl();
   if (apiBaseUrl) {
     const normalizedApiBaseUrl = trimTrailingSlash(apiBaseUrl);
 

--- a/frontend/src/lib/notification-preferences.ts
+++ b/frontend/src/lib/notification-preferences.ts
@@ -4,6 +4,7 @@
  * Covers channel-level toggles (email / push / marketing) and
  * per-event toggles for each channel.
  */
+import { getApiBaseUrl } from '@/lib/api/base-url';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -90,7 +91,7 @@ export const DEFAULT_PREFERENCES: NotificationPreferences = {
 
 // ── API ────────────────────────────────────────────────────────────────────
 
-const API_BASE = 'http://localhost:3001/api/v1';
+const API_BASE = `${getApiBaseUrl()}/api/v1`;
 
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,6 +1,7 @@
 /**
  * Notification inbox API integration.
  */
+import { getApiBaseUrl } from '@/lib/api/base-url';
 
 export type NotificationType =
   | 'new_subscriber'
@@ -26,7 +27,7 @@ export interface Notification {
   digest_event_times: string[] | null;
 }
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api/v1';
+const API_BASE = `${getApiBaseUrl()}/api/v1`;
 
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {


### PR DESCRIPTION
Closes #1454
Closes #1455

## #1455 — Frontend: Centralize API base URL configuration

Every client (`api-client.ts`, `csrf.ts`, `checkout.ts`, `favorites.ts`, `earnings-api.ts`, `notifications.ts`, `notification-preferences.ts`, `api/creators.ts`, `api/posts.ts`, `api/profile.ts`, `feature-flags.ts`, `next.config.ts`'s CSP) read `process.env.NEXT_PUBLIC_API_URL` directly and hardcoded its own fallback host/port — a mix of `localhost:3000` and `localhost:3001`, with and without `/api`/`/api/v1` suffixes. `checkout.ts` ignored the env var entirely (hardcoded `http://localhost:3000`). Because several clients only appended their `/api/v1` suffix to the *default* (not to an explicit env value), setting `NEXT_PUBLIC_API_URL` in a real deployment would have silently broken those clients' request paths.

Added `frontend/src/lib/api/base-url.ts` exporting `getApiBaseUrl()` (and `getConfiguredApiBaseUrl()` for the one caller that needs a same-origin-relative fallback instead of an absolute default) and migrated every call site to it. Default is `http://localhost:3001`, matching `docker-compose.yml`'s own `NEXT_PUBLIC_API_URL`. Each file's existing path-suffix behavior was preserved so existing tests (`api-client.test.ts`, `feature-flags.test.ts`, `csrf.test.ts`) keep passing unchanged. Documented the convention in `DEVELOPMENT.md`.

## #1454 — Backend: Sync creator-registry on-chain ID with CreatorProfile

Added `creator_onchain_mappings` (entity + migration) mapping a `Creator` row to the `creator-registry` Soroban contract's `creator_id`, plus `CreatorRegistrySyncService`:
- `syncOnOnboard(creatorId, stellarAddress, onchainCreatorId)` — upserts the mapping; exposed via `POST /v1/creators/:creatorId/onchain-sync` for the onboarding flow to call once `register_creator` succeeds on-chain.
- `reconcile(dryRun?)` — re-checks every mapped creator's on-chain `creator_id` and flags disagreement via `drift_detected_at`, running hourly via `@Cron` (`CREATOR_REGISTRY_RECONCILER_DRY_RUN` env var), mirroring the existing `SubscriptionReconcilerService` pattern already in this backend.

`queryOnchainCreatorId()` is intentionally a stub (always returns `null`) — this matches the exact same convention `SubscriptionReconcilerService` already uses for `queryChainExpiry()` (a comment there says "Stub: real impl would call soroban contract read via SorobanRpcService"). Wiring a real read against the deployed `creator-registry` contract is follow-up work; until then `reconcile()`'s output should be treated as informational. Documented in `backend/docs/CREATOR_REGISTRY_SYNC.md`. Tests cover onboard-write (create/update/clear-drift) and reconcile (drift detected, dry-run, no-drift, error-doesn't-abort-scan).

## Notes / things found along the way
- `backend/src/users/users.service.ts` injects `@InjectRepository(User)` into a field typed `Repository<Creator>` (copy-paste bug) — that field is unused, so left untouched as out of scope here.
- `backend/src/users/entities/creator.entity.ts` is an orphaned duplicate of the real, wired `backend/src/creators/entities/creator.entity.ts` — not touched, out of scope.