### PR TITLE
feat:  Adds four backend features to bring comments to audit parity with posts, aggregate a personalized fan feed, implement the favorites API the frontend already calls, and expose Stellar network config for client discovery.

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -27,6 +27,9 @@ import { FeatureFlagsModule } from './feature-flags/feature-flags.module';
 import { ReferralModule } from './referral/referral.module';
 import { CsrfModule } from './csrf/csrf.module';
 import { SocialLinksModule } from './social-link/social-links.module';
+import { FeedModule } from './feed/feed.module';
+import { FavoritesModule } from './favorites/favorites.module';
+import { NetworkConfigModule } from './config/network-config.module';
 import { CsrfMiddleware } from './common/middleware/csrf.middleware';
 import { CorrelationExceptionFilter } from './common/filters/correlation-exception.filter';
 import { RequestContextService } from './common/services/request-context.service';
@@ -64,6 +67,9 @@ const IDEMPOTENCY_ROUTES = [
     ReferralModule,
     CsrfModule,
     SocialLinksModule,
+    FeedModule,
+    FavoritesModule,
+    NetworkConfigModule,
   ],
   controllers: [AppController, OpenAPIController],
   providers: [

--- a/backend/src/comments/1753000000000-AddCommentSoftDeleteAndAudit.ts
+++ b/backend/src/comments/1753000000000-AddCommentSoftDeleteAndAudit.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCommentSoftDeleteAndAudit1753000000000
+  implements MigrationInterface
+{
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "comments"
+      ADD COLUMN "deletedAt" TIMESTAMP NULL,
+      ADD COLUMN "deletedBy" character varying NULL
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_comments_deletedAt" ON "comments" ("deletedAt")`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "comment_audit_logs" (
+        "id"         uuid              NOT NULL DEFAULT uuid_generate_v4(),
+        "commentId"  character varying NOT NULL,
+        "deletedBy"  character varying NOT NULL,
+        "action"     character varying NOT NULL DEFAULT 'soft_delete',
+        "createdAt"  TIMESTAMP         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_comment_audit_logs" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_comment_audit_logs_commentId" ON "comment_audit_logs" ("commentId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_comment_audit_logs_deletedBy" ON "comment_audit_logs" ("deletedBy")`,
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_comment_audit_logs_deletedBy"`);
+    await queryRunner.query(`DROP INDEX "IDX_comment_audit_logs_commentId"`);
+    await queryRunner.query(`DROP TABLE "comment_audit_logs"`);
+
+    await queryRunner.query(`DROP INDEX "IDX_comments_deletedAt"`);
+    await queryRunner.query(`
+      ALTER TABLE "comments"
+      DROP COLUMN "deletedBy",
+      DROP COLUMN "deletedAt"
+    `);
+  }
+}

--- a/backend/src/comments/comments.module.ts
+++ b/backend/src/comments/comments.module.ts
@@ -3,9 +3,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommentsController } from './comments.controller';
 import { CommentsService } from './comments.service';
 import { Comment } from './entities/comment.entity';
+import { CommentAuditLog } from './entities/comment-audit-log.entity';
+import { EventsModule } from '../events/events.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Comment])],
+  imports: [TypeOrmModule.forFeature([Comment, CommentAuditLog]), EventsModule],
   controllers: [CommentsController],
   providers: [CommentsService],
   exports: [CommentsService],

--- a/backend/src/comments/comments.service.spec.ts
+++ b/backend/src/comments/comments.service.spec.ts
@@ -3,6 +3,9 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { CommentsService } from './comments.service';
 import { Comment } from './entities/comment.entity';
+import { CommentAuditLog } from './entities/comment-audit-log.entity';
+import { EventBus } from '../events/event-bus';
+import { CommentDeletedEvent } from '../events/domain-events';
 
 const makeComment = (overrides: Partial<Comment> = {}): Comment =>
   ({
@@ -13,6 +16,8 @@ const makeComment = (overrides: Partial<Comment> = {}): Comment =>
     parentId: null,
     createdAt: new Date('2026-01-01T00:00:00Z'),
     updatedAt: new Date('2026-01-01T00:00:00Z'),
+    deletedAt: null,
+    deletedBy: null,
     ...overrides,
   }) as Comment;
 
@@ -24,7 +29,10 @@ describe('CommentsService', () => {
     findOne: jest.Mock;
     findAndCount: jest.Mock;
     remove: jest.Mock;
+    delete: jest.Mock;
   };
+  let auditRepo: { create: jest.Mock; save: jest.Mock };
+  let eventBus: { publish: jest.Mock };
 
   beforeEach(async () => {
     repo = {
@@ -33,12 +41,20 @@ describe('CommentsService', () => {
       findOne: jest.fn(),
       findAndCount: jest.fn(),
       remove: jest.fn(),
+      delete: jest.fn(),
     };
+    auditRepo = {
+      create: jest.fn((data: unknown) => data),
+      save: jest.fn((e: unknown) => Promise.resolve(e)),
+    };
+    eventBus = { publish: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CommentsService,
         { provide: getRepositoryToken(Comment), useValue: repo },
+        { provide: getRepositoryToken(CommentAuditLog), useValue: auditRepo },
+        { provide: EventBus, useValue: eventBus },
       ],
     }).compile();
 
@@ -143,6 +159,19 @@ describe('CommentsService', () => {
       expect(result.limit).toBe(20);
     });
 
+    it('filters by deletedAt: IsNull()', async () => {
+      repo.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ page: 1, limit: 20 });
+
+      expect(repo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- jest matcher typings are `any`
+          where: expect.objectContaining({ deletedAt: expect.anything() }),
+        }),
+      );
+    });
+
     it('returns empty list when there are no comments', async () => {
       repo.findAndCount.mockResolvedValue([[], 0]);
 
@@ -186,7 +215,7 @@ describe('CommentsService', () => {
   // ── findByPost ───────────────────────────────────────────────────────────────
 
   describe('findByPost', () => {
-    it('returns comments filtered by postId', async () => {
+    it('returns comments filtered by postId and deletedAt: IsNull()', async () => {
       const comment = makeComment({ postId: 'post-42' });
       repo.findAndCount.mockResolvedValue([[comment], 1]);
 
@@ -196,7 +225,13 @@ describe('CommentsService', () => {
       });
 
       expect(repo.findAndCount).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { postId: 'post-42' } }),
+        expect.objectContaining({
+          where: expect.objectContaining({
+            postId: 'post-42',
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- jest matcher typings are `any`
+            deletedAt: expect.anything(),
+          }),
+        }),
       );
       expect(result.data).toHaveLength(1);
       expect(result.data[0].postId).toBe('post-42');
@@ -244,7 +279,11 @@ describe('CommentsService', () => {
 
       const result = await service.findOne('comment-1');
 
-      expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 'comment-1' } });
+      expect(repo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: 'comment-1' }),
+        }),
+      );
       expect(result.id).toBe('comment-1');
       expect(result.content).toBe('Great post!');
     });
@@ -261,6 +300,14 @@ describe('CommentsService', () => {
       repo.findOne.mockResolvedValue(null);
 
       await expect(service.findOne('missing-id')).rejects.toThrow('missing-id');
+    });
+
+    it('throws NotFoundException for a soft-deleted comment (filtered by IsNull)', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('comment-1')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
     });
   });
 
@@ -289,7 +336,11 @@ describe('CommentsService', () => {
 
       await service.update('comment-1', { content: 'New content' }, 'author-1');
 
-      expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 'comment-1' } });
+      expect(repo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: 'comment-1' }),
+        }),
+      );
     });
 
     it('throws NotFoundException when comment does not exist', async () => {
@@ -335,23 +386,64 @@ describe('CommentsService', () => {
     });
   });
 
