### PR TITLE
feat: stub WalletConnect, proxy transactions, unify flags, API-first notification

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -2,6 +2,23 @@
 
 Frontend feature flags in `frontend/` are resolved at runtime and fail closed by default. If a flag is missing, the remote endpoint is unavailable, or a value is invalid, the feature stays off.
 
+## Single source of truth
+
+**Use only** `frontend/src/lib/feature-flags.ts`.
+
+The legacy duplicate module `frontend/src/lib/featureFlags.ts` was removed. All imports must use:
+
+```ts
+import { FeatureFlag, isFeatureEnabled } from '@/lib/feature-flags';
+```
+
+Do not reintroduce a second flag registry. The React gate components both read this module:
+
+| Component | Path | When to use |
+| --- | --- | --- |
+| `FeatureGate` | `frontend/src/components/FeatureGate.tsx` | Preferred — uses `FeatureFlagsProvider` / `useFeatureFlag` |
+| `FeatureFlag` | `frontend/src/components/FeatureFlag.tsx` | Thin sync gate for simple examples; still backed by `feature-flags.ts` |
+
 ## Architecture
 
 - Central flag registry: `frontend/src/lib/feature-flags.ts`
@@ -12,7 +29,7 @@ Frontend feature flags in `frontend/` are resolved at runtime and fail closed by
 Resolution order for each flag:
 
 1. Remote JSON from `NEXT_PUBLIC_FEATURE_FLAGS_URL`
-2. Environment variable `NEXT_PUBLIC_FLAG_<FLAG_NAME>`
+2. Environment variable `NEXT_PUBLIC_FLAG_<FLAG_NAME>` (or the flag's documented `envKey`)
 3. `localStorage` override `flags:<flag-name>` when local overrides are allowed
 4. Default `false`
 
@@ -20,11 +37,15 @@ When `NEXT_PUBLIC_FEATURE_FLAGS_URL` is configured, the client re-fetches the re
 
 ## Current Flags
 
-| Flag key | Purpose | Default |
-| --- | --- | --- |
-| `bookmarks` | Shows bookmark controls on creator discovery and subscribe flows | `false` |
-| `earnings_withdrawals` | Enables the earnings withdrawal panel | `false` |
-| `earnings_fee_transparency` | Enables the fee transparency card on the earnings page | `false` |
+| Flag key | Purpose | Default | Env key |
+| --- | --- | --- | --- |
+| `bookmarks` | Shows bookmark controls on creator discovery and subscribe flows | `false` | `NEXT_PUBLIC_FLAG_BOOKMARKS` |
+| `earnings_withdrawals` | Enables the earnings withdrawal panel | `false` | `NEXT_PUBLIC_FLAG_EARNINGS_WITHDRAWALS` |
+| `earnings_fee_transparency` | Enables the fee transparency card on the earnings page | `false` | `NEXT_PUBLIC_FLAG_EARNINGS_FEE_TRANSPARENCY` |
+| `referral_codes` | Enables referral / invite code input during checkout | `false` | `NEXT_PUBLIC_FLAG_REFERRAL_CODES` |
+| `newSubscriptionFlow` | Enables the new subscription checkout flow | `false` | `NEXT_PUBLIC_FEATURE_NEW_SUBSCRIPTION_FLOW` |
+| `cryptoPayments` | Enables crypto payment options in checkout | `false` | `NEXT_PUBLIC_FEATURE_CRYPTO_PAYMENTS` |
+| `walletConnect` | Enables WalletConnect option (stubbed until provider lands) | `false` | `NEXT_PUBLIC_FEATURE_WALLET_CONNECT` |
 
 ## Remote JSON Format
 
@@ -34,7 +55,8 @@ Point `NEXT_PUBLIC_FEATURE_FLAGS_URL` at a JSON document with either shape:
 {
   "bookmarks": true,
   "earnings_withdrawals": false,
-  "earnings_fee_transparency": true
+  "earnings_fee_transparency": true,
+  "walletConnect": false
 }
 ```
 
@@ -45,7 +67,8 @@ or:
   "flags": {
     "bookmarks": true,
     "earnings_withdrawals": false,
-    "earnings_fee_transparency": true
+    "earnings_fee_transparency": true,
+    "walletConnect": false
   }
 }
 ```

--- a/frontend/src/app/api/transactions/__tests__/route.test.ts
+++ b/frontend/src/app/api/transactions/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET, POST } from '@/app/api/transactions/route';
+import { NextRequest } from 'next/server';
+
+describe('/api/transactions route', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('proxies GET to backend and maps response', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: '1',
+            creator: 'GC',
+            fan: 'GF',
+            amount: '10',
+            fee: '0.1',
+            asset: 'XLM',
+            txHash: 'hash',
+            paidAt: '2026-03-01T00:00:00.000Z',
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+      }),
+    }) as unknown as typeof fetch;
+
+    const request = new NextRequest('http://localhost:3000/api/transactions?page=1&limit=10', {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].amount).toBe(10);
+    expect(body.data[0].type).toBe('payment');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/v1/analytics/payments'),
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+      }),
+    );
+  });
+
+  it('surfaces upstream errors without 404 from missing route', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ message: 'Unauthorized' }),
+    }) as unknown as typeof fetch;
+
+    const request = new NextRequest('http://localhost:3000/api/transactions');
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.message).toBe('Unauthorized');
+    expect(body.data).toEqual([]);
+  });
+
+  it('supports POST body filters for legacy clients', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [], total: 0, page: 2, limit: 10, totalPages: 1 }),
+    }) as unknown as typeof fetch;
+
+    const request = new NextRequest('http://localhost:3000/api/transactions', {
+      method: 'POST',
+      body: JSON.stringify({
+        page: 2,
+        limit: 10,
+        filters: { fromDate: '2026-01-01', toDate: '2026-02-01' },
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/from=2026-01-01/),
+      expect.any(Object),
+    );
+  });
+});