-  // ── remove ───────────────────────────────────────────────────────────────────
+  // ── remove (soft delete) ─────────────────────────────────────────────────────
 
   describe('remove', () => {
-    it('removes the comment when it exists', async () => {
-      const comment = makeComment();
+    it('sets deletedAt and deletedBy then saves', async () => {
+      const comment = makeComment({ authorId: 'author-1' });
       repo.findOne.mockResolvedValue(comment);
-      repo.remove.mockResolvedValue(undefined);
+      repo.save.mockResolvedValue({
+        ...comment,
+        deletedAt: new Date(),
+        deletedBy: 'author-1',
+      });
 
       await service.remove('comment-1', 'author-1');
 
-      expect(repo.remove).toHaveBeenCalledWith(comment);
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ deletedBy: 'author-1' }),
+      );
+      expect(comment.deletedAt).not.toBeNull();
+      expect(repo.remove).not.toHaveBeenCalled();
+    });
+
+    it('persists an audit log row with correct fields', async () => {
+      const comment = makeComment({ authorId: 'author-1' });
+      repo.findOne.mockResolvedValue(comment);
+      repo.save.mockResolvedValue(comment);
+
+      await service.remove('comment-1', 'author-1');
+
+      expect(auditRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          commentId: 'comment-1',
+          deletedBy: 'author-1',
+          action: 'soft_delete',
+        }),
+      );
+      expect(auditRepo.save).toHaveBeenCalled();
+    });
+
+    it('emits CommentDeletedEvent with correct commentId and deletedBy', async () => {
+      const comment = makeComment({ authorId: 'author-1' });
+      repo.findOne.mockResolvedValue(comment);
+      repo.save.mockResolvedValue(comment);
+
+      await service.remove('comment-1', 'author-1');
+
+      expect(eventBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'comment.deleted',
+          commentId: 'comment-1',
+          deletedBy: 'author-1',
+        }),
+      );
     });
 
     it('returns void on success', async () => {
       const comment = makeComment();
       repo.findOne.mockResolvedValue(comment);
-      repo.remove.mockResolvedValue(undefined);
+      repo.save.mockResolvedValue(comment);
 
       const result = await service.remove('comment-1', 'author-1');
 
@@ -364,14 +456,37 @@ describe('CommentsService', () => {
       await expect(
         service.remove('missing', 'author-1'),
       ).rejects.toBeInstanceOf(NotFoundException);
+      expect(eventBus.publish).not.toHaveBeenCalled();
+      expect(auditRepo.save).not.toHaveBeenCalled();
     });
 
-    it('does not call remove when comment is not found', async () => {
+    it('does not emit event or write audit log when comment is already soft-deleted', async () => {
+      // IsNull() filter means the repo returns null for already-deleted comments
       repo.findOne.mockResolvedValue(null);
 
-      await expect(service.remove('missing', 'author-1')).rejects.toThrow();
+      await expect(
+        service.remove('comment-1', 'author-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(eventBus.publish).not.toHaveBeenCalled();
+      expect(auditRepo.save).not.toHaveBeenCalled();
+    });
 
-      expect(repo.remove).not.toHaveBeenCalled();
+    it('audit log is written before event is published', async () => {
+      const order: string[] = [];
+      const comment = makeComment({ authorId: 'author-1' });
+      repo.findOne.mockResolvedValue(comment);
+      repo.save.mockResolvedValue(comment);
+      auditRepo.save.mockImplementation((e: unknown) => {
+        order.push('audit');
+        return Promise.resolve(e);
+      });
+      eventBus.publish.mockImplementation(() => {
+        order.push('event');
+      });
+
+      await service.remove('comment-1', 'author-1');
+
+      expect(order).toEqual(['audit', 'event']);
     });
 
     it('throws ForbiddenException when the requester is not the author', async () => {
@@ -381,7 +496,47 @@ describe('CommentsService', () => {
       await expect(
         service.remove('comment-1', 'someone-else'),
       ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(repo.save).not.toHaveBeenCalled();
+      expect(auditRepo.save).not.toHaveBeenCalled();
+      expect(eventBus.publish).not.toHaveBeenCalled();
       expect(repo.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── hardDelete ───────────────────────────────────────────────────────────────
+
+  describe('hardDelete', () => {
+    it('is not the default deletion path (hard-deletes only when called explicitly)', async () => {
+      repo.delete.mockResolvedValue({ affected: 1 });
+
+      await service.hardDelete('comment-1');
+
+      expect(repo.delete).toHaveBeenCalledWith('comment-1');
+    });
+
+    it('throws NotFoundException when nothing was deleted', async () => {
+      repo.delete.mockResolvedValue({ affected: 0 });
+
+      await expect(service.hardDelete('missing')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── CommentDeletedEvent ──────────────────────────────────────────────────────
+
+  describe('CommentDeletedEvent', () => {
+    it('has the correct type discriminant', () => {
+      const event = new CommentDeletedEvent('c1', 'u1');
+      expect(event.type).toBe('comment.deleted');
+      expect(event.commentId).toBe('c1');
+      expect(event.deletedBy).toBe('u1');
+    });
+
+    it('records a timestamp', () => {
+      const before = Date.now();
+      const event = new CommentDeletedEvent('c1', 'u1');
+      expect(event.timestamp).toBeGreaterThanOrEqual(before);
     });
   });
 });

--- a/backend/src/comments/comments.service.ts
+++ b/backend/src/comments/comments.service.ts
@@ -4,17 +4,23 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { plainToInstance } from 'class-transformer';
 import { Comment } from './entities/comment.entity';
+import { CommentAuditLog } from './entities/comment-audit-log.entity';
 import { CommentDto, CreateCommentDto, UpdateCommentDto } from './dto';
 import { PaginationDto, PaginatedResponseDto } from '../common/dto';
+import { EventBus } from '../events/event-bus';
+import { CommentDeletedEvent } from '../events/domain-events';
 
 @Injectable()
 export class CommentsService {
   constructor(
     @InjectRepository(Comment)
     private readonly commentsRepository: Repository<Comment>,
+    @InjectRepository(CommentAuditLog)
+    private readonly auditRepository: Repository<CommentAuditLog>,
+    private readonly eventBus: EventBus,
   ) {}
 
   private toDto(comment: Comment): CommentDto {
@@ -39,6 +45,7 @@ export class CommentsService {
     const skip = (page - 1) * limit;
 
     const [comments, total] = await this.commentsRepository.findAndCount({
+      where: { deletedAt: IsNull() },
       skip,
       take: limit,
       order: { createdAt: 'DESC' },
@@ -60,7 +67,7 @@ export class CommentsService {
     const skip = (page - 1) * limit;
 
     const [comments, total] = await this.commentsRepository.findAndCount({
-      where: { postId },
+      where: { postId, deletedAt: IsNull() },
       skip,
       take: limit,
       order: { createdAt: 'DESC' },
@@ -75,7 +82,9 @@ export class CommentsService {
   }
 
   async findOne(id: string): Promise<CommentDto> {
-    const comment = await this.commentsRepository.findOne({ where: { id } });
+    const comment = await this.commentsRepository.findOne({
+      where: { id, deletedAt: IsNull() },
+    });
     if (!comment) {
       throw new NotFoundException(`Comment with id "${id}" not found`);
     }
@@ -91,7 +100,9 @@ export class CommentsService {
     dto: UpdateCommentDto,
     requesterId: string,
   ): Promise<CommentDto> {
-    const comment = await this.commentsRepository.findOne({ where: { id } });
+    const comment = await this.commentsRepository.findOne({
+      where: { id, deletedAt: IsNull() },
+    });
     if (!comment) {
       throw new NotFoundException(`Comment with id "${id}" not found`);
     }
@@ -105,9 +116,19 @@ export class CommentsService {
     return this.toDto(updated);
   }
 
-  /** Only the comment's author may delete it; admin takedowns go through `/moderation`. */
+  /**
+   * Soft-delete a comment: sets deletedAt and deletedBy, persists an audit
+   * log row, then emits a CommentDeletedEvent for downstream consumers.
+   *
+   * Idempotent guard: throws NotFoundException if the comment is already
+   * deleted or does not exist, so callers cannot double-delete. Only the
+   * comment's author may delete it; admin takedowns go through
+   * `/moderation`.
+   */
   async remove(id: string, requesterId: string): Promise<void> {
-    const comment = await this.commentsRepository.findOne({ where: { id } });
+    const comment = await this.commentsRepository.findOne({
+      where: { id, deletedAt: IsNull() },
+    });
     if (!comment) {
       throw new NotFoundException(`Comment with id "${id}" not found`);
     }
@@ -116,6 +137,27 @@ export class CommentsService {
         'You do not have permission to delete this comment',
       );
     }
-    await this.commentsRepository.remove(comment);
+
+    comment.deletedAt = new Date();
+    comment.deletedBy = requesterId;
+    await this.commentsRepository.save(comment);
+
+    await this.auditRepository.save(
+      this.auditRepository.create({
+        commentId: id,
+        deletedBy: requesterId,
+        action: 'soft_delete',
+      }),
+    );
+
+    this.eventBus.publish(new CommentDeletedEvent(id, requesterId));
+  }
+
+  /** @deprecated Use `remove` (soft delete) instead. Hard-deletes the comment. */
+  async hardDelete(id: string): Promise<void> {
+    const res = await this.commentsRepository.delete(id);
+    if (!res.affected) {
+      throw new NotFoundException(`Comment with id "${id}" not found`);
+    }
   }
 }

--- a/backend/src/comments/entities/comment-audit-log.entity.ts
+++ b/backend/src/comments/entities/comment-audit-log.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Immutable audit record written whenever a comment is soft-deleted.
+ * One row per deletion event; never updated or hard-deleted.
+ */
+@Entity('comment_audit_logs')
+@Index(['commentId'])
+@Index(['deletedBy'])
+export class CommentAuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar' })
+  commentId: string;
+
+  @Column({ type: 'varchar' })
+  deletedBy: string;
+
+  @Column({ type: 'varchar', default: 'soft_delete' })
+  action: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/comments/entities/comment.entity.ts
+++ b/backend/src/comments/entities/comment.entity.ts
@@ -1,4 +1,13 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
 
 @Entity('comments')
 export class Comment {
@@ -22,4 +31,12 @@ export class Comment {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  /** Soft-delete timestamp. Null when the comment is active. */
+  @DeleteDateColumn({ nullable: true })
+  deletedAt: Date | null;
+
+  /** ID of the user who performed the soft delete (audit trail). */
+  @Column({ nullable: true, type: 'varchar' })
+  deletedBy: string | null;
 }

--- a/backend/src/config/dto/network-config.dto.ts
+++ b/backend/src/config/dto/network-config.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class NetworkConfigDto {
+  @ApiProperty({
+    example: 'testnet',
+    description: 'Stellar network the backend is configured against',
+    enum: ['testnet', 'futurenet', 'mainnet'],
+  })
+  @Expose()
+  network: string;
+
+  @ApiProperty({
+    example: 'Test SDF Network ; September 2015',
+    description: 'Stellar network passphrase clients must sign transactions with',
+  })
+  @Expose()
+  networkPassphrase: string;
+
+  @ApiProperty({
+    example: 'https://horizon-testnet.stellar.org',
+    description: 'Horizon endpoint for this network',
+  })
+  @Expose()
+  horizonUrl: string;
+
+  @ApiProperty({
+    example: 'https://soroban-testnet.stellar.org',
+    description: 'Soroban RPC endpoint for this network',
+  })
+  @Expose()
+  rpcUrl: string;
+}

--- a/backend/src/config/network-config.controller.spec.ts
+++ b/backend/src/config/network-config.controller.spec.ts
@@ -1,0 +1,46 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import { NetworkConfigController } from './network-config.controller';
+import { NetworkConfigService } from './network-config.service';
+import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
+
+describe('NetworkConfigController', () => {
+  let controller: NetworkConfigController;
+  let service: { getNetworkConfig: jest.Mock };
+
+  beforeEach(async () => {
+    service = { getNetworkConfig: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NetworkConfigController],
+      providers: [{ provide: NetworkConfigService, useValue: service }],
+    }).compile();
+
+    controller = module.get(NetworkConfigController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns the network config from the service', () => {
+    const config = {
+      network: 'testnet',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      rpcUrl: 'https://soroban-testnet.stellar.org',
+    };
+    service.getNetworkConfig.mockReturnValue(config);
+
+    const result = controller.getNetworkConfig();
+
+    expect(result).toBe(config);
+  });
+
+  it('is marked @Public() so it bypasses JwtAuthGuard', () => {
+    const reflector = new Reflector();
+    const isPublic = reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      NetworkConfigController.prototype.getNetworkConfig,
+      NetworkConfigController,
+    ]);
+    expect(isPublic).toBe(true);
+  });
+});

--- a/backend/src/config/network-config.controller.ts
+++ b/backend/src/config/network-config.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Public } from '../common/decorators/public.decorator';
+import { NetworkConfigService } from './network-config.service';
+import { NetworkConfigDto } from './dto/network-config.dto';
+
+/**
+ * NetworkConfigController
+ *
+ * Public, unauthenticated Stellar network discovery endpoint so clients
+ * (web, mobile, wallets) can learn which network/passphrase/RPC/Horizon
+ * endpoints to use without hardcoding them.
+ *
+ * @Controller config
+ * @version 1
+ * @tags config
+ */
+@ApiTags('config')
+@Public()
+@Controller({ path: 'config', version: '1' })
+export class NetworkConfigController {
+  constructor(private readonly networkConfigService: NetworkConfigService) {}
+
+  @Get('network')
+  @ApiOperation({
+    summary: 'Stellar network discovery',
+    description:
+      'Returns the Stellar network name, passphrase, Horizon URL, and ' +
+      'Soroban RPC URL the backend is configured against. Public — no ' +
+      'secrets are included.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Network configuration',
+    type: NetworkConfigDto,
+  })
+  getNetworkConfig(): NetworkConfigDto {
+    return this.networkConfigService.getNetworkConfig();
+  }
+}

--- a/backend/src/config/network-config.module.ts
+++ b/backend/src/config/network-config.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { NetworkConfigController } from './network-config.controller';
+import { NetworkConfigService } from './network-config.service';
+
+@Module({
+  controllers: [NetworkConfigController],
+  providers: [NetworkConfigService],
+  exports: [NetworkConfigService],
+})
+export class NetworkConfigModule {}

--- a/backend/src/config/network-config.service.spec.ts
+++ b/backend/src/config/network-config.service.spec.ts
@@ -1,0 +1,90 @@
+import { Networks } from '@stellar/stellar-sdk';
+import { NetworkConfigService } from './network-config.service';
+
+describe('NetworkConfigService', () => {
+  let service: NetworkConfigService;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    service = new NetworkConfigService();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('defaults to testnet when STELLAR_NETWORK is unset', () => {
+    delete process.env.STELLAR_NETWORK;
+
+    const result = service.getNetworkConfig();
+
+    expect(result.network).toBe('testnet');
+    expect(result.networkPassphrase).toBe(Networks.TESTNET);
+    expect(result.horizonUrl).toBe('https://horizon-testnet.stellar.org');
+    expect(result.rpcUrl).toBe('https://soroban-testnet.stellar.org');
+  });
+
+  it('resolves the mainnet passphrase and endpoints', () => {
+    process.env.STELLAR_NETWORK = 'mainnet';
+    delete process.env.STELLAR_NETWORK_PASSPHRASE;
+    delete process.env.HORIZON_URL;
+    delete process.env.SOROBAN_RPC_URL;
+
+    const result = service.getNetworkConfig();
+
+    expect(result.network).toBe('mainnet');
+    expect(result.networkPassphrase).toBe(Networks.PUBLIC);
+    expect(result.horizonUrl).toBe('https://horizon.stellar.org');
+  });
+
+  it('resolves the futurenet passphrase', () => {
+    process.env.STELLAR_NETWORK = 'futurenet';
+    delete process.env.STELLAR_NETWORK_PASSPHRASE;
+
+    const result = service.getNetworkConfig();
+
+    expect(result.networkPassphrase).toBe(Networks.FUTURENET);
+  });
+
+  it('is case-insensitive for STELLAR_NETWORK', () => {
+    process.env.STELLAR_NETWORK = 'TESTNET';
+
+    const result = service.getNetworkConfig();
+
+    expect(result.network).toBe('testnet');
+  });
+
+  it('prefers an explicit STELLAR_NETWORK_PASSPHRASE override', () => {
+    process.env.STELLAR_NETWORK = 'testnet';
+    process.env.STELLAR_NETWORK_PASSPHRASE = 'Custom Passphrase';
+
+    const result = service.getNetworkConfig();
+
+    expect(result.networkPassphrase).toBe('Custom Passphrase');
+  });
+
+  it('prefers explicit HORIZON_URL and SOROBAN_RPC_URL overrides', () => {
+    process.env.STELLAR_NETWORK = 'testnet';
+    process.env.HORIZON_URL = 'https://custom-horizon.example.com';
+    process.env.SOROBAN_RPC_URL = 'https://custom-rpc.example.com';
+
+    const result = service.getNetworkConfig();
+
+    expect(result.horizonUrl).toBe('https://custom-horizon.example.com');
+    expect(result.rpcUrl).toBe('https://custom-rpc.example.com');
+  });
+
+  it('never includes secret-bearing fields such as JWT_SECRET or WEBHOOK_SECRET', () => {
+    process.env.JWT_SECRET = 'super-secret';
+    process.env.WEBHOOK_SECRET = 'another-secret';
+
+    const result = service.getNetworkConfig();
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('super-secret');
+    expect(serialized).not.toContain('another-secret');
+    expect(Object.keys(result).sort()).toEqual(
+      ['horizonUrl', 'network', 'networkPassphrase', 'rpcUrl'].sort(),
+    );
+  });
+});

--- a/backend/src/config/network-config.service.ts
+++ b/backend/src/config/network-config.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { Networks } from '@stellar/stellar-sdk';
+import { NetworkConfigDto } from './dto/network-config.dto';
+
+const PASSPHRASE_BY_NETWORK: Record<string, string> = {
+  testnet: Networks.TESTNET,
+  futurenet: Networks.FUTURENET,
+  mainnet: Networks.PUBLIC,
+};
+
+const HORIZON_URL_BY_NETWORK: Record<string, string> = {
+  testnet: 'https://horizon-testnet.stellar.org',
+  futurenet: 'https://horizon-futurenet.stellar.org',
+  mainnet: 'https://horizon.stellar.org',
+};
+
+const RPC_URL_BY_NETWORK: Record<string, string> = {
+  testnet: 'https://soroban-testnet.stellar.org',
+  futurenet: 'https://rpc-futurenet.stellar.org',
+  mainnet: 'https://mainnet.sorobanrpc.com',
+};
+
+@Injectable()
+export class NetworkConfigService {
+  /** Public network discovery info derived from env; never includes secrets. */
+  getNetworkConfig(): NetworkConfigDto {
+    const network = (process.env.STELLAR_NETWORK ?? 'testnet')
+      .trim()
+      .toLowerCase();
+
+    const networkPassphrase =
+      process.env.STELLAR_NETWORK_PASSPHRASE?.trim() ||
+      PASSPHRASE_BY_NETWORK[network] ||
+      Networks.TESTNET;
+
+    const horizonUrl =
+      process.env.HORIZON_URL?.trim() ||
+      HORIZON_URL_BY_NETWORK[network] ||
+      HORIZON_URL_BY_NETWORK.testnet;
+
+    const rpcUrl =
+      process.env.SOROBAN_RPC_URL?.trim() ||
+      RPC_URL_BY_NETWORK[network] ||
+      RPC_URL_BY_NETWORK.testnet;
+
+    return { network, networkPassphrase, horizonUrl, rpcUrl };
+  }
+}

--- a/backend/src/events/domain-events.ts
+++ b/backend/src/events/domain-events.ts
@@ -75,6 +75,16 @@ export class PostDeletedEvent {
   ) {}
 }
 
+// Comment events
+export class CommentDeletedEvent {
+  readonly type = 'comment.deleted' as const;
+  constructor(
+    public readonly commentId: string,
+    public readonly deletedBy: string,
+    public readonly timestamp: number = Date.now(),
+  ) {}
+}
+
 export class SubscriptionRenewalFailedEvent {
   readonly type = 'subscription.renewal_failed' as const;
   constructor(
@@ -95,4 +105,5 @@ export type DomainEvent =
   | SubscriptionExpiredEvent
   | SubscriptionRenewalFailedEvent
   | PlanCreatedEvent
-  | PostDeletedEvent;
+  | PostDeletedEvent
+  | CommentDeletedEvent;

--- a/backend/src/favorites/1753100000000-CreateFavorites.ts
+++ b/backend/src/favorites/1753100000000-CreateFavorites.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateFavorites1753100000000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "favorites" (
+        "id"        uuid              NOT NULL DEFAULT uuid_generate_v4(),
+        "userId"    uuid              NOT NULL,
+        "creatorId" uuid              NOT NULL,
+        "createdAt" TIMESTAMP         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_favorites" PRIMARY KEY ("id"),
+        CONSTRAINT "unique_favorite" UNIQUE ("userId", "creatorId"),
+        CONSTRAINT "FK_favorites_userId" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_favorites_creatorId" FOREIGN KEY ("creatorId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_favorites_userId" ON "favorites" ("userId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_favorites_creatorId" ON "favorites" ("creatorId")`,
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_favorites_creatorId"`);
+    await queryRunner.query(`DROP INDEX "IDX_favorites_userId"`);
+    await queryRunner.query(`DROP TABLE "favorites"`);
+  }
+}

--- a/backend/src/favorites/dto/favorite.dto.ts
+++ b/backend/src/favorites/dto/favorite.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class FavoriteDto {
+  @ApiProperty({ description: 'Unique favorite record identifier' })
+  @Expose()
+  id: string;
+
+  @ApiProperty({ description: 'ID of the user who favorited the creator' })
+  @Expose()
+  userId: string;
+
+  @ApiProperty({ description: 'ID of the favorited creator' })
+  @Expose()
+  creatorId: string;
+
+  @ApiProperty({ description: 'Favorite creation timestamp' })
+  @Expose()
+  createdAt: Date;
+}

--- a/backend/src/favorites/dto/index.ts
+++ b/backend/src/favorites/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './favorite.dto';

--- a/backend/src/favorites/entities/favorite.entity.ts
+++ b/backend/src/favorites/entities/favorite.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('favorites')
+@Unique('unique_favorite', ['userId', 'creatorId'])
+export class Favorite {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column()
+  @Index()
+  creatorId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'creatorId' })
+  creator: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/favorites/favorites.controller.spec.ts
+++ b/backend/src/favorites/favorites.controller.spec.ts
@@ -1,0 +1,87 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { FavoritesController } from './favorites.controller';
+import { FavoritesService } from './favorites.service';
+
+describe('FavoritesController', () => {
+  let controller: FavoritesController;
+  let service: {
+    addFavorite: jest.Mock;
+    removeFavorite: jest.Mock;
+    listFavoriteCreatorIds: jest.Mock;
+  };
+  const mockUser = { userId: 'jwt-user-1' };
+
+  beforeEach(async () => {
+    service = {
+      addFavorite: jest.fn(),
+      removeFavorite: jest.fn(),
+      listFavoriteCreatorIds: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FavoritesController],
+      providers: [{ provide: FavoritesService, useValue: service }],
+    }).compile();
+
+    controller = module.get(FavoritesController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('findAll', () => {
+    it("returns only the authenticated user's favorite creator IDs", async () => {
+      service.listFavoriteCreatorIds.mockResolvedValue(['creator-1', 'creator-2']);
+
+      const result = await controller.findAll(mockUser);
+
+      expect(service.listFavoriteCreatorIds).toHaveBeenCalledWith('jwt-user-1');
+      expect(result).toEqual(['creator-1', 'creator-2']);
+    });
+  });
+
+  describe('addFavorite', () => {
+    it('calls service.addFavorite with userId and creatorId', async () => {
+      service.addFavorite.mockResolvedValue({ status: 201, favorite: {} });
+
+      const result = await controller.addFavorite('creator-1', mockUser);
+
+      expect(service.addFavorite).toHaveBeenCalledWith('jwt-user-1', 'creator-1');
+      expect(result).toEqual({ creatorId: 'creator-1', favorited: true });
+    });
+
+    it('propagates NotFoundException when the target creator is missing', async () => {
+      service.addFavorite.mockRejectedValue(
+        new NotFoundException('Creator with id "missing" not found'),
+      );
+
+      await expect(
+        controller.addFavorite('missing', mockUser),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('removeFavorite', () => {
+    it('calls service.removeFavorite with userId and creatorId', async () => {
+      service.removeFavorite.mockResolvedValue(undefined);
+
+      const result = await controller.removeFavorite('creator-1', mockUser);
+
+      expect(service.removeFavorite).toHaveBeenCalledWith(
+        'jwt-user-1',
+        'creator-1',
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('propagates NotFoundException when the favorite does not exist', async () => {
+      service.removeFavorite.mockRejectedValue(
+        new NotFoundException('Favorite not found'),
+      );
+
+      await expect(
+        controller.removeFavorite('creator-1', mockUser),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/backend/src/favorites/favorites.controller.ts
+++ b/backend/src/favorites/favorites.controller.ts
@@ -1,0 +1,109 @@
+import {
+  Controller,
+  Post,
+  Delete,
+  Get,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import { FavoritesService } from './favorites.service';
+import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth-module/decorators/current-user.decorator';
+
+/**
+ * FavoritesController
+ *
+ * CRUD for a fan's favorited creators. Matches the frontend contract in
+ * `frontend/src/lib/favorites.ts`: GET returns an array of creator IDs,
+ * POST/DELETE take the creator ID as a path param.
+ *
+ * @Controller favorites
+ * @version 1
+ * @tags favorites
+ * @security BearerAuth
+ */
+@ApiTags('favorites')
+@UseGuards(JwtAuthGuard, ThrottlerGuard)
+@ApiBearerAuth()
+@Controller({ path: 'favorites', version: '1' })
+export class FavoritesController {
+  constructor(private readonly favoritesService: FavoritesService) {}
+
+  @Get()
+  @ApiOperation({ summary: "List the current user's favorited creator IDs" })
+  @ApiResponse({
+    status: 200,
+    description: 'Array of favorited creator IDs',
+    schema: { example: ['creator-1', 'creator-2'] },
+  })
+  async findAll(
+    @CurrentUser() user: { userId: string },
+  ): Promise<string[]> {
+    return this.favoritesService.listFavoriteCreatorIds(user.userId);
+  }
+
+  @Post(':creatorId')
+  @Throttle({ short: { limit: 10, ttl: 60000 } })
+  @ApiOperation({ summary: 'Favorite a creator' })
+  @ApiParam({ name: 'creatorId', description: 'Creator (user) ID' })
+  @ApiResponse({
+    status: 201,
+    description: 'Favorite added successfully',
+    schema: { example: { creatorId: 'uuid', favorited: true } },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Creator already favorited (idempotent)',
+    schema: { example: { creatorId: 'uuid', favorited: true } },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Creator not found',
+    schema: { example: { statusCode: 404, message: 'Creator with id "id" not found' } },
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Too Many Requests',
+    schema: { example: { statusCode: 429, message: 'Too Many Requests' } },
+  })
+  async addFavorite(
+    @Param('creatorId') creatorId: string,
+    @CurrentUser() user: { userId: string },
+  ) {
+    await this.favoritesService.addFavorite(user.userId, creatorId);
+    return { creatorId, favorited: true };
+  }
+
+  @Delete(':creatorId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Throttle({ short: { limit: 10, ttl: 60000 } })
+  @ApiOperation({ summary: 'Unfavorite a creator' })
+  @ApiParam({ name: 'creatorId', description: 'Creator (user) ID' })
+  @ApiResponse({ status: 204, description: 'Favorite removed successfully' })
+  @ApiResponse({
+    status: 404,
+    description: 'Favorite not found',
+    schema: { example: { statusCode: 404, message: 'Favorite not found' } },
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Too Many Requests',
+    schema: { example: { statusCode: 429, message: 'Too Many Requests' } },
+  })
+  async removeFavorite(
+    @Param('creatorId') creatorId: string,
+    @CurrentUser() user: { userId: string },
+  ): Promise<void> {
+    await this.favoritesService.removeFavorite(user.userId, creatorId);
+  }
+}

--- a/backend/src/favorites/favorites.module.ts
+++ b/backend/src/favorites/favorites.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FavoritesController } from './favorites.controller';
+import { FavoritesService } from './favorites.service';
+import { Favorite } from './entities/favorite.entity';
+import { User } from '../users/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Favorite, User])],
+  controllers: [FavoritesController],
+  providers: [FavoritesService],
+  exports: [FavoritesService],
+})
+export class FavoritesModule {}

--- a/backend/src/favorites/favorites.service.spec.ts
+++ b/backend/src/favorites/favorites.service.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { FavoritesService } from './favorites.service';
+import { Favorite } from './entities/favorite.entity';
+import { User } from '../users/entities/user.entity';
+
+const makeFavorite = (overrides: Partial<Favorite> = {}): Favorite =>
+  ({
+    id: 'favorite-1',
+    userId: 'user-1',
+    creatorId: 'creator-1',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  }) as Favorite;
+
+describe('FavoritesService', () => {
+  let service: FavoritesService;
+  let favoritesRepo: {
+    create: jest.Mock;
+    save: jest.Mock;
+    findOne: jest.Mock;
+    find: jest.Mock;
+    remove: jest.Mock;
+  };
+  let userRepo: { findOne: jest.Mock };
+
+  beforeEach(async () => {
+    favoritesRepo = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+      find: jest.fn(),
+      remove: jest.fn(),
+    };
+    userRepo = { findOne: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FavoritesService,
+        { provide: getRepositoryToken(Favorite), useValue: favoritesRepo },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+      ],
+    }).compile();
+
+    service = module.get(FavoritesService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── addFavorite ─────────────────────────────────────────────────────────────
+
+  describe('addFavorite', () => {
+    it('throws NotFoundException when the target creator does not exist', async () => {
+      userRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.addFavorite('user-1', 'missing-creator'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(favoritesRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('creates and returns a 201 when not already favorited', async () => {
+      userRepo.findOne.mockResolvedValue({ id: 'creator-1' });
+      favoritesRepo.findOne.mockResolvedValue(null);
+      const favorite = makeFavorite();
+      favoritesRepo.create.mockReturnValue(favorite);
+      favoritesRepo.save.mockResolvedValue(favorite);
+
+      const result = await service.addFavorite('user-1', 'creator-1');
+
+      expect(favoritesRepo.create).toHaveBeenCalledWith({
+        userId: 'user-1',
+        creatorId: 'creator-1',
+      });
+      expect(result.status).toBe(201);
+      expect(result.favorite).toBe(favorite);
+    });
+
+    it('is idempotent: returns 200 and does not duplicate when already favorited', async () => {
+      userRepo.findOne.mockResolvedValue({ id: 'creator-1' });
+      const existing = makeFavorite();
+      favoritesRepo.findOne.mockResolvedValue(existing);
+
+      const result = await service.addFavorite('user-1', 'creator-1');
+
+      expect(favoritesRepo.save).not.toHaveBeenCalled();
+      expect(result.status).toBe(200);
+      expect(result.favorite).toBe(existing);
+    });
+  });
+
+  // ── removeFavorite ──────────────────────────────────────────────────────────
+
+  describe('removeFavorite', () => {
+    it('removes the favorite when it exists', async () => {
+      const favorite = makeFavorite();
+      favoritesRepo.findOne.mockResolvedValue(favorite);
+
+      await service.removeFavorite('user-1', 'creator-1');
+
+      expect(favoritesRepo.remove).toHaveBeenCalledWith(favorite);
+    });
+
+    it('throws NotFoundException when the favorite does not exist', async () => {
+      favoritesRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.removeFavorite('user-1', 'creator-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(favoritesRepo.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── listFavoriteCreatorIds ──────────────────────────────────────────────────
+
+  describe('listFavoriteCreatorIds', () => {
+    it('scopes results to the given userId only', async () => {
+      favoritesRepo.find.mockResolvedValue([
+        makeFavorite({ creatorId: 'creator-1' }),
+        makeFavorite({ creatorId: 'creator-2' }),
+      ]);
+
+      const result = await service.listFavoriteCreatorIds('user-1');
+
+      expect(favoritesRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 'user-1' } }),
+      );
+      expect(result).toEqual(['creator-1', 'creator-2']);
+    });
+
+    it('returns an empty array when the user has no favorites', async () => {
+      favoritesRepo.find.mockResolvedValue([]);
+
+      const result = await service.listFavoriteCreatorIds('user-1');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── isFavorite ───────────────────────────────────────────────────────────────
+
+  describe('isFavorite', () => {
+    it('returns true when a favorite exists', async () => {
+      favoritesRepo.findOne.mockResolvedValue(makeFavorite());
+
+      expect(await service.isFavorite('user-1', 'creator-1')).toBe(true);
+    });
+
+    it('returns false when no favorite exists', async () => {
+      favoritesRepo.findOne.mockResolvedValue(null);
+
+      expect(await service.isFavorite('user-1', 'creator-1')).toBe(false);
+    });
+  });
+});

--- a/backend/src/favorites/favorites.service.ts
+++ b/backend/src/favorites/favorites.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Favorite } from './entities/favorite.entity';
+import { User } from '../users/entities/user.entity';
+
+@Injectable()
+export class FavoritesService {
+  constructor(
+    @InjectRepository(Favorite)
+    private readonly favoritesRepository: Repository<Favorite>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  /**
+   * Add a creator to the user's favorites (idempotent).
+   * Returns 201 if created, 200 if already favorited.
+   */
+  async addFavorite(
+    userId: string,
+    creatorId: string,
+  ): Promise<{ status: number; favorite: Favorite }> {
+    const creator = await this.userRepository.findOne({
+      where: { id: creatorId },
+    });
+    if (!creator) {
+      throw new NotFoundException(`Creator with id "${creatorId}" not found`);
+    }
+
+    const existing = await this.favoritesRepository.findOne({
+      where: { userId, creatorId },
+    });
+    if (existing) {
+      return { status: 200, favorite: existing };
+    }
+
+    const favorite = this.favoritesRepository.create({ userId, creatorId });
+    const saved = await this.favoritesRepository.save(favorite);
+    return { status: 201, favorite: saved };
+  }
+
+  /** Remove a creator from the user's favorites. */
+  async removeFavorite(userId: string, creatorId: string): Promise<void> {
+    const favorite = await this.favoritesRepository.findOne({
+      where: { userId, creatorId },
+    });
+    if (!favorite) {
+      throw new NotFoundException('Favorite not found');
+    }
+    await this.favoritesRepository.remove(favorite);
+  }
+
+  /** Lists the authenticated user's own favorited creator IDs. Never another user's. */
+  async listFavoriteCreatorIds(userId: string): Promise<string[]> {
+    const favorites = await this.favoritesRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+    return favorites.map((f) => f.creatorId);
+  }
+
+  async isFavorite(userId: string, creatorId: string): Promise<boolean> {
+    const favorite = await this.favoritesRepository.findOne({
+      where: { userId, creatorId },
+    });
+    return !!favorite;
+  }
+}

--- a/backend/src/feed/dto/feed-query.dto.ts
+++ b/backend/src/feed/dto/feed-query.dto.ts
@@ -1,0 +1,26 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class FeedQueryDto {
+  @ApiPropertyOptional({
+    description: 'Opaque cursor returned as `nextCursor` on the previous page',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({
+    description: 'Number of items per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number = 20;
+}

--- a/backend/src/feed/feed.controller.spec.ts
+++ b/backend/src/feed/feed.controller.spec.ts
@@ -1,0 +1,52 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FeedController } from './feed.controller';
+import { FeedService } from './feed.service';
+import { PaginatedResponseDto } from '../common/dto';
+import { PostDto } from '../posts/dto';
+
+describe('FeedController', () => {
+  let controller: FeedController;
+  let service: { getSubscriptionsFeed: jest.Mock };
+  const mockUser = { userId: 'jwt-user-1' };
+
+  beforeEach(async () => {
+    service = { getSubscriptionsFeed: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FeedController],
+      providers: [{ provide: FeedService, useValue: service }],
+    }).compile();
+
+    controller = module.get(FeedController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('getSubscriptionsFeed', () => {
+    it('passes the authenticated userId, cursor, and limit through to the service', async () => {
+      const page = new PaginatedResponseDto<PostDto>([], 10, null, false);
+      service.getSubscriptionsFeed.mockResolvedValue(page);
+
+      const result = await controller.getSubscriptionsFeed(
+        { cursor: 'abc', limit: 10 },
+        mockUser,
+      );
+
+      expect(service.getSubscriptionsFeed).toHaveBeenCalledWith(
+        'jwt-user-1',
+        'abc',
+        10,
+      );
+      expect(result).toBe(page);
+    });
+
+    it('returns an empty page when the fan has no active subscriptions', async () => {
+      const emptyPage = new PaginatedResponseDto<PostDto>([], 20, null, false);
+      service.getSubscriptionsFeed.mockResolvedValue(emptyPage);
+
+      const result = await controller.getSubscriptionsFeed({}, mockUser);
+
+      expect(result.data).toHaveLength(0);
+    });
+  });
+});

--- a/backend/src/feed/feed.controller.ts
+++ b/backend/src/feed/feed.controller.ts
@@ -1,0 +1,79 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import { FeedService } from './feed.service';
+import { FeedQueryDto } from './dto/feed-query.dto';
+import { PaginatedResponseDto } from '../common/dto';
+import { PostDto } from '../posts/dto';
+import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth-module/decorators/current-user.decorator';
+
+/**
+ * FeedController
+ *
+ * Aggregates published posts from the authenticated fan's actively
+ * subscribed creators into a single cursor-paginated timeline.
+ *
+ * @Controller feed
+ * @version 1
+ * @tags feed
+ * @security BearerAuth
+ */
+@ApiTags('feed')
+@UseGuards(JwtAuthGuard, ThrottlerGuard)
+@ApiBearerAuth()
+@Controller({ path: 'feed', version: '1' })
+export class FeedController {
+  constructor(private readonly feedService: FeedService) {}
+
+  @Get('subscriptions')
+  @Throttle({ medium: { limit: 50, ttl: 60000 } })
+  @ApiOperation({
+    summary: 'Personalized fan feed of subscribed creators posts',
+    description:
+      'Cursor-paginated timeline aggregating published, non-deleted posts ' +
+      'from creators the authenticated fan actively subscribes to. Returns ' +
+      'an empty page when the fan has no active subscriptions.',
+  })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    description: 'Opaque cursor returned as `nextCursor` on the previous page',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: 'Items per page (default 20, max 100)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Cursor-paginated feed of subscribed creators posts',
+    type: PaginatedResponseDto<PostDto>,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Too many requests',
+    schema: { example: { statusCode: 429, message: 'Too many requests' } },
+  })
+  async getSubscriptionsFeed(
+    @Query() query: FeedQueryDto,
+    @CurrentUser() user: { userId: string },
+  ): Promise<PaginatedResponseDto<PostDto>> {
+    return this.feedService.getSubscriptionsFeed(
+      user.userId,
+      query.cursor,
+      query.limit,
+    );
+  }
+}

--- a/backend/src/feed/feed.module.ts
+++ b/backend/src/feed/feed.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { FeedController } from './feed.controller';
+import { FeedService } from './feed.service';
+import { PostsModule } from '../posts/posts.module';
+import { SubscriptionsModule } from '../subscriptions/subscriptions.module';
+
+@Module({
+  imports: [PostsModule, SubscriptionsModule],
+  controllers: [FeedController],
+  providers: [FeedService],
+})
+export class FeedModule {}

--- a/backend/src/feed/feed.service.spec.ts
+++ b/backend/src/feed/feed.service.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FeedService } from './feed.service';
+import { PostsService } from '../posts/posts.service';
+import { SubscriptionsService } from '../subscriptions/subscriptions.service';
+import { PaginatedResponseDto } from '../common/dto';
+import { PostDto } from '../posts/dto';
+
+describe('FeedService', () => {
+  let service: FeedService;
+  let postsService: { findFeed: jest.Mock };
+  let subscriptionsService: { getActiveCreatorIdsForFan: jest.Mock };
+
+  beforeEach(async () => {
+    postsService = { findFeed: jest.fn() };
+    subscriptionsService = { getActiveCreatorIdsForFan: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FeedService,
+        { provide: PostsService, useValue: postsService },
+        { provide: SubscriptionsService, useValue: subscriptionsService },
+      ],
+    }).compile();
+
+    service = module.get(FeedService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('resolves the active creator IDs for the fan and delegates to PostsService.findFeed', async () => {
+    subscriptionsService.getActiveCreatorIdsForFan.mockResolvedValue([
+      'creator-1',
+      'creator-2',
+    ]);
+    const page = new PaginatedResponseDto<PostDto>([], 20, null, false);
+    postsService.findFeed.mockResolvedValue(page);
+
+    const result = await service.getSubscriptionsFeed('fan-1', 'cursor-1', 10);
+
+    expect(subscriptionsService.getActiveCreatorIdsForFan).toHaveBeenCalledWith(
+      'fan-1',
+    );
+    expect(postsService.findFeed).toHaveBeenCalledWith(
+      ['creator-1', 'creator-2'],
+      'cursor-1',
+      10,
+    );
+    expect(result).toBe(page);
+  });
+
+  it('returns an empty feed (not an error) when the fan has no active subscriptions', async () => {
+    subscriptionsService.getActiveCreatorIdsForFan.mockResolvedValue([]);
+    const emptyPage = new PaginatedResponseDto<PostDto>([], 20, null, false);
+    postsService.findFeed.mockResolvedValue(emptyPage);
+
+    const result = await service.getSubscriptionsFeed('fan-1');
+
+    expect(postsService.findFeed).toHaveBeenCalledWith([], undefined, 20);
+    expect(result.data).toHaveLength(0);
+  });
+
+  it('defaults limit to 20 when not provided', async () => {
+    subscriptionsService.getActiveCreatorIdsForFan.mockResolvedValue([
+      'creator-1',
+    ]);
+    postsService.findFeed.mockResolvedValue(
+      new PaginatedResponseDto<PostDto>([], 20, null, false),
+    );
+
+    await service.getSubscriptionsFeed('fan-1');
+
+    expect(postsService.findFeed).toHaveBeenCalledWith(
+      ['creator-1'],
+      undefined,
+      20,
+    );
+  });
+});

--- a/backend/src/feed/feed.service.ts
+++ b/backend/src/feed/feed.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { PostsService } from '../posts/posts.service';
+import { SubscriptionsService } from '../subscriptions/subscriptions.service';
+import { PostDto } from '../posts/dto';
+import { PaginatedResponseDto } from '../common/dto';
+
+@Injectable()
+export class FeedService {
+  constructor(
+    private readonly postsService: PostsService,
+    private readonly subscriptionsService: SubscriptionsService,
+  ) {}
+
+  /**
+   * Aggregated timeline of published posts from creators the fan actively
+   * subscribes to. Returns an empty page (not an error) when the fan has no
+   * active subscriptions.
+   */
+  async getSubscriptionsFeed(
+    fanId: string,
+    cursor?: string,
+    limit = 20,
+  ): Promise<PaginatedResponseDto<PostDto>> {
+    const creatorIds =
+      await this.subscriptionsService.getActiveCreatorIdsForFan(fanId);
+    return this.postsService.findFeed(creatorIds, cursor, limit);
+  }
+}

--- a/backend/src/migration.datasource.ts
+++ b/backend/src/migration.datasource.ts
@@ -12,6 +12,8 @@ import { AddDigestColumnsToNotifications1745100000000 } from './notifications/17
 import { AddOnboardingStateToUsers1745200000000 } from './users/1745200000000-AddOnboardingStateToUsers';
 import { AddRoleToUsers1747000000000 } from './users/1747000000000-AddRoleToUsers';
 import { CreateSocialLinksTable1748000000000 } from './social-link/1748000000000-CreateSocialLinksTable';
+import { AddCommentSoftDeleteAndAudit1753000000000 } from './comments/1753000000000-AddCommentSoftDeleteAndAudit';
+import { CreateFavorites1753100000000 } from './favorites/1753100000000-CreateFavorites';
 
 export const migrationDataSource = new DataSource({
   type: 'postgres',
@@ -33,5 +35,7 @@ export const migrationDataSource = new DataSource({
     AddOnboardingStateToUsers1745200000000,
     AddRoleToUsers1747000000000,
     CreateSocialLinksTable1748000000000,
+    AddCommentSoftDeleteAndAudit1753000000000,
+    CreateFavorites1753100000000,
   ],
 });

--- a/backend/src/posts/posts.service.spec.ts
+++ b/backend/src/posts/posts.service.spec.ts
@@ -440,6 +440,97 @@ describe('PostsService', () => {
     });
   });
 
+  // ── findFeed ─────────────────────────────────────────────────────────────────
+
+  describe('findFeed', () => {
+    it('returns an empty page without querying when authorIds is empty', async () => {
+      const result = await service.findFeed([], undefined, 20);
+
+      expect(repo.createQueryBuilder).not.toHaveBeenCalled();
+      expect(result.data).toHaveLength(0);
+      expect(result.hasMore).toBe(false);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('filters by authorId IN (...), isPublished, and deletedAt IS NULL', async () => {
+      queryBuilder.getMany.mockResolvedValue([]);
+
+      await service.findFeed(['author-1', 'author-2'], undefined, 20);
+
+      expect(repo.createQueryBuilder).toHaveBeenCalledWith('post');
+      expect(queryBuilder.where).toHaveBeenCalledWith(
+        'post.authorId IN (:...authorIds)',
+        { authorIds: ['author-1', 'author-2'] },
+      );
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        'post.isPublished = :isPublished',
+        { isPublished: true },
+      );
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        'post.deletedAt IS NULL',
+      );
+    });
+
+    it('orders by createdAt DESC, id DESC and requests limit + 1 rows', async () => {
+      queryBuilder.getMany.mockResolvedValue([]);
+
+      await service.findFeed(['author-1'], undefined, 10);
+
+      expect(queryBuilder.orderBy).toHaveBeenCalledWith(
+        'post.createdAt',
+        'DESC',
+      );
+      expect(queryBuilder.take).toHaveBeenCalledWith(11);
+    });
+
+    it('returns hasMore=true and a nextCursor when more rows exist than the limit', async () => {
+      const posts = [
+        makePost({ id: 'p1', createdAt: new Date('2026-01-03T00:00:00Z') }),
+        makePost({ id: 'p2', createdAt: new Date('2026-01-02T00:00:00Z') }),
+        makePost({ id: 'p3', createdAt: new Date('2026-01-01T00:00:00Z') }),
+      ];
+      queryBuilder.getMany.mockResolvedValue(posts);
+
+      const result = await service.findFeed(['author-1'], undefined, 2);
+
+      expect(result.data).toHaveLength(2);
+      expect(result.hasMore).toBe(true);
+      expect(result.nextCursor).not.toBeNull();
+    });
+
+    it('returns hasMore=false and nextCursor=null when exactly at the page boundary', async () => {
+      const posts = [makePost({ id: 'p1' })];
+      queryBuilder.getMany.mockResolvedValue(posts);
+
+      const result = await service.findFeed(['author-1'], undefined, 20);
+
+      expect(result.hasMore).toBe(false);
+      expect(result.data).toHaveLength(1);
+    });
+
+    it('applies a keyset filter derived from the cursor on subsequent pages', async () => {
+      queryBuilder.getMany.mockResolvedValue([]);
+      const cursor = Buffer.from('2026-01-01T00:00:00.000Z|post-9').toString(
+        'base64',
+      );
+
+      await service.findFeed(['author-1'], cursor, 20);
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('post.createdAt < :cCreatedAt'),
+        { cCreatedAt: '2026-01-01T00:00:00.000Z', cId: 'post-9' },
+      );
+    });
+
+    it('ignores a malformed cursor rather than throwing', async () => {
+      queryBuilder.getMany.mockResolvedValue([]);
+
+      await expect(
+        service.findFeed(['author-1'], 'not-valid-base64!!', 20),
+      ).resolves.toBeDefined();
+    });
+  });
+
   // ── PostDeletedEvent ─────────────────────────────────────────────────────────
 
   describe('PostDeletedEvent', () => {

--- a/backend/src/posts/posts.service.ts
+++ b/backend/src/posts/posts.service.ts
@@ -159,4 +159,72 @@ export class PostsService {
       throw new NotFoundException(`Post with ID ${id} not found`);
     }
   }
+
+  /**
+   * Cursor-paginated, published, non-deleted posts authored by any of
+   * `authorIds`, newest first. Used by the fan feed to aggregate posts from
+   * subscribed creators. Returns an empty page when `authorIds` is empty
+   * rather than querying with an empty IN clause.
+   */
+  async findFeed(
+    authorIds: string[],
+    cursor?: string,
+    limit = 20,
+  ): Promise<PaginatedResponseDto<PostDto>> {
+    if (authorIds.length === 0) {
+      return new PaginatedResponseDto([], limit, null, false);
+    }
+
+    const qb = this.postRepo
+      .createQueryBuilder('post')
+      .where('post.authorId IN (:...authorIds)', { authorIds })
+      .andWhere('post.isPublished = :isPublished', { isPublished: true })
+      .andWhere('post.deletedAt IS NULL')
+      .orderBy('post.createdAt', 'DESC')
+      .addOrderBy('post.id', 'DESC')
+      .take(limit + 1);
+
+    const decoded = cursor ? this.decodeFeedCursor(cursor) : null;
+    if (decoded) {
+      qb.andWhere(
+        '(post.createdAt < :cCreatedAt OR (post.createdAt = :cCreatedAt AND post.id < :cId))',
+        { cCreatedAt: decoded.createdAt, cId: decoded.id },
+      );
+    }
+
+    const rows = await qb.getMany();
+    const hasMore = rows.length > limit;
+    if (hasMore) {
+      rows.pop();
+    }
+
+    const nextCursor =
+      rows.length > 0 ? this.encodeFeedCursor(rows[rows.length - 1]) : null;
+
+    return new PaginatedResponseDto(
+      rows.map((p) => this.toDto(p)),
+      limit,
+      nextCursor,
+      hasMore,
+    );
+  }
+
+  private encodeFeedCursor(post: Post): string {
+    return Buffer.from(`${post.createdAt.toISOString()}|${post.id}`).toString(
+      'base64',
+    );
+  }
+
+  private decodeFeedCursor(
+    cursor: string,
+  ): { createdAt: string; id: string } | null {
+    try {
+      const decoded = Buffer.from(cursor, 'base64').toString('utf8');
+      const [createdAt, id] = decoded.split('|');
+      if (!createdAt || !id) return null;
+      return { createdAt, id };
+    } catch {
+      return null;
+    }
+  }
 }

--- a/backend/src/subscriptions/subscriptions.service.spec.ts
+++ b/backend/src/subscriptions/subscriptions.service.spec.ts
@@ -602,4 +602,41 @@ describe('SubscriptionsService', () => {
       }),
     );
   });
+
+  describe('getActiveCreatorIdsForFan', () => {
+    const fan = 'GFANFEED1111111111111111111111111111111111111111111111111';
+
+    it('returns the distinct creator IDs the fan actively subscribes to', async () => {
+      await service.addSubscription(
+        fan,
+        'GCREATORFEED1111111111111111111111111111111111111111111111',
+        1,
+        Math.floor(Date.now() / 1000) + 3600,
+      );
+      await service.addSubscription(
+        fan,
+        'GCREATORFEED2222222222222222222222222222222222222222222222',
+        2,
+        Math.floor(Date.now() / 1000) + 3600,
+      );
+
+      const creatorIds = await service.getActiveCreatorIdsForFan(fan);
+
+      expect(creatorIds).toEqual(
+        expect.arrayContaining([
+          'GCREATORFEED1111111111111111111111111111111111111111111111',
+          'GCREATORFEED2222222222222222222222222222222222222222222222',
+        ]),
+      );
+      expect(creatorIds).toHaveLength(2);
+    });
+
+    it('returns an empty array when the fan has no active subscriptions', async () => {
+      const creatorIds = await service.getActiveCreatorIdsForFan(
+        'GNOSUBSCRIPTIONS11111111111111111111111111111111111111111',
+      );
+
+      expect(creatorIds).toEqual([]);
+    });
+  });
 });

--- a/backend/src/subscriptions/subscriptions.service.ts
+++ b/backend/src/subscriptions/subscriptions.service.ts
@@ -296,6 +296,12 @@ export class SubscriptionsService {
     return this.indexRepo.isSubscriber(fan, creator);
   }
 
+  /** Returns the distinct creator IDs the fan currently holds an active subscription to. */
+  async getActiveCreatorIdsForFan(fan: string): Promise<string[]> {
+    const subs = await this.indexRepo.listActiveForFan(fan, 1, 1000);
+    return [...new Set(subs.map((sub) => sub.creator))];
+  }
+
   async getSubscription(
     fan: string,
     creator: string,

--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -158,6 +158,7 @@ name = "content-access"
 version = "0.1.1"
 dependencies = [
  "myfans-lib",
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -208,6 +209,7 @@ dependencies = [
 name = "creator-earnings"
 version = "0.1.1"
 dependencies = [
+ "myfans-lib",
  "proptest",
  "soroban-sdk",
 ]
@@ -216,6 +218,7 @@ dependencies = [
 name = "creator-registry"
 version = "0.1.1"
 dependencies = [
+ "myfans-lib",
  "proptest",
  "soroban-sdk",
 ]


### PR DESCRIPTION


## Changes

- **Comments soft-delete + audit (#1434)**: `deletedAt`/`deletedBy` added to `Comment`; new `CommentAuditLog` entity + migration; `CommentsService.remove()` now soft-deletes, writes an audit row, and emits `CommentDeletedEvent`; all reads filter `deletedAt IS NULL`; hard delete kept as a separate, non-default `hardDelete()` method — mirrors the existing `Post`/`PostAuditLog` pattern exactly.
- **Personalized fan feed (#1435)**: new `feed` module — `GET /v1/feed/subscriptions` (JWT-required, cursor-paginated). `SubscriptionsService.getActiveCreatorIdsForFan()` resolves the fan's actively-subscribed creators; `PostsService.findFeed()` returns their published, non-deleted posts via keyset (createdAt+id) cursor pagination. Empty subscriptions → empty page, not an error.
- **Favorites API (#1436)**: new `favorites` module — `Favorite` entity (unique on `userId`+`creatorId`), migration, service, and controller matching the existing frontend contract in `frontend/src/lib/favorites.ts` (`GET /v1/favorites` → creator ID array, `POST`/`DELETE /v1/favorites/:creatorId`). Add is idempotent; missing target creator → 404; listing is always scoped to the caller's own `userId`.
- **Network discovery config (#1437)**: new `config` module — public `GET /v1/config/network` returning `network`, `networkPassphrase`, `horizonUrl`, `rpcUrl` derived from `STELLAR_NETWORK`/env overrides (same passphrase-mapping convention as `subscription-chain-reader.service.ts`). No secrets in the response.
- Wired `FeedModule`, `FavoritesModule`, and `NetworkConfigModule` into `AppModule`; registered the two new migrations in `migration.datasource.ts`.

## Test Plan

### Automated tests added or updated

- [x] **Unit tests** (`backend/src/**/*.spec.ts`) — `comments.service.spec.ts` rewritten for soft-delete/audit/event behavior; `posts.service.spec.ts` extended with `findFeed` cursor/filter cases; `subscriptions.service.spec.ts` extended with `getActiveCreatorIdsForFan`; new specs for `feed.service`, `feed.controller`, `favorites.service`, `favorites.controller`, `network-config.service`, `network-config.controller`.
- [ ] Integration / e2e tests — not added; existing modules follow the same unit-test-only convention (repos mocked via `getRepositoryToken`), and `AppModule` has no `TypeOrmModule.forRoot` wired yet (pre-existing, see Notes).
- [ ] Frontend tests — no frontend changes.
- [ ] Contract tests — no contract changes.

### How to run the tests locally

```bash
cd backend && npm install   # not run in this session — see Notes
npm test
Manual verification checklist
 Happy path works end-to-end in a local environment
 Error / edge cases handled gracefully
 No regressions in closely related API or UI flows
 Rate-limiting, auth guards, and feature flags behave as expected where touched
 Linting passes: cd backend && npm run lint
Related issues
Closes #1434, #1435, #1436, #1437

Notes for reviewers
Dependencies were not installed and the build/test suite was not run in this session (per task constraints) — please run npm install && npm test && npm run lint before merging.
Two pre-existing gaps, unrelated to this PR, worth a follow-up ticket: (1) PostsModule, CommentsModule, and LikesModule were already not imported into AppModule before this change; (2) there is no TypeOrmModule.forRoot(...) anywhere in AppModule — only migration.datasource.ts configures a real Postgres connection for the migration CLI. Neither was introduced or worsened here.
contract/Cargo.lock shows as locally modified but was not touched by this work — worth checking before commit/push.

closes #1435 
Closes #1434
closes  #1436
 closes  #1437