--- a/frontend/src/app/api/transactions/route.ts
+++ b/frontend/src/app/api/transactions/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getAnalyticsPaymentsUrl,
+  mapPaymentsResponse,
+  type TransactionsResponse,
+} from '@/lib/transactions';
+
+function buildUpstreamUrl(searchParams: URLSearchParams): string {
+  const upstream = new URL(getAnalyticsPaymentsUrl());
+  const page = searchParams.get('page');
+  const limit = searchParams.get('limit');
+  const creator = searchParams.get('creator');
+  const from = searchParams.get('from') ?? searchParams.get('fromDate');
+  const to = searchParams.get('to') ?? searchParams.get('toDate');
+
+  if (page) upstream.searchParams.set('page', page);
+  if (limit) upstream.searchParams.set('limit', limit);
+  if (creator) upstream.searchParams.set('creator', creator);
+  if (from) upstream.searchParams.set('from', from);
+  if (to) upstream.searchParams.set('to', to);
+
+  return upstream.toString();
+}
+
+function forwardAuthHeaders(request: NextRequest): HeadersInit {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  const authorization = request.headers.get('authorization');
+  const cookie = request.headers.get('cookie');
+  if (authorization) headers.Authorization = authorization;
+  if (cookie) headers.Cookie = cookie;
+  return headers;
+}
+
+async function proxyTransactions(request: NextRequest, searchParams: URLSearchParams) {
+  const url = buildUpstreamUrl(searchParams);
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, {
+      method: 'GET',
+      headers: forwardAuthHeaders(request),
+      cache: 'no-store',
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        message: error instanceof Error ? error.message : 'Failed to reach transactions backend',
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+      },
+      { status: 502 },
+    );
+  }
+
+  const raw = await upstream.json().catch(() => ({}));
+
+  if (!upstream.ok) {
+    const message =
+      (raw && typeof raw === 'object' && 'message' in raw && typeof raw.message === 'string'
+        ? raw.message
+        : null) ?? `Failed to fetch transactions (${upstream.status})`;
+
+    return NextResponse.json(
+      {
+        message,
+        data: [],
+        total: 0,
+        page: Number(searchParams.get('page') ?? 1),
+        limit: Number(searchParams.get('limit') ?? 10),
+        totalPages: 1,
+      },
+      { status: upstream.status },
+    );
+  }
+
+  const mapped: TransactionsResponse = mapPaymentsResponse(raw);
+  return NextResponse.json(mapped);
+}
+
+/**
+ * GET /api/transactions — Next proxy to Nest analytics payments.
+ * Forwards Authorization / Cookie so auth works end-to-end.
+ */
+export async function GET(request: NextRequest) {
+  return proxyTransactions(request, request.nextUrl.searchParams);
+}
+
+/**
+ * POST /api/transactions — same proxy; accepts `{ filters, page, limit }` body
+ * for compatibility with the original client shape.
+ */
+export async function POST(request: NextRequest) {
+  let body: { filters?: Record<string, string>; page?: number; limit?: number } = {};
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    body = {};
+  }
+
+  const params = new URLSearchParams(request.nextUrl.searchParams);
+  if (body.page != null) params.set('page', String(body.page));
+  if (body.limit != null) params.set('limit', String(body.limit));
+
+  const filters = body.filters ?? {};
+  for (const key of ['creator', 'from', 'to', 'fromDate', 'toDate', 'type', 'status'] as const) {
+    const value = filters[key];
+    if (value) params.set(key, value);
+  }
+
+  return proxyTransactions(request, params);
+}

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -1,90 +1,81 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { apiClient } from "@/clients/api-client";
+import { useCallback, useEffect, useState } from "react";
 import { TransactionTable } from "@/components/transactions/TransactionTable";
 import { TransactionFilters } from "@/components/transactions/TransactionFilters";
 import { Pagination } from "@/components/transactions/Pagination";
-import type { PaymentRecord } from "@/types";
+import { getAuthHeaders } from "@/lib/api-utils";
+import type { Transaction, TransactionsResponse } from "@/lib/transactions";
 
-interface Transaction {
-    id: string;
-    type: "subscription" | "payment" | "refund";
-    status: "pending" | "success" | "failed";
-    amount: number;
-    currency: string;
-    txHash?: string;
-    createdAt: string;
-}
-
-function mapPaymentToTransaction(payment: PaymentRecord): Transaction {
-    return {
-        id: payment.id,
-        type: "payment",
-        status: (payment.status as "completed" | "pending" | "failed" | "refunded") === "completed"
-            ? "success"
-            : payment.status === "pending"
-            ? "pending"
-            : "failed",
-        amount: payment.amount,
-        currency: payment.currency,
-        txHash: payment.txHash,
-        createdAt: payment.date,
-    };
+interface Filters {
+  type?: string;
+  status?: string;
+  fromDate?: string;
+  toDate?: string;
+  creator?: string;
 }
 
 export default function TransactionsPage() {
-    const [data, setData] = useState<Transaction[]>([]);
-    const [isLoading, setIsLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [filters, setFilters] = useState({});
-    const [page, setPage] = useState(1);
-    const [totalPages, setTotalPages] = useState(1);
+  const [data, setData] = useState<Transaction[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<Filters>({});
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
 
-    useEffect(() => {
-        fetchTransactions();
-    }, [filters, page]);
+  const fetchTransactions = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
 
-    async function fetchTransactions() {
-        setIsLoading(true);
-        setError(null);
-        try {
-            const result = await apiClient.getPaymentHistory({
-                page,
-                limit: 10,
-                creator: (filters as any).creator,
-                from: (filters as any).from,
-                to: (filters as any).to,
-            });
+    const params = new URLSearchParams({
+      page: String(page),
+      limit: "10",
+    });
+    if (filters.creator) params.set("creator", filters.creator);
+    if (filters.fromDate) params.set("from", filters.fromDate);
+    if (filters.toDate) params.set("to", filters.toDate);
+    if (filters.type) params.set("type", filters.type);
+    if (filters.status) params.set("status", filters.status);
 
-            if (!result.data || result.data.length === 0) {
-                setData([]);
-            } else {
-                setData(result.data.map(mapPaymentToTransaction));
-            }
+    try {
+      const res = await fetch(`/api/transactions?${params.toString()}`, {
+        method: "GET",
+        credentials: "include",
+        headers: getAuthHeaders(),
+      });
 
-            setTotalPages(result.totalPages || 1);
-        } catch (err) {
-            setError(err instanceof Error ? err.message : "Failed to fetch transactions");
-            setData([]);
-        } finally {
-            setIsLoading(false);
-        }
+      const json = (await res.json().catch(() => ({}))) as TransactionsResponse & {
+        message?: string;
+      };
+
+      if (!res.ok) {
+        throw new Error(json.message || `Failed to fetch transactions (${res.status})`);
+      }
+
+      setData(Array.isArray(json.data) ? json.data : []);
+      setTotalPages(json.totalPages || 1);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch transactions");
+      setData([]);
+      setTotalPages(1);
+    } finally {
+      setIsLoading(false);
     }
+  }, [filters, page]);
 
-    return (
-        <div className="p-6">
-            <h1 className="text-2xl font-semibold mb-4">Transaction History</h1>
+  useEffect(() => {
+    fetchTransactions();
+  }, [fetchTransactions]);
 
-            <TransactionFilters filters={filters} setFilters={setFilters} />
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">Transaction History</h1>
 
-            <TransactionTable data={data} isLoading={isLoading} error={error} />
+      <TransactionFilters filters={filters} setFilters={setFilters} />
 
-            <Pagination
-                page={page}
-                totalPages={totalPages}
-                onPageChange={setPage}
-            />
-        </div>
-    );
+      <TransactionTable data={data} isLoading={isLoading} error={error} />
+
+      <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+    </div>
+  );
 }

--- a/frontend/src/components/FeatureFlag.tsx
+++ b/frontend/src/components/FeatureFlag.tsx
@@ -1,14 +1,21 @@
 'use client';
 
 import { ReactNode } from 'react';
-import { isFeatureEnabled } from '@/lib/featureFlags';
+import {
+  FeatureFlag as FeatureFlagKey,
+  isFeatureEnabled,
+} from '@/lib/feature-flags';
 
 interface FeatureFlagProps {
-  feature: 'newSubscriptionFlow' | 'cryptoPayments';
+  feature: typeof FeatureFlagKey.NEW_SUBSCRIPTION_FLOW | typeof FeatureFlagKey.CRYPTO_PAYMENTS;
   children: ReactNode;
   fallback?: ReactNode;
 }
 
+/**
+ * Lightweight gate that reads the unified feature-flag module.
+ * Prefer `FeatureGate` + `useFeatureFlag` for new UI that needs the provider.
+ */
 export function FeatureFlag({ feature, children, fallback = null }: FeatureFlagProps) {
   if (!isFeatureEnabled(feature)) {
     return <>{fallback}</>;

--- a/frontend/src/components/notifications/NotificationInbox.tsx
+++ b/frontend/src/components/notifications/NotificationInbox.tsx
@@ -8,14 +8,13 @@ import {
   markAllNotificationsRead,
   deleteNotification,
   MOCK_NOTIFICATIONS,
+  shouldUseMockNotifications,
 } from '@/lib/notifications';
 import NotificationItem from './NotificationItem';
 import NotificationDetail from './NotificationDetail';
 import NotificationSkeleton from '../ui/NotificationSkeleton';
 
 type Filter = 'all' | 'unread';
-
-// USE_MOCK is evaluated dynamically to allow tests to override it.
 
 export default function NotificationInbox() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
@@ -28,7 +27,7 @@ export default function NotificationInbox() {
     setLoading(true);
     setError(null);
     try {
-      const useMock = process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS !== 'false';
+      const useMock = shouldUseMockNotifications();
       const data = useMock
         ? MOCK_NOTIFICATIONS
         : await fetchNotifications(filter === 'unread');
@@ -48,24 +47,21 @@ export default function NotificationInbox() {
       prev.map((n: Notification) => (n.id === id ? { ...n, is_read: isRead } : n)),
     );
     if (selected?.id === id) setSelected((s: Notification | null) => s ? { ...s, is_read: isRead } : s);
-    const useMock = process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS !== 'false';
-    if (!useMock) {
+    if (!shouldUseMockNotifications()) {
       await markNotificationRead(id, isRead).catch(() => load());
     }
   }, [selected, load]);
 
   const handleMarkAllRead = useCallback(async () => {
     setNotifications((prev: Notification[]) => prev.map((n: Notification) => ({ ...n, is_read: true })));
-    const useMock = process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS !== 'false';
-    if (!useMock) {
+    if (!shouldUseMockNotifications()) {
       await markAllNotificationsRead().catch(() => load());
     }
   }, [load]);
 
   const handleDelete = useCallback(async (id: string) => {
     setNotifications((prev: Notification[]) => prev.filter((n: Notification) => n.id !== id));
-    const useMock = process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS !== 'false';
-    if (!useMock) {
+    if (!shouldUseMockNotifications()) {
       await deleteNotification(id).catch(() => load());
     }
   }, [load]);

--- a/frontend/src/components/notifications/__tests__/NotificationInbox.test.tsx
+++ b/frontend/src/components/notifications/__tests__/NotificationInbox.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import NotificationInbox from '../NotificationInbox';
 
 // Mock the dependencies
@@ -9,6 +9,7 @@ vi.mock('@/lib/notifications', async () => {
   return {
     ...actual,
     fetchNotifications: vi.fn(),
+    shouldUseMockNotifications: vi.fn(() => false),
   };
 });
 
@@ -19,21 +20,28 @@ vi.mock('@/components/ui/NotificationSkeleton', () => ({
 describe('NotificationInbox', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS = 'false';
+    delete process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS;
   });
 
-  it('renders skeletons while loading', async () => {
-    const { fetchNotifications } = await import('@/lib/notifications');
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS;
+  });
+
+  it('defaults to API (not mock) and renders skeletons while loading', async () => {
+    const { fetchNotifications, shouldUseMockNotifications } = await import('@/lib/notifications');
+    (shouldUseMockNotifications as any).mockReturnValue(false);
     (fetchNotifications as any).mockReturnValue(new Promise(() => {}));
 
     render(<NotificationInbox />);
-    
+
+    expect(shouldUseMockNotifications).toHaveBeenCalled();
     const skeletons = screen.getAllByTestId('notification-skeleton');
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it('renders notifications after loading', async () => {
-    const { fetchNotifications } = await import('@/lib/notifications');
+  it('renders notifications after loading from API', async () => {
+    const { fetchNotifications, shouldUseMockNotifications } = await import('@/lib/notifications');
+    (shouldUseMockNotifications as any).mockReturnValue(false);
     (fetchNotifications as any).mockResolvedValue([
       { id: '1', type: 'new_subscriber', title: 'New subscriber', body: 'User subscribed', is_read: false, created_at: new Date().toISOString() }
     ]);
@@ -46,5 +54,44 @@ describe('NotificationInbox', () => {
     
     expect(screen.getByText('Notifications')).toBeInTheDocument();
     expect(screen.getByText('New subscriber')).toBeInTheDocument();
+  });
+
+  it('renders empty inbox without error when API returns []', async () => {
+    const { fetchNotifications, shouldUseMockNotifications } = await import('@/lib/notifications');
+    (shouldUseMockNotifications as any).mockReturnValue(false);
+    (fetchNotifications as any).mockResolvedValue([]);
+
+    render(<NotificationInbox />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No notifications yet')).toBeInTheDocument();
+    });
+  });
+
+  it('surfaces API errors with retry', async () => {
+    const { fetchNotifications, shouldUseMockNotifications } = await import('@/lib/notifications');
+    (shouldUseMockNotifications as any).mockReturnValue(false);
+    (fetchNotifications as any).mockRejectedValue(new Error('boom'));
+
+    render(<NotificationInbox />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('boom');
+    });
+    expect(screen.getByText('Retry')).toBeInTheDocument();
+  });
+
+  it('uses mock data only when mock flag is opted in', async () => {
+    const { fetchNotifications, shouldUseMockNotifications, MOCK_NOTIFICATIONS } = await import('@/lib/notifications');
+    (shouldUseMockNotifications as any).mockReturnValue(true);
+
+    render(<NotificationInbox />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('notification-skeleton')).not.toBeInTheDocument();
+    });
+
+    expect(fetchNotifications).not.toHaveBeenCalled();
+    expect(screen.getByText(MOCK_NOTIFICATIONS[0].title)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/wallet/WalletOption.tsx
+++ b/frontend/src/components/wallet/WalletOption.tsx
@@ -10,6 +10,9 @@ interface WalletOptionProps {
   isConnecting: boolean;
   isInstalled: boolean;
   installUrl?: string;
+  /** When true, wallet is known but not available yet (stub / feature-flagged off). */
+  unsupported?: boolean;
+  unsupportedLabel?: string;
   onSelect: () => void;
   onInstall?: () => void;
   disabled: boolean;
@@ -22,27 +25,35 @@ export function WalletOption({
   isConnecting,
   isInstalled,
   installUrl,
+  unsupported = false,
+  unsupportedLabel = 'Coming soon',
   onSelect,
   onInstall,
   disabled,
 }: WalletOptionProps) {
-  const showInstallButton = !isInstalled && installUrl && onInstall;
-  
+  const showInstallButton = !unsupported && !isInstalled && installUrl && onInstall;
+  const isUnavailable = unsupported;
+
   return (
     <div className="relative">
       <button
         onClick={showInstallButton ? onInstall : onSelect}
         disabled={disabled || isConnecting}
         className={`w-full rounded-lg border p-4 text-left transition-all ${
-          showInstallButton
+          isUnavailable
+            ? 'border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900/60'
+            : showInstallButton
             ? 'border-amber-200 bg-amber-50 hover:border-amber-300 hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-900/20 dark:hover:border-amber-700 dark:hover:bg-amber-900/30'
             : 'border-slate-200 bg-white hover:border-primary-500 hover:shadow-md dark:border-slate-700 dark:bg-slate-900 dark:hover:border-primary-600'
         } disabled:cursor-not-allowed disabled:opacity-50`}
         aria-busy={isConnecting}
+        aria-disabled={isUnavailable || undefined}
       >
         <div className="flex items-center gap-4">
           <div className={`flex h-12 w-12 items-center justify-center rounded-lg text-2xl ${
-            showInstallButton
+            isUnavailable
+              ? 'bg-slate-200 dark:bg-slate-800'
+              : showInstallButton
               ? 'bg-amber-100 dark:bg-amber-800'
               : 'bg-slate-100 dark:bg-slate-800'
           }`}>
@@ -51,18 +62,42 @@ export function WalletOption({
           <div className="flex-1">
             <h3 className="font-semibold text-slate-900 dark:text-white">
               {name}
-              {!isInstalled && (
+              {isUnavailable && (
+                <span className="ml-2 inline-flex items-center rounded-full bg-slate-200 px-2 py-1 text-xs font-medium text-slate-700 dark:bg-slate-700 dark:text-slate-200">
+                  {unsupportedLabel}
+                </span>
+              )}
+              {!isUnavailable && !isInstalled && (
                 <span className="ml-2 inline-flex items-center rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 dark:bg-amber-800 dark:text-amber-200">
                   Not Installed
                 </span>
               )}
             </h3>
             <p className="text-sm text-slate-600 dark:text-slate-400">
-              {showInstallButton ? `Install ${name} to connect` : description}
+              {isUnavailable
+                ? 'Not supported yet — use Freighter or Lobstr'
+                : showInstallButton
+                ? `Install ${name} to connect`
+                : description}
             </p>
           </div>
           <div className="flex items-center gap-2">
-            {showInstallButton ? (
+            {isUnavailable ? (
+              <svg
+                className="h-5 w-5 text-slate-400 dark:text-slate-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            ) : showInstallButton ? (
               <svg
                 className="h-5 w-5 text-amber-600 dark:text-amber-400"
                 fill="none"

--- a/frontend/src/components/wallet/WalletSelectionModal.tsx
+++ b/frontend/src/components/wallet/WalletSelectionModal.tsx
@@ -5,7 +5,12 @@ import { WalletOption } from './WalletOption';
 import { ConnectedWalletView } from './ConnectedWalletView';
 import type { WalletType, WalletConnectionState } from '@/types/wallet';
 import { useToast } from '@/contexts/ToastContext';
-import { connectWallet } from '@/lib/wallet';
+import {
+  connectWallet,
+  isWalletConnectEnabled,
+  WALLETCONNECT_UNSUPPORTED_DESCRIPTION,
+  WALLETCONNECT_UNSUPPORTED_MESSAGE,
+} from '@/lib/wallet';
 import { errorToastWithCause } from '@/lib/error-copy';
 
 interface WalletSelectionModalProps {
@@ -31,6 +36,7 @@ export function WalletSelectionModal({
   });
   const modalRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  const walletConnectEnabled = isWalletConnectEnabled();
 
   const handleClose = useCallback(() => {
     if (connectionState.status === 'connecting') return;
@@ -112,6 +118,16 @@ export function WalletSelectionModal({
   }, [handleClose, isOpen]);
 
   const handleWalletSelect = useCallback(async (walletType: WalletType) => {
+    if (walletType === 'walletconnect' && !isWalletConnectEnabled()) {
+      setConnectionState({
+        status: 'error',
+        error: WALLETCONNECT_UNSUPPORTED_MESSAGE,
+        walletType,
+      });
+      showInfo(WALLETCONNECT_UNSUPPORTED_MESSAGE, WALLETCONNECT_UNSUPPORTED_DESCRIPTION);
+      return;
+    }
+
     // Check if wallet is installed first
     if (!isWalletInstalled(walletType)) {
       const installUrl = getInstallUrl(walletType);
@@ -144,7 +160,12 @@ export function WalletSelectionModal({
       onConnect?.(address, walletType);
       showSuccess('Wallet connected', `${walletType} wallet is ready.`);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Failed to connect';
+      const errorMessage =
+        error && typeof error === 'object' && 'message' in error && typeof error.message === 'string'
+          ? error.message
+          : error instanceof Error
+          ? error.message
+          : 'Failed to connect';
       dismiss(loadingToastId);
       setConnectionState({
         status: 'error',
@@ -153,7 +174,7 @@ export function WalletSelectionModal({
       });
       showError('WALLET_CONNECTION_FAILED', errorToastWithCause('WALLET_CONNECTION_FAILED', error));
     }
-  }, [dismiss, onConnect, showError, showLoading, showSuccess, showInfo]);
+  }, [dismiss, getInstallUrl, isWalletInstalled, onConnect, showError, showLoading, showSuccess, showInfo]);
 
   const handleInstallWallet = useCallback((walletType: WalletType) => {
     const installUrl = getInstallUrl(walletType);
@@ -164,7 +185,7 @@ export function WalletSelectionModal({
         `Opening ${walletType} installation page. Please return here after installation.`
       );
     }
-  }, [showInfo]);
+  }, [getInstallUrl, showInfo]);
 
   const handleDisconnect = useCallback(() => {
     setConnectionState({ status: 'disconnected' });
@@ -173,6 +194,9 @@ export function WalletSelectionModal({
 
   const handleRetry = useCallback(() => {
     if (connectionState.status === 'error' && connectionState.walletType) {
+      if (connectionState.walletType === 'walletconnect' && !isWalletConnectEnabled()) {
+        return;
+      }
       handleWalletSelect(connectionState.walletType);
     }
   }, [connectionState, handleWalletSelect]);
@@ -287,7 +311,9 @@ export function WalletSelectionModal({
                 connectionState.status === 'connecting' &&
                 connectionState.walletType === 'walletconnect'
               }
-              isInstalled={isWalletInstalled('walletconnect')}
+              isInstalled={walletConnectEnabled}
+              unsupported={!walletConnectEnabled}
+              unsupportedLabel="Coming soon"
               installUrl={getInstallUrl('walletconnect') || undefined}
               onSelect={() => handleWalletSelect('walletconnect')}
               onInstall={() => handleInstallWallet('walletconnect')}
@@ -319,12 +345,18 @@ export function WalletSelectionModal({
                     <p className="text-sm font-medium text-red-800 dark:text-red-200">
                       {connectionState.error}
                     </p>
-                    <button
-                      onClick={handleRetry}
-                      className="mt-2 text-sm font-medium text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                    >
-                      Try again
-                    </button>
+                    {connectionState.walletType === 'walletconnect' && !walletConnectEnabled ? (
+                      <p className="mt-1 text-sm text-red-700 dark:text-red-300">
+                        {WALLETCONNECT_UNSUPPORTED_DESCRIPTION}
+                      </p>
+                    ) : (
+                      <button
+                        onClick={handleRetry}
+                        className="mt-2 text-sm font-medium text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                      >
+                        Try again
+                      </button>
+                    )}
                   </div>
                 </div>
               </div>
@@ -335,4 +367,3 @@ export function WalletSelectionModal({
     </div>
   );
 }
-

--- a/frontend/src/components/wallet/__tests__/WalletSelectionModal.test.tsx
+++ b/frontend/src/components/wallet/__tests__/WalletSelectionModal.test.tsx
@@ -10,6 +10,10 @@ vi.mock('@/lib/wallet', () => ({
   connectWallet: vi.fn(),
   isWalletInstalled: vi.fn(),
   getWalletInstallUrl: vi.fn(),
+  isWalletConnectEnabled: vi.fn(() => false),
+  WALLETCONNECT_UNSUPPORTED_MESSAGE: 'WalletConnect is not available yet',
+  WALLETCONNECT_UNSUPPORTED_DESCRIPTION:
+    'WalletConnect support is coming soon. Please connect with Freighter or Lobstr for now.',
 }));
 
 // Mock the toast context
@@ -28,7 +32,7 @@ vi.mock('@/lib/error-copy', () => ({
   errorToastWithCause: vi.fn(() => ({ title: 'Test Error', message: 'Test error message' })),
 }));
 
-import { connectWallet, isWalletInstalled, getWalletInstallUrl } from '@/lib/wallet';
+import { connectWallet, isWalletInstalled, getWalletInstallUrl, isWalletConnectEnabled } from '@/lib/wallet';
 
 describe('WalletSelectionModal', () => {
   const mockOnConnect = vi.fn();
@@ -83,12 +87,25 @@ describe('WalletSelectionModal', () => {
   it('shows installation status for wallets', () => {
     renderModal();
 
-    // Freighter is installed
-    expect(screen.queryByText('Not Installed')).not.toBeInTheDocument();
-    
-    // Lobstr and WalletConnect are not installed
-    const lobstrNotInstalled = screen.getAllByText('Not Installed');
-    expect(lobstrNotInstalled).toHaveLength(2);
+    // Lobstr is not installed
+    expect(screen.getByText('Not Installed')).toBeInTheDocument();
+    // WalletConnect is feature-flagged off → Coming soon CTA
+    expect(screen.getByText('Coming soon')).toBeInTheDocument();
+    expect(screen.getByText('Not supported yet — use Freighter or Lobstr')).toBeInTheDocument();
+  });
+
+  it('shows unsupported CTA for WalletConnect without crashing Freighter', async () => {
+    const { isWalletConnectEnabled } = await import('@/lib/wallet');
+    (isWalletConnectEnabled as any).mockReturnValue(false);
+
+    renderModal();
+
+    const wcButton = screen.getByText('WalletConnect').closest('button');
+    await userEvent.click(wcButton!);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('WalletConnect is not available yet');
+    expect(connectWallet).not.toHaveBeenCalled();
+    expect(screen.getByText('Freighter')).toBeInTheDocument();
   });
 
   it('opens installation page when clicking non-installed wallet', async () => {

--- a/frontend/src/lib/__tests__/notifications.test.ts
+++ b/frontend/src/lib/__tests__/notifications.test.ts
@@ -2,10 +2,39 @@
  * Unit tests for notifications lib helpers
  */
 
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   MOCK_NOTIFICATIONS,
+  shouldUseMockNotifications,
   type Notification,
 } from '../notifications';
+
+describe('shouldUseMockNotifications', () => {
+  const original = process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS;
+    } else {
+      process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS = original;
+    }
+  });
+
+  it('defaults to API (false) when unset', () => {
+    delete process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS;
+    expect(shouldUseMockNotifications()).toBe(false);
+  });
+
+  it('is opt-in only when set to true', () => {
+    process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS = 'true';
+    expect(shouldUseMockNotifications()).toBe(true);
+  });
+
+  it('does not treat "false" as mock', () => {
+    process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS = 'false';
+    expect(shouldUseMockNotifications()).toBe(false);
+  });
+});
 
 describe('MOCK_NOTIFICATIONS', () => {
   it('contains at least one notification', () => {
@@ -48,18 +77,20 @@ describe('fetchNotifications (mocked fetch)', () => {
     is_read: false,
     metadata: null,
     created_at: new Date().toISOString(),
+    digest_count: 1,
+    digest_event_times: null,
   };
 
   beforeEach(() => {
-    global.fetch = jest.fn();
+    global.fetch = vi.fn();
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('calls the correct endpoint', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 200,
       json: async () => [mockNotif],
@@ -75,7 +106,7 @@ describe('fetchNotifications (mocked fetch)', () => {
   });
 
   it('appends unread_only query param when requested', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 200,
       json: async () => [],
@@ -90,7 +121,7 @@ describe('fetchNotifications (mocked fetch)', () => {
   });
 
   it('throws on non-ok response', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: false,
       status: 401,
       json: async () => ({ message: 'Unauthorized' }),
@@ -103,15 +134,15 @@ describe('fetchNotifications (mocked fetch)', () => {
 
 describe('markAllNotificationsRead (mocked fetch)', () => {
   beforeEach(() => {
-    global.fetch = jest.fn();
+    global.fetch = vi.fn();
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('calls PATCH mark-all-read endpoint', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 200,
       json: async () => ({ updated: 3 }),

--- a/frontend/src/lib/__tests__/transactions.test.ts
+++ b/frontend/src/lib/__tests__/transactions.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mapPaymentToTransaction,
+  mapPaymentsResponse,
+  getAnalyticsPaymentsUrl,
+} from '../transactions';
+
+describe('transactions helpers', () => {
+  it('maps backend payment records to UI transactions', () => {
+    const tx = mapPaymentToTransaction({
+      id: 'pay-1',
+      creator: 'GCREATOR',
+      fan: 'GFAN',
+      amount: '12.5',
+      fee: '0.1',
+      asset: 'XLM',
+      txHash: 'abc123',
+      paidAt: '2026-01-15T12:00:00.000Z',
+    });
+
+    expect(tx).toEqual({
+      id: 'pay-1',
+      type: 'payment',
+      status: 'success',
+      amount: 12.5,
+      currency: 'XLM',
+      txHash: 'abc123',
+      createdAt: '2026-01-15T12:00:00.000Z',
+    });
+  });
+
+  it('maps paginated backend payloads and tolerates empty data', () => {
+    const empty = mapPaymentsResponse({ data: [], total: 0, page: 1, limit: 10, totalPages: 1 });
+    expect(empty.data).toEqual([]);
+    expect(empty.totalPages).toBe(1);
+
+    const mapped = mapPaymentsResponse({
+      data: [
+        {
+          id: 'p2',
+          creator: 'C',
+          fan: 'F',
+          amount: '3',
+          fee: '0',
+          asset: 'USDC',
+          txHash: '',
+          paidAt: '2026-02-01T00:00:00.000Z',
+        },
+      ],
+      total: 1,
+      page: 1,
+      limit: 10,
+      totalPages: 1,
+    });
+
+    expect(mapped.data).toHaveLength(1);
+    expect(mapped.data[0].currency).toBe('USDC');
+    expect(mapped.data[0].txHash).toBeUndefined();
+  });
+
+  it('builds an absolute analytics payments URL', () => {
+    expect(getAnalyticsPaymentsUrl()).toMatch(/\/v1\/analytics\/payments$/);
+  });
+});

--- a/frontend/src/lib/__tests__/wallet.test.ts
+++ b/frontend/src/lib/__tests__/wallet.test.ts
@@ -12,8 +12,11 @@ import {
   signTransactionLegacy,
   getConnectedAddressLegacy,
   isWalletConnectedLegacy,
+  isWalletConnectEnabled,
+  WALLETCONNECT_UNSUPPORTED_MESSAGE,
 } from '../wallet';
 import { createAppError } from '@/types/errors';
+import { resetFeatureFlagsForTests } from '@/lib/feature-flags';
 
 // Mock window object
 const mockFreighter = {
@@ -34,6 +37,8 @@ const mockWindow = {
 describe('wallet library', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetFeatureFlagsForTests();
+    delete process.env.NEXT_PUBLIC_FEATURE_WALLET_CONNECT;
     Object.defineProperty(window, 'freighter', {
       value: mockFreighter,
       writable: true,
@@ -46,6 +51,8 @@ describe('wallet library', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    resetFeatureFlagsForTests();
+    delete process.env.NEXT_PUBLIC_FEATURE_WALLET_CONNECT;
   });
 
   describe('isWalletInstalled', () => {
@@ -57,7 +64,14 @@ describe('wallet library', () => {
       expect(isWalletInstalled('lobstr')).toBe(true);
     });
 
-    it('returns true for WalletConnect (protocol does not require installation)', () => {
+    it('returns false for WalletConnect when feature flag is off (stub)', () => {
+      expect(isWalletConnectEnabled()).toBe(false);
+      expect(isWalletInstalled('walletconnect')).toBe(false);
+    });
+
+    it('returns true for WalletConnect when feature flag is enabled', () => {
+      process.env.NEXT_PUBLIC_FEATURE_WALLET_CONNECT = 'true';
+      expect(isWalletConnectEnabled()).toBe(true);
       expect(isWalletInstalled('walletconnect')).toBe(true);
     });
 
@@ -105,10 +119,22 @@ describe('wallet library', () => {
       expect(mockLobstr.getPublicKey).toHaveBeenCalled();
     });
 
-    it('throws error for WalletConnect (not implemented)', async () => {
-      await expect(connectWallet('walletconnect')).rejects.toThrow(
-        'WalletConnect integration is not yet implemented'
-      );
+    it('throws structured unsupported error for WalletConnect stub', async () => {
+      process.env.NEXT_PUBLIC_FEATURE_WALLET_CONNECT = 'true';
+
+      await expect(connectWallet('walletconnect')).rejects.toMatchObject({
+        code: 'UNSUPPORTED_WALLET',
+        message: WALLETCONNECT_UNSUPPORTED_MESSAGE,
+      });
+    });
+
+    it('does not affect Freighter when WalletConnect stub fails', async () => {
+      await expect(connectWallet('walletconnect')).rejects.toMatchObject({
+        code: 'WALLET_NOT_INSTALLED',
+      });
+
+      mockFreighter.getPublicKey.mockResolvedValue(mockAddress);
+      await expect(connectWallet('freighter')).resolves.toBe(mockAddress);
     });
 
     it('throws error when wallet is not installed', async () => {
@@ -169,10 +195,9 @@ describe('wallet library', () => {
       expect(mockLobstr.signTransaction).toHaveBeenCalledWith(mockXdr);
     });
 
-    it('throws error for WalletConnect signing (not implemented)', async () => {
-      await expect(signTransaction(mockXdr, 'walletconnect')).rejects.toThrow(
-        'WalletConnect integration is not yet implemented'
-      );
+    it('signs with Freighter even when WalletConnect is stubbed', async () => {
+      mockFreighter.signTransaction.mockResolvedValue(mockSignedXdr);
+      await expect(signTransaction(mockXdr)).resolves.toBe(mockSignedXdr);
     });
 
     it('throws error when wallet is not installed', async () => {

--- a/frontend/src/lib/feature-flags.ts
+++ b/frontend/src/lib/feature-flags.ts
@@ -7,6 +7,7 @@ export const FeatureFlag = {
   REFERRAL_CODES: 'referral_codes',
   NEW_SUBSCRIPTION_FLOW: 'newSubscriptionFlow',
   CRYPTO_PAYMENTS: 'cryptoPayments',
+  WALLET_CONNECT: 'walletConnect',
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -50,6 +51,10 @@ export const featureFlagDefinitions: Record<FeatureFlag, FeatureFlagDefinition> 
     description: 'Enables crypto payment options in the checkout flow.',
     envKey: 'NEXT_PUBLIC_FEATURE_CRYPTO_PAYMENTS',
   },
+  [FeatureFlag.WALLET_CONNECT]: {
+    description: 'Enables WalletConnect as a wallet connection option. Disabled by default until the provider is fully integrated.',
+    envKey: 'NEXT_PUBLIC_FEATURE_WALLET_CONNECT',
+  },
 };
 
 export const defaultFeatureFlags: FeatureFlagSnapshot = Object.freeze({
@@ -59,6 +64,7 @@ export const defaultFeatureFlags: FeatureFlagSnapshot = Object.freeze({
   [FeatureFlag.REFERRAL_CODES]: false,
   [FeatureFlag.NEW_SUBSCRIPTION_FLOW]: false,
   [FeatureFlag.CRYPTO_PAYMENTS]: false,
+  [FeatureFlag.WALLET_CONNECT]: false,
 });
 
 let cachedRemoteFlags: FeatureFlagOverrides = {};

--- a/frontend/src/lib/featureFlags.ts
+++ b/frontend/src/lib/featureFlags.ts
@@ -1,9 +1,0 @@
-export const featureFlags = {
-  newSubscriptionFlow:
-    process.env.NEXT_PUBLIC_FEATURE_NEW_SUBSCRIPTION_FLOW === 'true',
-  cryptoPayments: process.env.NEXT_PUBLIC_FEATURE_CRYPTO_PAYMENTS === 'true',
-};
-
-export function isFeatureEnabled(feature: keyof typeof featureFlags): boolean {
-  return featureFlags[feature];
-}

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -29,6 +29,15 @@ export interface Notification {
 
 const API_BASE = `${getApiBaseUrl()}/api/v1`;
 
+/**
+ * Mock inbox is opt-in only.
+ * Production / default: hit the API.
+ * Set `NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS=true` to use MOCK_NOTIFICATIONS.
+ */
+export function shouldUseMockNotifications(): boolean {
+  return process.env.NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS === 'true';
+}
+
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/lib/transactions.ts
+++ b/frontend/src/lib/transactions.ts
@@ -1,0 +1,95 @@
+import { getApiBaseUrl } from '@/lib/api/base-url';
+
+/** UI transaction row used by the transactions page table. */
+export interface Transaction {
+  id: string;
+  type: 'subscription' | 'payment' | 'refund';
+  status: 'pending' | 'success' | 'failed';
+  amount: number;
+  currency: string;
+  txHash?: string;
+  createdAt: string;
+}
+
+/** Shape returned by Nest `GET /v1/analytics/payments`. */
+export interface BackendPaymentRecord {
+  id: string;
+  creator: string;
+  fan: string;
+  amount: string;
+  fee: string;
+  asset: string;
+  txHash: string;
+  paidAt: string;
+}
+
+export interface TransactionsQuery {
+  page?: number;
+  limit?: number;
+  creator?: string;
+  from?: string;
+  to?: string;
+  type?: string;
+  status?: string;
+}
+
+export interface TransactionsResponse {
+  data: Transaction[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+/**
+ * Absolute Nest URL for analytics payments (server-side proxy target).
+ */
+export function getAnalyticsPaymentsUrl(): string {
+  const base = getApiBaseUrl();
+  if (base.endsWith('/api/v1') || base.endsWith('/v1')) {
+    return `${base}/analytics/payments`;
+  }
+  if (base.endsWith('/api')) {
+    return `${base}/v1/analytics/payments`;
+  }
+  return `${base}/v1/analytics/payments`;
+}
+
+export function mapPaymentToTransaction(payment: BackendPaymentRecord): Transaction {
+  return {
+    id: payment.id,
+    type: 'payment',
+    status: 'success',
+    amount: parseFloat(payment.amount) || 0,
+    currency: payment.asset || 'XLM',
+    txHash: payment.txHash || undefined,
+    createdAt: payment.paidAt,
+  };
+}
+
+export function mapPaymentsResponse(payload: unknown): TransactionsResponse {
+  const body = (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>;
+  const rawItems = Array.isArray(body.data) ? body.data : Array.isArray(payload) ? payload : [];
+
+  const data = rawItems.map((item) => {
+    const record = item as Partial<BackendPaymentRecord> & Record<string, unknown>;
+    return mapPaymentToTransaction({
+      id: String(record.id ?? ''),
+      creator: String(record.creator ?? ''),
+      fan: String(record.fan ?? ''),
+      amount: String(record.amount ?? '0'),
+      fee: String(record.fee ?? '0'),
+      asset: String(record.asset ?? record.currency ?? 'XLM'),
+      txHash: String(record.txHash ?? ''),
+      paidAt: String(record.paidAt ?? record.date ?? record.createdAt ?? new Date().toISOString()),
+    });
+  });
+
+  const page = typeof body.page === 'number' ? body.page : 1;
+  const limit = typeof body.limit === 'number' ? body.limit : 10;
+  const total = typeof body.total === 'number' ? body.total : data.length;
+  const totalPages =
+    typeof body.totalPages === 'number' ? body.totalPages : Math.max(1, Math.ceil(total / limit));
+
+  return { data, total, page, limit, totalPages };
+}

--- a/frontend/src/lib/wallet.ts
+++ b/frontend/src/lib/wallet.ts
@@ -1,4 +1,18 @@
 import { createAppError, type AppError } from '@/types/errors';
+import { FeatureFlag, isFeatureEnabled } from '@/lib/feature-flags';
+
+/** Clear copy when WalletConnect is stubbed / not yet available */
+export const WALLETCONNECT_UNSUPPORTED_MESSAGE = 'WalletConnect is not available yet';
+export const WALLETCONNECT_UNSUPPORTED_DESCRIPTION =
+  'WalletConnect support is coming soon. Please connect with Freighter or Lobstr for now.';
+
+/**
+ * Whether WalletConnect is enabled via feature flag.
+ * Defaults to false — the provider is a stub until fully integrated.
+ */
+export function isWalletConnectEnabled(): boolean {
+  return isFeatureEnabled(FeatureFlag.WALLET_CONNECT);
+}
 
 /** Base wallet interface */
 interface BaseWallet {
@@ -57,8 +71,8 @@ export function isWalletInstalled(walletType: 'freighter' | 'lobstr' | 'walletco
     case 'lobstr':
       return !!windowWithWallets.lobstr;
     case 'walletconnect':
-      // WalletConnect doesn't require installation - it's a protocol
-      return true;
+      // Protocol wallets need no extension; still gated by feature flag.
+      return isWalletConnectEnabled();
     default:
       return false;
   }
@@ -325,9 +339,16 @@ async function connectLobstr(): Promise<string> {
 }
 
 async function connectWalletConnect(): Promise<string> {
-  // WalletConnect implementation would go here
-  // For now, throw an error as it's not implemented
-  throw new Error('WalletConnect integration is not yet implemented');
+  // Stub: full WalletConnect provider is not wired yet.
+  // Throw a structured AppError so UI can show a clear unsupported CTA
+  // without crashing Freighter/Lobstr flows.
+  throw createAppError('UNSUPPORTED_WALLET', {
+    message: WALLETCONNECT_UNSUPPORTED_MESSAGE,
+    description: WALLETCONNECT_UNSUPPORTED_DESCRIPTION,
+    actions: [
+      { label: 'Use Freighter', type: 'retry', primary: true },
+    ],
+  });
 }
 
 async function signWithFreighter(xdr: string): Promise<string> {
@@ -358,7 +379,9 @@ async function signWithLobstr(xdr: string): Promise<string> {
   return signedXdr;
 }
 
-async function signWithWalletConnect(xdr: string): Promise<string> {
-  // WalletConnect implementation would go here
-  throw new Error('WalletConnect integration is not yet implemented');
+async function signWithWalletConnect(_xdr: string): Promise<string> {
+  throw createAppError('UNSUPPORTED_WALLET', {
+    message: WALLETCONNECT_UNSUPPORTED_MESSAGE,
+    description: WALLETCONNECT_UNSUPPORTED_DESCRIPTION,
+  });
 }


### PR DESCRIPTION
closes #1456 
closes #1458 
closes #1463 
closes #1465

### PR description

## Summary
- **WalletConnect stub:** Feature-flagged off by default (`walletConnect` / `NEXT_PUBLIC_FEATURE_WALLET_CONNECT`). Connect throws a structured `UNSUPPORTED_WALLET` error; modal shows a clear “Coming soon” CTA. Freighter/Lobstr flows unchanged.
- **Transactions:** Added Next.js `GET`/`POST` `/api/transactions` proxy to Nest `GET /v1/analytics/payments` with auth header forwarding, response mapping, and error surfaces. Page no longer 404s on a missing route.
- **Feature flags:** Removed duplicate `featureFlags.ts`; single source of truth is `feature-flags.ts`. `FeatureFlag` component and docs updated.
- **Notifications:** Inbox defaults to the API; mocks only when `NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS=true`. Empty/error/loading states covered.

## Changes by task

### 1 — WalletConnect provider stub
- Stub in `connectWalletConnect()` + `isWalletConnectEnabled()`
- UI: `WalletOption` unsupported state + modal CTA copy
- Tests: wallet lib + modal unsupported CTA

### 2 — Transactions route
- `frontend/src/app/api/transactions/route.ts` (proxy + auth)
- `frontend/src/lib/transactions.ts` (types/mappers)
- Page wired to `/api/transactions` with loading/error
- Route + mapper unit tests

### 3 — Unify feature-flag modules
- Deleted `frontend/src/lib/featureFlags.ts`
- Migrated `FeatureFlag.tsx` → `@/lib/feature-flags`
- Updated `docs/feature-flags.md` (single module + `walletConnect` flag)

### 4 — Notification inbox mock default
- `shouldUseMockNotifications()` opt-in only
- Inbox always API unless flag set
- Tests for API default, empty inbox, errors, mock opt-in

## Test plan
- [ ] Wallet modal: Freighter still connects; WalletConnect shows “Coming soon” and does not crash
- [ ] `/transactions` loads without 404; auth failures show error message (not blank crash)
- [ ] Notifications page hits API by default; empty list OK; set `NEXT_PUBLIC_USE_MOCK_NOTIFICATIONS=true` to confirm mock opt-in
- [ ] Confirm no imports of `@/lib/featureFlags` remain
- [ ] `npx vitest run` on the touched test files above