### PR TITLE
Title: feat: durable notification queue, gated content, expanded games API  

### DIFF
--- a/backend/src/auth-module/guards/optional-jwt-auth.guard.spec.ts
+++ b/backend/src/auth-module/guards/optional-jwt-auth.guard.spec.ts
@@ -1,0 +1,47 @@
+import { ExecutionContext } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { OptionalJwtAuthGuard } from './optional-jwt-auth.guard';
+
+describe('OptionalJwtAuthGuard', () => {
+  let guard: OptionalJwtAuthGuard;
+  const context = {} as ExecutionContext;
+
+  beforeEach(() => {
+    guard = new OptionalJwtAuthGuard();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('handleRequest', () => {
+    it('returns the user when authentication succeeds', () => {
+      const user = { userId: 'user-1' };
+      expect(guard.handleRequest(null, user)).toBe(user);
+    });
+
+    it('returns undefined instead of throwing when there is no user', () => {
+      expect(guard.handleRequest(null, false)).toBeUndefined();
+    });
+
+    it('returns undefined instead of throwing when passport reports an error', () => {
+      expect(guard.handleRequest(new Error('bad token'), false)).toBeUndefined();
+    });
+  });
+
+  describe('canActivate', () => {
+    it('returns true when passport authentication fails', async () => {
+      jest
+        .spyOn(AuthGuard('jwt').prototype, 'canActivate')
+        .mockRejectedValue(new Error('no token'));
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+    });
+
+    it('returns true when passport authentication succeeds', async () => {
+      jest.spyOn(AuthGuard('jwt').prototype, 'canActivate').mockResolvedValue(true);
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+    });
+  });
+});

--- a/backend/src/auth-module/guards/optional-jwt-auth.guard.ts
+++ b/backend/src/auth-module/guards/optional-jwt-auth.guard.ts
@@ -1,0 +1,28 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+/**
+ * Like {@link JwtAuthGuard} but never rejects the request: a valid bearer
+ * token populates `req.user`, while a missing or invalid one just leaves it
+ * undefined and the request proceeds unauthenticated.
+ *
+ * Use on routes that vary their response for authenticated vs. anonymous
+ * callers without requiring auth (e.g. gated-content teasers).
+ */
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard('jwt') {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    try {
+      await super.canActivate(context);
+    } catch {
+      // No/invalid token — proceed unauthenticated.
+    }
+    return true;
+  }
+
+  handleRequest(_err: unknown, user: unknown): unknown {
+    // Never throw here (that's what makes auth "optional"); just pass
+    // through whatever passport resolved, or undefined if it resolved none.
+    return user || undefined;
+  }
+}

--- a/backend/src/content/content-access.service.spec.ts
+++ b/backend/src/content/content-access.service.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ContentAccessService } from './content-access.service';
+import { ContentService } from './content.service';
+import { SubscriptionsService } from '../subscriptions/subscriptions.service';
+import { ContentMetadata, ContentType } from './entities/content.entity';
+
+const makeContent = (overrides: Partial<ContentMetadata> = {}): ContentMetadata =>
+  ({
+    id: 'uuid-1',
+    creator_id: 'creator-1',
+    title: 'Test Content',
+    description: 'Full description',
+    ipfs_cid: 'QmTest',
+    ipfs_url: 'https://gateway/QmTest',
+    content_type: ContentType.IMAGE,
+    subscription_tier: null,
+    is_published: true,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  }) as ContentMetadata;
+
+describe('ContentAccessService', () => {
+  let service: ContentAccessService;
+  let contentService: { findOne: jest.Mock };
+  let subscriptionsService: { isSubscriber: jest.Mock };
+
+  beforeEach(async () => {
+    contentService = { findOne: jest.fn() };
+    subscriptionsService = { isSubscriber: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ContentAccessService,
+        { provide: ContentService, useValue: contentService },
+        { provide: SubscriptionsService, useValue: subscriptionsService },
+      ],
+    }).compile();
+
+    service = module.get(ContentAccessService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns full content unlocked when not gated (public)', async () => {
+    contentService.findOne.mockResolvedValue(makeContent({ subscription_tier: null }));
+
+    const result = await service.getForRequester('uuid-1');
+
+    expect(result.locked).toBe(false);
+    expect(result.ipfs_cid).toBe('QmTest');
+    expect(result.description).toBe('Full description');
+    expect(subscriptionsService.isSubscriber).not.toHaveBeenCalled();
+  });
+
+  it('returns full content unlocked for anonymous callers when not gated', async () => {
+    contentService.findOne.mockResolvedValue(makeContent({ subscription_tier: null }));
+
+    const result = await service.getForRequester('uuid-1', undefined);
+
+    expect(result.locked).toBe(false);
+  });
+
+  it('returns full content unlocked for the owner even when gated', async () => {
+    contentService.findOne.mockResolvedValue(makeContent({ subscription_tier: 'gold' }));
+
+    const result = await service.getForRequester('uuid-1', 'creator-1');
+
+    expect(result.locked).toBe(false);
+    expect(result.ipfs_cid).toBe('QmTest');
+    expect(subscriptionsService.isSubscriber).not.toHaveBeenCalled();
+  });
+
+  it('returns full content unlocked for an active subscriber', async () => {
+    contentService.findOne.mockResolvedValue(makeContent({ subscription_tier: 'gold' }));
+    subscriptionsService.isSubscriber.mockResolvedValue(true);
+
+    const result = await service.getForRequester('uuid-1', 'fan-1');
+
+    expect(result.locked).toBe(false);
+    expect(result.ipfs_cid).toBe('QmTest');
+    expect(subscriptionsService.isSubscriber).toHaveBeenCalledWith('fan-1', 'creator-1');
+  });
+
+  it('returns a teaser without sensitive fields for a non-subscriber', async () => {
+    contentService.findOne.mockResolvedValue(makeContent({ subscription_tier: 'gold' }));
+    subscriptionsService.isSubscriber.mockResolvedValue(false);
+
+    const result = await service.getForRequester('uuid-1', 'fan-1');
+
+    expect(result.locked).toBe(true);
+    expect(result.ipfs_cid).toBeNull();
+    expect(result.ipfs_url).toBeNull();
+    expect(result.description).toBeNull();
+    expect(result.title).toBe('Test Content');
+    expect(result.preview_message).toBeTruthy();
+  });
+
+  it('returns a teaser for anonymous callers on gated content, without calling isSubscriber', async () => {
+    contentService.findOne.mockResolvedValue(makeContent({ subscription_tier: 'gold' }));
+
+    const result = await service.getForRequester('uuid-1');
+
+    expect(result.locked).toBe(true);
+    expect(subscriptionsService.isSubscriber).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/content/content-access.service.ts
+++ b/backend/src/content/content-access.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@nestjs/common';
+import { ContentService } from './content.service';
+import { ContentMetadata } from './entities/content.entity';
+import { SubscriptionsService } from '../subscriptions/subscriptions.service';
+
+export type GatedContentView = Partial<ContentMetadata> & {
+  locked: boolean;
+  preview_message?: string;
+};
+
+/**
+ * Resolves what a given requester is allowed to see for a content item.
+ *
+ * Gating is keyed on `subscription_tier`: content without a tier is public.
+ * Gated content is fully visible to its owner and to active subscribers;
+ * everyone else gets a teaser with the sensitive fields (description, IPFS
+ * pointers) stripped.
+ *
+ * NOTE: the subscriber check reuses `SubscriptionsService#isSubscriber`,
+ * which is keyed on Stellar addresses in the on-chain subscription flow.
+ * Until platform user IDs are bridged to wallet addresses (see the caveat
+ * documented on `HybridFanAuthGuard`), this treats `requesterId` /
+ * `creator_id` as opaque identity strings — the subscriber check only
+ * resolves correctly once the caller's identity matches how the
+ * subscription was indexed.
+ */
+@Injectable()
+export class ContentAccessService {
+  constructor(
+    private readonly contentService: ContentService,
+    private readonly subscriptionsService: SubscriptionsService,
+  ) {}
+
+  async getForRequester(
+    id: string,
+    requesterId?: string,
+  ): Promise<GatedContentView> {
+    const content = await this.contentService.findOne(id);
+
+    if (!content.subscription_tier) {
+      return { ...content, locked: false };
+    }
+
+    if (requesterId && requesterId === content.creator_id) {
+      return { ...content, locked: false };
+    }
+
+    const isSubscriber = requesterId
+      ? await this.subscriptionsService.isSubscriber(requesterId, content.creator_id)
+      : false;
+
+    if (isSubscriber) {
+      return { ...content, locked: false };
+    }
+
+    return this.buildTeaser(content);
+  }
+
+  private buildTeaser(content: ContentMetadata): GatedContentView {
+    return {
+      id: content.id,
+      creator_id: content.creator_id,
+      title: content.title,
+      description: null,
+      ipfs_cid: null,
+      ipfs_url: null,
+      content_type: content.content_type,
+      subscription_tier: content.subscription_tier,
+      is_published: content.is_published,
+      created_at: content.created_at,
+      updated_at: content.updated_at,
+      locked: true,
+      preview_message: 'Subscribe to this creator to unlock the full content.',
+    };
+  }
+}

--- a/backend/src/content/content.controller.spec.ts
+++ b/backend/src/content/content.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ContentController } from './content.controller';
+import { ContentAccessService } from './content-access.service';
 import { ContentService } from './content.service';
 import { ContentType } from './entities/content.entity';
 import { PaginatedResponseDto } from '../common/dto';
@@ -11,6 +12,10 @@ const mockService = () => ({
   findOne: jest.fn(),
   update: jest.fn(),
   remove: jest.fn(),
+});
+
+const mockAccessService = () => ({
+  getForRequester: jest.fn(),
 });
 
 const fakeUser = { userId: 'creator-1', email: 'test@example.com', role: 'user' };
@@ -32,15 +37,20 @@ const fakeContent = {
 describe('ContentController', () => {
   let controller: ContentController;
   let service: ReturnType<typeof mockService>;
+  let accessService: ReturnType<typeof mockAccessService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ContentController],
-      providers: [{ provide: ContentService, useFactory: mockService }],
+      providers: [
+        { provide: ContentService, useFactory: mockService },
+        { provide: ContentAccessService, useFactory: mockAccessService },
+      ],
     }).compile();
 
     controller = module.get(ContentController);
     service = module.get(ContentService);
+    accessService = module.get(ContentAccessService);
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -81,10 +91,24 @@ describe('ContentController', () => {
   });
 
   describe('findOne', () => {
-    it('returns single content item', async () => {
-      service.findOne.mockResolvedValue(fakeContent);
-      const result = await controller.findOne('uuid-1');
-      expect(result).toBe(fakeContent);
+    it('delegates to ContentAccessService with the requester id from the JWT', async () => {
+      const view = { ...fakeContent, locked: false };
+      accessService.getForRequester.mockResolvedValue(view);
+
+      const result = await controller.findOne('uuid-1', fakeUser);
+
+      expect(accessService.getForRequester).toHaveBeenCalledWith('uuid-1', 'creator-1');
+      expect(result).toBe(view);
+    });
+
+    it('passes undefined as requester id for anonymous callers', async () => {
+      const teaser = { ...fakeContent, locked: true };
+      accessService.getForRequester.mockResolvedValue(teaser);
+
+      const result = await controller.findOne('uuid-1', undefined as any);
+
+      expect(accessService.getForRequester).toHaveBeenCalledWith('uuid-1', undefined);
+      expect(result).toBe(teaser);
     });
   });
 

--- a/backend/src/content/content.controller.ts
+++ b/backend/src/content/content.controller.ts
@@ -20,7 +20,9 @@ import {
 } from '@nestjs/swagger';
 import { CurrentUser, JwtUserPayload } from '../auth-module/decorators/current-user.decorator';
 import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../auth-module/guards/optional-jwt-auth.guard';
 import { PaginatedResponseDto, PaginationDto } from '../common/dto';
+import { ContentAccessService, GatedContentView } from './content-access.service';
 import { ContentService } from './content.service';
 import { ContentResponseDto, CreateContentDto, UpdateContentDto } from './dto/content.dto';
 import { ContentMetadata } from './entities/content.entity';
@@ -28,7 +30,10 @@ import { ContentMetadata } from './entities/content.entity';
 @ApiTags('content')
 @Controller({ path: 'content', version: '1' })
 export class ContentController {
-  constructor(private readonly contentService: ContentService) {}
+  constructor(
+    private readonly contentService: ContentService,
+    private readonly contentAccessService: ContentAccessService,
+  ) {}
 
   @Post()
   @UseGuards(JwtAuthGuard)
@@ -62,11 +67,18 @@ export class ContentController {
   }
 
   @Get(':id')
-  @ApiOperation({ summary: 'Get content by ID' })
-  @ApiResponse({ status: 200, type: ContentResponseDto })
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiOperation({
+    summary:
+      'Get content by ID — gated content returns a teaser to non-subscribers',
+  })
+  @ApiResponse({ status: 200 })
   @ApiResponse({ status: 404 })
-  findOne(@Param('id', ParseUUIDPipe) id: string): Promise<ContentMetadata> {
-    return this.contentService.findOne(id);
+  findOne(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: JwtUserPayload,
+  ): Promise<GatedContentView> {
+    return this.contentAccessService.getForRequester(id, user?.userId);
   }
 
   @Put(':id')

--- a/backend/src/content/content.module.ts
+++ b/backend/src/content/content.module.ts
@@ -1,15 +1,21 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { SubscriptionsModule } from '../subscriptions/subscriptions.module';
 import { ContentController } from './content.controller';
+import { ContentAccessService } from './content-access.service';
 import { ContentService } from './content.service';
 import { ContentMetadata } from './entities/content.entity';
 import { IpfsService } from './ipfs.service';
 
 @Module({
-  imports: [ConfigModule, TypeOrmModule.forFeature([ContentMetadata])],
+  imports: [
+    ConfigModule,
+    TypeOrmModule.forFeature([ContentMetadata]),
+    SubscriptionsModule,
+  ],
   controllers: [ContentController],
-  providers: [ContentService, IpfsService],
+  providers: [ContentService, IpfsService, ContentAccessService],
   exports: [ContentService],
 })
 export class ContentModule {}

--- a/backend/src/games/dto/submit-score.dto.ts
+++ b/backend/src/games/dto/submit-score.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, Min } from 'class-validator';
+
+export class SubmitScoreDto {
+  @ApiProperty({ description: "Player's current/final balance for the game" })
+  @IsNumber()
+  @Min(0)
+  balance: number;
+}

--- a/backend/src/games/entities/game.entity.ts
+++ b/backend/src/games/entities/game.entity.ts
@@ -24,6 +24,10 @@ export class Game {
     randomize_turn_order: boolean;
   };
 
+  /** User ID of the player who can start the game; the first player to join. */
+  @Column({ type: 'varchar', nullable: true })
+  host_user_id: string | null;
+
   @OneToMany(() => Player, player => player.game)
   players: Player[];
 

--- a/backend/src/games/games.controller.spec.ts
+++ b/backend/src/games/games.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { GamesController } from './games.controller';
 import { GamesService } from './games.service';
 import { GameStatus } from './entities/game.entity';
@@ -32,6 +32,9 @@ describe('GamesController', () => {
   const mockGamesService = {
     findAll: jest.fn(),
     joinGame: jest.fn(),
+    startGame: jest.fn(),
+    leaveGame: jest.fn(),
+    submitScore: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -156,6 +159,93 @@ describe('GamesController', () => {
       await expect(controller.joinGame('game-1', mockUser)).rejects.toThrow(
         BadRequestException,
       );
+    });
+  });
+
+  describe('startGame', () => {
+    it('returns the started game on success', async () => {
+      const startedGame = { ...mockGame, status: GameStatus.IN_PROGRESS };
+      mockGamesService.startGame.mockResolvedValue(startedGame);
+
+      const result = await controller.startGame('game-1', mockUser);
+
+      expect(result).toEqual(startedGame);
+      expect(mockGamesService.startGame).toHaveBeenCalledWith('game-1', 'user-1');
+    });
+
+    it('propagates ForbiddenException when caller is not the host', async () => {
+      mockGamesService.startGame.mockRejectedValue(
+        new ForbiddenException('Only the host can start the game'),
+      );
+
+      await expect(controller.startGame('game-1', mockUser)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('propagates BadRequestException when game is not in a startable state', async () => {
+      mockGamesService.startGame.mockRejectedValue(
+        new BadRequestException('Game is not in PENDING status'),
+      );
+
+      await expect(controller.startGame('game-1', mockUser)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('leaveGame', () => {
+    it('returns confirmation on success', async () => {
+      mockGamesService.leaveGame.mockResolvedValue({ left: true });
+
+      const result = await controller.leaveGame('game-1', mockUser);
+
+      expect(result).toEqual({ left: true });
+      expect(mockGamesService.leaveGame).toHaveBeenCalledWith('game-1', 'user-1');
+    });
+
+    it('propagates BadRequestException when game is completed', async () => {
+      mockGamesService.leaveGame.mockRejectedValue(
+        new BadRequestException('Cannot leave a completed game'),
+      );
+
+      await expect(controller.leaveGame('game-1', mockUser)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('propagates NotFoundException when player never joined', async () => {
+      mockGamesService.leaveGame.mockRejectedValue(
+        new NotFoundException('Player not found in this game'),
+      );
+
+      await expect(controller.leaveGame('game-1', mockUser)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('submitScore', () => {
+    it('delegates to the service with the JWT subject and dto', async () => {
+      const updatedPlayer = { ...mockPlayer, balance: 2500 };
+      mockGamesService.submitScore.mockResolvedValue(updatedPlayer);
+
+      const result = await controller.submitScore('game-1', mockUser, { balance: 2500 });
+
+      expect(result).toEqual(updatedPlayer);
+      expect(mockGamesService.submitScore).toHaveBeenCalledWith('game-1', 'user-1', {
+        balance: 2500,
+      });
+    });
+
+    it('propagates BadRequestException when game is not in progress', async () => {
+      mockGamesService.submitScore.mockRejectedValue(
+        new BadRequestException('Game is not in progress'),
+      );
+
+      await expect(
+        controller.submitScore('game-1', mockUser, { balance: 100 }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/backend/src/games/games.controller.ts
+++ b/backend/src/games/games.controller.ts
@@ -1,4 +1,5 @@
 import {
+  Body,
   Controller,
   Get,
   Post,
@@ -18,6 +19,7 @@ import {
 } from '@nestjs/swagger';
 import { GamesService } from './games.service';
 import { ListGamesDto } from './dto/list-games.dto';
+import { SubmitScoreDto } from './dto/submit-score.dto';
 import { JwtAuthGuard } from '../auth-module/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth-module/decorators/current-user.decorator';
 
@@ -67,5 +69,60 @@ export class GamesController {
     @CurrentUser() user: { userId: string },
   ) {
     return await this.gamesService.joinGame(id, user.userId);
+  }
+
+  /**
+   * As with join, the actor is always the authenticated JWT subject —
+   * never a caller-supplied body field.
+   */
+  @Post(':id/start')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Start a game (host only)' })
+  @ApiParam({ name: 'id', description: 'Game ID' })
+  @ApiResponse({ status: 201, description: 'Game started' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Only the host can start the game' })
+  @ApiResponse({ status: 404, description: 'Game not found' })
+  @ApiResponse({ status: 400, description: 'Game is not in a startable state' })
+  async startGame(
+    @Param('id') id: string,
+    @CurrentUser() user: { userId: string },
+  ) {
+    return await this.gamesService.startGame(id, user.userId);
+  }
+
+  @Post(':id/leave')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Leave a game as the authenticated user' })
+  @ApiParam({ name: 'id', description: 'Game ID' })
+  @ApiResponse({ status: 200, description: 'Successfully left the game' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Game or player not found' })
+  @ApiResponse({ status: 400, description: 'Cannot leave a completed game' })
+  async leaveGame(
+    @Param('id') id: string,
+    @CurrentUser() user: { userId: string },
+  ) {
+    return await this.gamesService.leaveGame(id, user.userId);
+  }
+
+  @Post(':id/score')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Submit the authenticated player's current/final score" })
+  @ApiParam({ name: 'id', description: 'Game ID' })
+  @ApiResponse({ status: 201, description: 'Score recorded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Game or player not found' })
+  @ApiResponse({ status: 400, description: 'Game is not in progress' })
+  async submitScore(
+    @Param('id') id: string,
+    @CurrentUser() user: { userId: string },
+    @Body() dto: SubmitScoreDto,
+  ) {
+    return await this.gamesService.submitScore(id, user.userId, dto);
   }
 }

--- a/backend/src/games/games.service.spec.ts
+++ b/backend/src/games/games.service.spec.ts
@@ -33,6 +33,7 @@ describe('GamesService', () => {
       findOne: jest.fn(),
       create: jest.fn(),
       save: jest.fn(),
+      remove: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -179,6 +180,218 @@ describe('GamesService', () => {
 
       await expect(service.joinGame(mockGame.id!, mockPlayer.user_id!))
         .rejects.toThrow('Player already joined this game');
+    });
+
+    it('assigns the first joining player as host', async () => {
+      mockManager.findOne
+        .mockResolvedValueOnce(mockGame)
+        .mockResolvedValueOnce(null);
+      mockManager.create.mockReturnValue(mockPlayer);
+      mockManager.save.mockResolvedValue(mockPlayer);
+
+      await service.joinGame(mockGame.id!, mockPlayer.user_id!);
+
+      expect(mockManager.save).toHaveBeenCalledWith(
+        Game,
+        expect.objectContaining({ host_user_id: mockPlayer.user_id }),
+      );
+    });
+
+    it('does not reassign host when a later player joins', async () => {
+      const gameWithHost = { ...mockGame, host_user_id: 'existing-host', players: [{ id: 'p1' }] };
+      mockManager.findOne
+        .mockResolvedValueOnce(gameWithHost)
+        .mockResolvedValueOnce(null);
+      mockManager.create.mockReturnValue(mockPlayer);
+      mockManager.save.mockResolvedValue(mockPlayer);
+
+      await service.joinGame(mockGame.id!, mockPlayer.user_id!);
+
+      expect(mockManager.save).not.toHaveBeenCalledWith(
+        Game,
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('startGame', () => {
+    const pendingGameWithPlayers = {
+      ...mockGame,
+      host_user_id: 'host-1',
+      players: [{ id: 'p1', user_id: 'host-1' }, { id: 'p2', user_id: 'user-2' }],
+    };
+
+    it('allows the host to start a pending game with enough players', async () => {
+      mockManager.findOne.mockResolvedValueOnce(pendingGameWithPlayers);
+      mockManager.save.mockImplementation((_entity: unknown, value: unknown) => value);
+
+      const result = await service.startGame(mockGame.id!, 'host-1');
+
+      expect(result.status).toBe(GameStatus.IN_PROGRESS);
+      expect(mockManager.save).toHaveBeenCalledWith(
+        Game,
+        expect.objectContaining({ status: GameStatus.IN_PROGRESS }),
+      );
+    });
+
+    it('throws NotFoundException when game does not exist', async () => {
+      mockManager.findOne.mockResolvedValueOnce(null);
+      await expect(service.startGame('missing', 'host-1')).rejects.toThrow('Game not found');
+    });
+
+    it('throws ForbiddenException when caller is not the host', async () => {
+      mockManager.findOne.mockResolvedValueOnce(pendingGameWithPlayers);
+      await expect(service.startGame(mockGame.id!, 'not-the-host')).rejects.toThrow(
+        'Only the host can start the game',
+      );
+    });
+
+    it('throws BadRequestException (invalid state) when game is not PENDING', async () => {
+      mockManager.findOne.mockResolvedValueOnce({
+        ...pendingGameWithPlayers,
+        status: GameStatus.IN_PROGRESS,
+      });
+      await expect(service.startGame(mockGame.id!, 'host-1')).rejects.toThrow(
+        'Game is not in PENDING status',
+      );
+    });
+
+    it('throws BadRequestException when fewer than 2 players have joined', async () => {
+      mockManager.findOne.mockResolvedValueOnce({
+        ...pendingGameWithPlayers,
+        players: [{ id: 'p1', user_id: 'host-1' }],
+      });
+      await expect(service.startGame(mockGame.id!, 'host-1')).rejects.toThrow(
+        'At least 2 players are required to start the game',
+      );
+    });
+  });
+
+  describe('leaveGame', () => {
+    it('removes the player and reports success', async () => {
+      const game = {
+        ...mockGame,
+        host_user_id: 'user-2',
+        players: [{ id: 'p1', user_id: 'user-2' }, { id: 'p2', user_id: mockPlayer.user_id }],
+      };
+      mockManager.findOne
+        .mockResolvedValueOnce(game)
+        .mockResolvedValueOnce({ id: 'p2', user_id: mockPlayer.user_id });
+
+      const result = await service.leaveGame(mockGame.id!, mockPlayer.user_id!);
+
+      expect(result).toEqual({ left: true });
+      expect(mockManager.remove).toHaveBeenCalledWith(Player, {
+        id: 'p2',
+        user_id: mockPlayer.user_id,
+      });
+    });
+
+    it('reassigns host to the remaining player with the lowest turn order', async () => {
+      const departingHost = mockPlayer.user_id!;
+      const game = {
+        ...mockGame,
+        host_user_id: departingHost,
+        players: [
+          { id: 'p1', user_id: departingHost, turn_order: 1 },
+          { id: 'p2', user_id: 'user-3', turn_order: 3 },
+          { id: 'p3', user_id: 'user-4', turn_order: 2 },
+        ],
+      };
+      mockManager.findOne
+        .mockResolvedValueOnce(game)
+        .mockResolvedValueOnce({ id: 'p1', user_id: departingHost });
+
+      await service.leaveGame(mockGame.id!, departingHost);
+
+      expect(mockManager.save).toHaveBeenCalledWith(
+        Game,
+        expect.objectContaining({ host_user_id: 'user-4' }),
+      );
+    });
+
+    it('clears host when the last player leaves', async () => {
+      const departingHost = mockPlayer.user_id!;
+      const game = {
+        ...mockGame,
+        host_user_id: departingHost,
+        players: [{ id: 'p1', user_id: departingHost, turn_order: 1 }],
+      };
+      mockManager.findOne
+        .mockResolvedValueOnce(game)
+        .mockResolvedValueOnce({ id: 'p1', user_id: departingHost });
+
+      await service.leaveGame(mockGame.id!, departingHost);
+
+      expect(mockManager.save).toHaveBeenCalledWith(
+        Game,
+        expect.objectContaining({ host_user_id: null }),
+      );
+    });
+
+    it('throws NotFoundException when game does not exist', async () => {
+      mockManager.findOne.mockResolvedValueOnce(null);
+      await expect(service.leaveGame('missing', mockPlayer.user_id!)).rejects.toThrow(
+        'Game not found',
+      );
+    });
+
+    it('throws BadRequestException (invalid state) when game is completed', async () => {
+      mockManager.findOne.mockResolvedValueOnce({ ...mockGame, status: GameStatus.COMPLETED });
+      await expect(service.leaveGame(mockGame.id!, mockPlayer.user_id!)).rejects.toThrow(
+        'Cannot leave a completed game',
+      );
+    });
+
+    it('throws NotFoundException when the caller never joined this game', async () => {
+      mockManager.findOne
+        .mockResolvedValueOnce(mockGame)
+        .mockResolvedValueOnce(null);
+      await expect(service.leaveGame(mockGame.id!, mockPlayer.user_id!)).rejects.toThrow(
+        'Player not found in this game',
+      );
+    });
+  });
+
+  describe('submitScore', () => {
+    const inProgressGame = { ...mockGame, status: GameStatus.IN_PROGRESS };
+
+    it('updates the player balance while the game is in progress', async () => {
+      mockManager.findOne
+        .mockResolvedValueOnce(inProgressGame)
+        .mockResolvedValueOnce({ ...mockPlayer });
+      mockManager.save.mockImplementation((_entity: unknown, value: unknown) => value);
+
+      const result = await service.submitScore(mockGame.id!, mockPlayer.user_id!, { balance: 2500 });
+
+      expect(result.balance).toBe(2500);
+      expect(mockManager.save).toHaveBeenCalledWith(
+        Player,
+        expect.objectContaining({ balance: 2500 }),
+      );
+    });
+
+    it('throws NotFoundException when game does not exist', async () => {
+      mockManager.findOne.mockResolvedValueOnce(null);
+      await expect(
+        service.submitScore('missing', mockPlayer.user_id!, { balance: 100 }),
+      ).rejects.toThrow('Game not found');
+    });
+
+    it('throws BadRequestException (invalid state) when game is not in progress', async () => {
+      mockManager.findOne.mockResolvedValueOnce(mockGame);
+      await expect(
+        service.submitScore(mockGame.id!, mockPlayer.user_id!, { balance: 100 }),
+      ).rejects.toThrow('Game is not in progress');
+    });
+
+    it('throws NotFoundException when the caller is not a player in this game', async () => {
+      mockManager.findOne
+        .mockResolvedValueOnce(inProgressGame)
+        .mockResolvedValueOnce(null);
+      await expect(
+        service.submitScore(mockGame.id!, mockPlayer.user_id!, { balance: 100 }),
+      ).rejects.toThrow('Player not found in this game');
     });
   });
 });

--- a/backend/src/games/games.service.ts
+++ b/backend/src/games/games.service.ts
@@ -1,9 +1,15 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { Game, GameStatus } from './entities/game.entity';
 import { Player } from './entities/player.entity';
 import { ListGamesDto } from './dto/list-games.dto';
+import { SubmitScoreDto } from './dto/submit-score.dto';
 import { PaginatedResponseDto } from '../common/dto/paginated-response.dto';
 
 @Injectable()
@@ -65,6 +71,7 @@ export class GamesService {
         throw new BadRequestException('Player already joined this game');
       }
 
+      const isFirstPlayer = game.players.length === 0;
       const turnOrder = game.game_settings.randomize_turn_order
         ? Math.floor(Math.random() * 1000)
         : game.players.length + 1;
@@ -76,6 +83,128 @@ export class GamesService {
         turn_order: turnOrder,
       });
 
+      const savedPlayer = await manager.save(Player, player);
+
+      if (isFirstPlayer) {
+        game.host_user_id = userId;
+        await manager.save(Game, game);
+      }
+
+      return savedPlayer;
+    });
+  }
+
+  /**
+   * Starts a pending game. Only the host (the first player to join) may
+   * start it, and only while it is still PENDING.
+   */
+  async startGame(gameId: string, userId: string): Promise<Game> {
+    return await this.dataSource.transaction(async (manager) => {
+      const game = await manager.findOne(Game, {
+        where: { id: gameId },
+        relations: ['players'],
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!game) {
+        throw new NotFoundException('Game not found');
+      }
+
+      if (game.host_user_id !== userId) {
+        throw new ForbiddenException('Only the host can start the game');
+      }
+
+      if (game.status !== GameStatus.PENDING) {
+        throw new BadRequestException('Game is not in PENDING status');
+      }
+
+      if (game.players.length < 2) {
+        throw new BadRequestException(
+          'At least 2 players are required to start the game',
+        );
+      }
+
+      game.status = GameStatus.IN_PROGRESS;
+      return await manager.save(Game, game);
+    });
+  }
+
+  /**
+   * Removes the caller from a game. If the departing player was the host,
+   * host status is handed to the remaining player with the lowest turn
+   * order, if any players remain.
+   */
+  async leaveGame(gameId: string, userId: string): Promise<{ left: boolean }> {
+    return await this.dataSource.transaction(async (manager) => {
+      const game = await manager.findOne(Game, {
+        where: { id: gameId },
+        relations: ['players'],
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!game) {
+        throw new NotFoundException('Game not found');
+      }
+
+      if (game.status === GameStatus.COMPLETED) {
+        throw new BadRequestException('Cannot leave a completed game');
+      }
+
+      const player = await manager.findOne(Player, {
+        where: { game_id: gameId, user_id: userId },
+      });
+
+      if (!player) {
+        throw new NotFoundException('Player not found in this game');
+      }
+
+      await manager.remove(Player, player);
+
+      if (game.host_user_id === userId) {
+        const remaining = game.players
+          .filter((p) => p.user_id !== userId)
+          .sort((a, b) => (a.turn_order ?? 0) - (b.turn_order ?? 0));
+        game.host_user_id = remaining[0]?.user_id ?? null;
+        await manager.save(Game, game);
+      }
+
+      return { left: true };
+    });
+  }
+
+  /**
+   * Records a player's current/final balance while the game is in progress.
+   * A stub for real scoring/payout logic, which will land once the game
+   * engine emits authoritative results.
+   */
+  async submitScore(
+    gameId: string,
+    userId: string,
+    dto: SubmitScoreDto,
+  ): Promise<Player> {
+    return await this.dataSource.transaction(async (manager) => {
+      const game = await manager.findOne(Game, {
+        where: { id: gameId },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!game) {
+        throw new NotFoundException('Game not found');
+      }
+
+      if (game.status !== GameStatus.IN_PROGRESS) {
+        throw new BadRequestException('Game is not in progress');
+      }
+
+      const player = await manager.findOne(Player, {
+        where: { game_id: gameId, user_id: userId },
+      });
+
+      if (!player) {
+        throw new NotFoundException('Player not found in this game');
+      }
+
+      player.balance = dto.balance;
       return await manager.save(Player, player);
     });
   }

--- a/backend/src/migration.datasource.ts
+++ b/backend/src/migration.datasource.ts
@@ -13,6 +13,7 @@ import { AddOnboardingStateToUsers1745200000000 } from './users/1745200000000-Ad
 import { AddRoleToUsers1747000000000 } from './users/1747000000000-AddRoleToUsers';
 import { CreateSocialLinksTable1748000000000 } from './social-link/1748000000000-CreateSocialLinksTable';
 import { CreateCreatorOnchainMappings1749000000000 } from './creators/1749000000000-CreateCreatorOnchainMappings';
+import { CreateNotificationDurableState1750000000000 } from './notifications/1750000000000-CreateNotificationDurableState';
 
 export const migrationDataSource = new DataSource({
   type: 'postgres',
@@ -35,5 +36,6 @@ export const migrationDataSource = new DataSource({
     AddRoleToUsers1747000000000,
     CreateSocialLinksTable1748000000000,
     CreateCreatorOnchainMappings1749000000000,
+    CreateNotificationDurableState1750000000000,
   ],
 });

--- a/backend/src/notifications/1750000000000-CreateNotificationDurableState.ts
+++ b/backend/src/notifications/1750000000000-CreateNotificationDurableState.ts
@@ -1,0 +1,87 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Backs the durable notification email queue (#1439) and the persisted
+ * retry-queue/digest-window state (#1440), replacing what previously lived
+ * only in `NotificationsService`'s in-memory Maps.
+ */
+export class CreateNotificationDurableState1750000000000 implements MigrationInterface {
+  name = 'CreateNotificationDurableState1750000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE "email_outbox_status_enum" AS ENUM ('pending', 'sent', 'failed');
+      EXCEPTION
+        WHEN duplicate_object THEN null;
+      END $$;
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "email_outbox" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "dedupe_key" varchar NOT NULL,
+        "to_user_id" varchar NOT NULL,
+        "subject" varchar NOT NULL,
+        "body" text NOT NULL,
+        "status" "email_outbox_status_enum" NOT NULL DEFAULT 'pending',
+        "attempts" integer NOT NULL DEFAULT 0,
+        "last_error" text,
+        "sent_at" TIMESTAMPTZ,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_email_outbox" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_email_outbox_dedupe_key" UNIQUE ("dedupe_key")
+      );
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_email_outbox_status" ON "email_outbox" ("status");`,
+    );
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE "notification_retry_job_status_enum" AS ENUM ('pending', 'processing', 'completed', 'failed');
+      EXCEPTION
+        WHEN duplicate_object THEN null;
+      END $$;
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "notification_retry_jobs" (
+        "dedupe_key" varchar NOT NULL,
+        "payload" jsonb NOT NULL,
+        "attempts" integer NOT NULL DEFAULT 0,
+        "status" "notification_retry_job_status_enum" NOT NULL DEFAULT 'pending',
+        "last_error" text,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_notification_retry_jobs" PRIMARY KEY ("dedupe_key")
+      );
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_notification_retry_jobs_status" ON "notification_retry_jobs" ("status");`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "notification_digest_windows" (
+        "digest_key" varchar NOT NULL,
+        "notification_id" varchar NOT NULL,
+        "event_times" jsonb NOT NULL,
+        "window_expires_at" bigint NOT NULL,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_notification_digest_windows" PRIMARY KEY ("digest_key")
+      );
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "notification_digest_windows";`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_notification_retry_jobs_status";`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "notification_retry_jobs";`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "notification_retry_job_status_enum";`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_email_outbox_status";`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "email_outbox";`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "email_outbox_status_enum";`);
+  }
+}

--- a/backend/src/notifications/adapters/console-email.adapter.spec.ts
+++ b/backend/src/notifications/adapters/console-email.adapter.spec.ts
@@ -1,0 +1,10 @@
+import { ConsoleEmailAdapter } from './console-email.adapter';
+
+describe('ConsoleEmailAdapter', () => {
+  it('logs the message and resolves without throwing', async () => {
+    const adapter = new ConsoleEmailAdapter();
+    await expect(
+      adapter.send({ to: 'fan@example.com', subject: 'Hello', body: 'World' }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/backend/src/notifications/adapters/console-email.adapter.ts
+++ b/backend/src/notifications/adapters/console-email.adapter.ts
@@ -1,0 +1,14 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EmailAdapter, EmailMessage } from './email-adapter.interface';
+
+/** Default adapter: logs the email instead of sending it. Safe for dev/test. */
+@Injectable()
+export class ConsoleEmailAdapter implements EmailAdapter {
+  private readonly logger = new Logger(ConsoleEmailAdapter.name);
+
+  async send(message: EmailMessage): Promise<void> {
+    this.logger.log(
+      `[console-email] to=${message.to} subject="${message.subject}" body="${message.body}"`,
+    );
+  }
+}

--- a/backend/src/notifications/adapters/email-adapter.interface.ts
+++ b/backend/src/notifications/adapters/email-adapter.interface.ts
@@ -1,0 +1,12 @@
+export interface EmailMessage {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+export interface EmailAdapter {
+  send(message: EmailMessage): Promise<void>;
+}
+
+/** DI token — inject with `@Inject(EMAIL_ADAPTER)`. */
+export const EMAIL_ADAPTER = Symbol('EMAIL_ADAPTER');

--- a/backend/src/notifications/adapters/smtp-email.adapter.spec.ts
+++ b/backend/src/notifications/adapters/smtp-email.adapter.spec.ts
@@ -1,0 +1,87 @@
+import * as net from 'net';
+import { SmtpEmailAdapter } from './smtp-email.adapter';
+
+function startFakeSmtpServer(
+  responses: string[],
+): Promise<{ server: net.Server; port: number; received: string[] }> {
+  return new Promise((resolve) => {
+    const received: string[] = [];
+    let step = 0;
+    const server = net.createServer((socket) => {
+      socket.write(responses[step++]);
+      socket.on('data', (chunk) => {
+        received.push(chunk.toString('utf8'));
+        if (step < responses.length) {
+          socket.write(responses[step++]);
+        }
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      resolve({ server, port, received });
+    });
+  });
+}
+
+const makeConfigService = (overrides: Record<string, string | undefined> = {}) => ({
+  get: jest.fn((key: string) => overrides[key]),
+});
+
+describe('SmtpEmailAdapter', () => {
+  it('throws when SMTP_HOST is not configured', async () => {
+    const adapter = new SmtpEmailAdapter(makeConfigService() as any);
+    await expect(
+      adapter.send({ to: 'fan@example.com', subject: 'Hi', body: 'Body' }),
+    ).rejects.toThrow('SmtpEmailAdapter requires SMTP_HOST');
+  });
+
+  it('completes a full SMTP conversation against a local test server', async () => {
+    const { server, port, received } = await startFakeSmtpServer([
+      '220 localhost ESMTP\r\n',
+      '250-localhost\r\n250 OK\r\n',
+      '250 OK\r\n',
+      '250 OK\r\n',
+      '354 Start mail input\r\n',
+      '250 OK\r\n',
+      '221 Bye\r\n',
+    ]);
+
+    const configService = makeConfigService({
+      SMTP_HOST: '127.0.0.1',
+      SMTP_PORT: String(port),
+      SMTP_FROM: 'no-reply@myfans.app',
+    });
+    const adapter = new SmtpEmailAdapter(configService as any);
+
+    await expect(
+      adapter.send({ to: 'fan@example.com', subject: 'Hello', body: 'World' }),
+    ).resolves.toBeUndefined();
+
+    expect(received.some((line) => line.startsWith('EHLO'))).toBe(true);
+    expect(received.some((line) => line.includes('MAIL FROM:<no-reply@myfans.app>'))).toBe(true);
+    expect(received.some((line) => line.includes('RCPT TO:<fan@example.com>'))).toBe(true);
+    expect(received.some((line) => line.includes('Subject: Hello'))).toBe(true);
+
+    server.close();
+  });
+
+  it('rejects when the server responds with an unexpected code', async () => {
+    const { server, port } = await startFakeSmtpServer([
+      '220 localhost ESMTP\r\n',
+      '550 Rejected\r\n',
+    ]);
+
+    const configService = makeConfigService({
+      SMTP_HOST: '127.0.0.1',
+      SMTP_PORT: String(port),
+    });
+    const adapter = new SmtpEmailAdapter(configService as any);
+
+    await expect(
+      adapter.send({ to: 'fan@example.com', subject: 'Hi', body: 'Body' }),
+    ).rejects.toThrow(/SMTP server responded/);
+
+    server.close();
+  });
+});

--- a/backend/src/notifications/adapters/smtp-email.adapter.ts
+++ b/backend/src/notifications/adapters/smtp-email.adapter.ts
@@ -1,0 +1,141 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as net from 'net';
+import * as tls from 'tls';
+import { EmailAdapter, EmailMessage } from './email-adapter.interface';
+
+interface SmtpConfig {
+  host: string;
+  port: number;
+  secure: boolean;
+  user?: string;
+  pass?: string;
+  from: string;
+}
+
+/**
+ * Minimal SMTP client built directly on Node's `net`/`tls` sockets — no
+ * external mail library. Supports plaintext or implicit-TLS connections and
+ * optional `AUTH LOGIN`.
+ *
+ * This is intentionally a basic stub, not a full RFC 5321 client: no
+ * STARTTLS upgrade, no multi-recipient batching, no MIME attachments, and
+ * each server reply is assumed to arrive in a single TCP chunk (true for
+ * every common relay in practice, but not guaranteed by the protocol).
+ * Swap in a hardened library-backed adapter before relying on this for
+ * production mail volume.
+ *
+ * Configure via env: `SMTP_HOST`, `SMTP_PORT` (default 25), `SMTP_SECURE`
+ * ('true' for implicit TLS), `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`.
+ */
+@Injectable()
+export class SmtpEmailAdapter implements EmailAdapter {
+  private readonly logger = new Logger(SmtpEmailAdapter.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async send(message: EmailMessage): Promise<void> {
+    const config = this.readConfig();
+    const socket = await this.connect(config);
+
+    try {
+      await this.expect(socket, 220);
+      await this.command(socket, `EHLO ${config.host}`, 250);
+
+      if (config.user && config.pass) {
+        await this.command(socket, 'AUTH LOGIN', 334);
+        await this.command(socket, Buffer.from(config.user).toString('base64'), 334);
+        await this.command(socket, Buffer.from(config.pass).toString('base64'), 235);
+      }
+
+      await this.command(socket, `MAIL FROM:<${config.from}>`, 250);
+      await this.command(socket, `RCPT TO:<${message.to}>`, 250);
+      await this.command(socket, 'DATA', 354);
+
+      const data = this.buildMessage(config.from, message);
+      await this.command(socket, `${data}\r\n.`, 250);
+      await this.command(socket, 'QUIT', 221);
+
+      this.logger.log(`[smtp-email] delivered to=${message.to} via ${config.host}:${config.port}`);
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  private readConfig(): SmtpConfig {
+    const host = this.configService.get<string>('SMTP_HOST');
+    if (!host) {
+      throw new Error('SmtpEmailAdapter requires SMTP_HOST to be configured');
+    }
+    return {
+      host,
+      port: Number(this.configService.get<string>('SMTP_PORT') ?? 25),
+      secure: this.configService.get<string>('SMTP_SECURE') === 'true',
+      user: this.configService.get<string>('SMTP_USER'),
+      pass: this.configService.get<string>('SMTP_PASS'),
+      from: this.configService.get<string>('SMTP_FROM') ?? 'no-reply@myfans.app',
+    };
+  }
+
+  private connect(config: SmtpConfig): Promise<net.Socket> {
+    return new Promise((resolve, reject) => {
+      const onConnect = () => {
+        socket.removeListener('error', onInitialError);
+        resolve(socket);
+      };
+      const onInitialError = (error: Error) => reject(error);
+
+      const socket: net.Socket = config.secure
+        ? tls.connect({ host: config.host, port: config.port }, onConnect)
+        : net.connect({ host: config.host, port: config.port }, onConnect);
+
+      socket.once('error', onInitialError);
+      socket.setTimeout(10_000, () => {
+        socket.destroy();
+        reject(new Error('SMTP connection timed out'));
+      });
+    });
+  }
+
+  private command(socket: net.Socket, line: string, expectedCode: number): Promise<string> {
+    socket.write(`${line}\r\n`);
+    return this.expect(socket, expectedCode);
+  }
+
+  private expect(socket: net.Socket, expectedCode: number): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const onData = (chunk: Buffer) => {
+        cleanup();
+        const response = chunk.toString('utf8');
+        const code = Number(response.slice(0, 3));
+        if (code !== expectedCode) {
+          reject(new Error(`SMTP server responded "${response.trim()}", expected ${expectedCode}`));
+          return;
+        }
+        resolve(response);
+      };
+      const onError = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+      const cleanup = () => {
+        socket.removeListener('data', onData);
+        socket.removeListener('error', onError);
+      };
+      socket.once('data', onData);
+      socket.once('error', onError);
+    });
+  }
+
+  private buildMessage(from: string, message: EmailMessage): string {
+    return [
+      `From: ${from}`,
+      `To: ${message.to}`,
+      `Subject: ${message.subject}`,
+      'MIME-Version: 1.0',
+      'Content-Type: text/plain; charset=utf-8',
+      '',
+      message.body,
+    ].join('\r\n');
+  }
+}

--- a/backend/src/notifications/email-outbox.service.spec.ts
+++ b/backend/src/notifications/email-outbox.service.spec.ts
@@ -1,0 +1,148 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EmailOutboxService } from './email-outbox.service';
+import { EmailOutboxEntry, EmailOutboxStatus } from './entities/email-outbox-entry.entity';
+import { EMAIL_ADAPTER } from './adapters/email-adapter.interface';
+
+const mockRepo = () => ({
+  findOne: jest.fn(),
+  create: jest.fn((data: Partial<EmailOutboxEntry>) => ({ ...data }) as EmailOutboxEntry),
+  save: jest.fn(async (entity: EmailOutboxEntry) => entity),
+  find: jest.fn(),
+});
+
+describe('EmailOutboxService', () => {
+  let service: EmailOutboxService;
+  let repo: ReturnType<typeof mockRepo>;
+  let adapter: { send: jest.Mock };
+
+  beforeEach(async () => {
+    adapter = { send: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailOutboxService,
+        { provide: getRepositoryToken(EmailOutboxEntry), useFactory: mockRepo },
+        { provide: EMAIL_ADAPTER, useValue: adapter },
+      ],
+    }).compile();
+
+    service = module.get(EmailOutboxService);
+    repo = module.get(getRepositoryToken(EmailOutboxEntry));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('enqueue', () => {
+    it('persists the entry before attempting delivery, then marks it sent', async () => {
+      repo.findOne.mockResolvedValue(null);
+      adapter.send.mockResolvedValue(undefined);
+
+      const result = await service.enqueue({
+        dedupeKey: 'k1',
+        toUserId: 'user-1',
+        subject: 'Hi',
+        body: 'Body',
+      });
+
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: EmailOutboxStatus.PENDING }),
+      );
+      expect(adapter.send).toHaveBeenCalledWith({
+        to: 'user-1',
+        subject: 'Hi',
+        body: 'Body',
+      });
+      expect(result.status).toBe(EmailOutboxStatus.SENT);
+      expect(result.sent_at).toBeInstanceOf(Date);
+    });
+
+    it('is idempotent on dedupe_key — returns the existing row without re-sending', async () => {
+      const existing = { dedupe_key: 'k1', status: EmailOutboxStatus.SENT } as EmailOutboxEntry;
+      repo.findOne.mockResolvedValue(existing);
+
+      const result = await service.enqueue({
+        dedupeKey: 'k1',
+        toUserId: 'user-1',
+        subject: 'Hi',
+        body: 'Body',
+      });
+
+      expect(result).toBe(existing);
+      expect(adapter.send).not.toHaveBeenCalled();
+      expect(repo.create).not.toHaveBeenCalled();
+    });
+
+    it('records the error and keeps the row pending when delivery fails', async () => {
+      repo.findOne.mockResolvedValue(null);
+      adapter.send.mockRejectedValue(new Error('smtp down'));
+
+      const result = await service.enqueue({
+        dedupeKey: 'k2',
+        toUserId: 'user-2',
+        subject: 'Hi',
+        body: 'Body',
+      });
+
+      expect(result.status).toBe(EmailOutboxStatus.PENDING);
+      expect(result.attempts).toBe(1);
+      expect(result.last_error).toBe('smtp down');
+    });
+
+    it('marks the row failed once max attempts are exhausted', async () => {
+      repo.findOne.mockResolvedValue(null);
+      adapter.send.mockRejectedValue(new Error('smtp down'));
+
+      // Simulate a row that has already failed 4 times.
+      repo.create.mockReturnValueOnce({
+        dedupe_key: 'k3',
+        to_user_id: 'user-3',
+        subject: 'Hi',
+        body: 'Body',
+        status: EmailOutboxStatus.PENDING,
+        attempts: 4,
+        last_error: null,
+        sent_at: null,
+      } as EmailOutboxEntry);
+
+      const result = await service.enqueue({
+        dedupeKey: 'k3',
+        toUserId: 'user-3',
+        subject: 'Hi',
+        body: 'Body',
+      });
+
+      expect(result.attempts).toBe(5);
+      expect(result.status).toBe(EmailOutboxStatus.FAILED);
+    });
+  });
+
+  describe('processPending', () => {
+    it('re-attempts delivery for every pending row', async () => {
+      const rows = [
+        { dedupe_key: 'a', to_user_id: 'u1', subject: 's', body: 'b', attempts: 0, status: EmailOutboxStatus.PENDING },
+        { dedupe_key: 'b', to_user_id: 'u2', subject: 's', body: 'b', attempts: 0, status: EmailOutboxStatus.PENDING },
+      ] as EmailOutboxEntry[];
+      repo.find.mockResolvedValue(rows);
+      adapter.send.mockResolvedValue(undefined);
+
+      await service.processPending();
+
+      expect(adapter.send).toHaveBeenCalledTimes(2);
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ dedupe_key: 'a', status: EmailOutboxStatus.SENT }),
+      );
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ dedupe_key: 'b', status: EmailOutboxStatus.SENT }),
+      );
+    });
+  });
+
+  describe('listAll', () => {
+    it('returns rows ordered by creation time', async () => {
+      repo.find.mockResolvedValue([]);
+      await service.listAll();
+      expect(repo.find).toHaveBeenCalledWith({ order: { created_at: 'ASC' } });
+    });
+  });
+});

--- a/backend/src/notifications/email-outbox.service.ts
+++ b/backend/src/notifications/email-outbox.service.ts
@@ -1,0 +1,88 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { EmailOutboxEntry, EmailOutboxStatus } from './entities/email-outbox-entry.entity';
+import { EMAIL_ADAPTER, EmailAdapter } from './adapters/email-adapter.interface';
+
+export interface EnqueueEmailRequest {
+  dedupeKey: string;
+  toUserId: string;
+  subject: string;
+  body: string;
+}
+
+/**
+ * Durable email queue: every email is persisted to the `email_outbox` table
+ * before delivery is attempted, and stays there (pending/failed) until
+ * delivered — replacing the previous in-memory-only `sentEmails` log.
+ *
+ * Retries: delivery failures increment `attempts` and leave the row
+ * `pending` for {@link processPending} to pick back up (intended to be
+ * called on a timer — see `NotificationRetryWorkerService`) until
+ * `maxAttempts` is reached, at which point the row is marked `failed` and
+ * left for manual/alerting follow-up rather than retried forever.
+ */
+@Injectable()
+export class EmailOutboxService {
+  private readonly logger = new Logger(EmailOutboxService.name);
+  private readonly maxAttempts = 5;
+
+  constructor(
+    @InjectRepository(EmailOutboxEntry)
+    private readonly repo: Repository<EmailOutboxEntry>,
+    @Inject(EMAIL_ADAPTER)
+    private readonly adapter: EmailAdapter,
+  ) {}
+
+  async enqueue(request: EnqueueEmailRequest): Promise<EmailOutboxEntry> {
+    const existing = await this.repo.findOne({ where: { dedupe_key: request.dedupeKey } });
+    if (existing) {
+      return existing;
+    }
+
+    const entry = this.repo.create({
+      dedupe_key: request.dedupeKey,
+      to_user_id: request.toUserId,
+      subject: request.subject,
+      body: request.body,
+      status: EmailOutboxStatus.PENDING,
+      attempts: 0,
+      last_error: null,
+      sent_at: null,
+    });
+    const saved = await this.repo.save(entry);
+    await this.deliver(saved);
+    return saved;
+  }
+
+  /** Re-attempts delivery of every still-pending row. Intended for a scheduled worker tick. */
+  async processPending(): Promise<void> {
+    const pending = await this.repo.find({ where: { status: EmailOutboxStatus.PENDING } });
+    for (const entry of pending) {
+      await this.deliver(entry);
+    }
+  }
+
+  async listAll(): Promise<EmailOutboxEntry[]> {
+    return this.repo.find({ order: { created_at: 'ASC' } });
+  }
+
+  private async deliver(entry: EmailOutboxEntry): Promise<void> {
+    try {
+      await this.adapter.send({ to: entry.to_user_id, subject: entry.subject, body: entry.body });
+      entry.status = EmailOutboxStatus.SENT;
+      entry.sent_at = new Date();
+      entry.last_error = null;
+      await this.repo.save(entry);
+    } catch (error) {
+      entry.attempts += 1;
+      entry.last_error = error instanceof Error ? error.message : String(error);
+      entry.status =
+        entry.attempts >= this.maxAttempts ? EmailOutboxStatus.FAILED : EmailOutboxStatus.PENDING;
+      await this.repo.save(entry);
+      this.logger.warn(
+        `Email delivery failed for ${entry.dedupe_key} (attempt ${entry.attempts}): ${entry.last_error}`,
+      );
+    }
+  }
+}

--- a/backend/src/notifications/entities/email-outbox-entry.entity.ts
+++ b/backend/src/notifications/entities/email-outbox-entry.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+
+export enum EmailOutboxStatus {
+  PENDING = 'pending',
+  SENT = 'sent',
+  FAILED = 'failed',
+}
+
+/** Durable record of an email queued for delivery, replacing the previous in-memory-only log. */
+@Entity('email_outbox')
+@Unique(['dedupe_key'])
+@Index(['status'])
+export class EmailOutboxEntry {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  dedupe_key: string;
+
+  @Column()
+  to_user_id: string;
+
+  @Column()
+  subject: string;
+
+  @Column({ type: 'text' })
+  body: string;
+
+  @Column({ type: 'enum', enum: EmailOutboxStatus, default: EmailOutboxStatus.PENDING })
+  status: EmailOutboxStatus;
+
+  @Column({ type: 'int', default: 0 })
+  attempts: number;
+
+  @Column({ type: 'text', nullable: true })
+  last_error: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  sent_at: Date | null;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/backend/src/notifications/entities/notification-digest-window.entity.ts
+++ b/backend/src/notifications/entities/notification-digest-window.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, PrimaryColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+/**
+ * Durable mirror of an open digest window (`userId:type:creatorUserId` ->
+ * batched notification), so a restart doesn't silently drop an in-flight
+ * digest and start a fresh one on the next event.
+ */
+@Entity('notification_digest_windows')
+export class NotificationDigestWindowEntity {
+  /** `${userId}:${type}:${creatorUserId}` */
+  @PrimaryColumn()
+  digest_key: string;
+
+  @Column()
+  notification_id: string;
+
+  @Column({ type: 'jsonb' })
+  event_times: string[];
+
+  /** Epoch ms after which this window is considered expired. */
+  @Column({ type: 'bigint' })
+  window_expires_at: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/backend/src/notifications/entities/notification-retry-job.entity.ts
+++ b/backend/src/notifications/entities/notification-retry-job.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import type { SubscriptionLifecycleNotificationRequest } from '../notifications.service';
+
+/**
+ * Matches `NotificationQueueJob['status']` in `notifications.service.ts` —
+ * kept as a plain string union (rather than a TS enum) so job records can
+ * flow between the in-memory queue and this entity without a nominal-type
+ * mismatch.
+ */
+export type RetryJobStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+export const RETRY_JOB_STATUSES: RetryJobStatus[] = [
+  'pending',
+  'processing',
+  'completed',
+  'failed',
+];
+
+/**
+ * Durable mirror of the subscription-lifecycle notification retry queue, so
+ * pending/failed jobs survive a process restart instead of living only in
+ * `NotificationsService`'s in-memory Map.
+ */
+@Entity('notification_retry_jobs')
+@Index(['status'])
+export class NotificationRetryJobEntity {
+  @PrimaryColumn()
+  dedupe_key: string;
+
+  @Column({ type: 'jsonb' })
+  payload: SubscriptionLifecycleNotificationRequest;
+
+  @Column({ type: 'int', default: 0 })
+  attempts: number;
+
+  @Column({ type: 'enum', enum: RETRY_JOB_STATUSES, default: 'pending' })
+  status: RetryJobStatus;
+
+  @Column({ type: 'text', nullable: true })
+  last_error: string | null;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/backend/src/notifications/notification-digest-store.service.spec.ts
+++ b/backend/src/notifications/notification-digest-store.service.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotificationDigestStoreService } from './notification-digest-store.service';
+import { NotificationDigestWindowEntity } from './entities/notification-digest-window.entity';
+
+const mockRepo = () => ({
+  create: jest.fn((data: Partial<NotificationDigestWindowEntity>) => data),
+  save: jest.fn(async (entity: unknown) => entity),
+  findOne: jest.fn(),
+  delete: jest.fn(),
+  find: jest.fn(),
+});
+
+describe('NotificationDigestStoreService', () => {
+  let service: NotificationDigestStoreService;
+  let repo: ReturnType<typeof mockRepo>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationDigestStoreService,
+        { provide: getRepositoryToken(NotificationDigestWindowEntity), useFactory: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get(NotificationDigestStoreService);
+    repo = module.get(getRepositoryToken(NotificationDigestWindowEntity));
+  });
+
+  it('returns null when no window is open for the key', async () => {
+    repo.findOne.mockResolvedValue(null);
+    const result = await service.get('user-1:subscription_renewed:creator-1');
+    expect(result).toBeNull();
+  });
+
+  it('returns the mapped record when a window exists, coercing bigint strings to numbers', async () => {
+    repo.findOne.mockResolvedValue({
+      digest_key: 'user-1:subscription_renewed:creator-1',
+      notification_id: 'notif-1',
+      event_times: ['2026-01-01T00:00:00.000Z'],
+      window_expires_at: '1234567890123',
+    });
+
+    const result = await service.get('user-1:subscription_renewed:creator-1');
+
+    expect(result).toEqual({
+      key: 'user-1:subscription_renewed:creator-1',
+      notificationId: 'notif-1',
+      eventTimes: ['2026-01-01T00:00:00.000Z'],
+      windowExpiresAt: 1234567890123,
+    });
+  });
+
+  it('persists a new window via set', async () => {
+    await service.set({
+      key: 'k',
+      notificationId: 'notif-1',
+      eventTimes: ['t1'],
+      windowExpiresAt: 999,
+    });
+
+    expect(repo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ digest_key: 'k', notification_id: 'notif-1' }),
+    );
+  });
+
+  it('deletes a window by key', async () => {
+    await service.delete('k');
+    expect(repo.delete).toHaveBeenCalledWith({ digest_key: 'k' });
+  });
+});

--- a/backend/src/notifications/notification-digest-store.service.ts
+++ b/backend/src/notifications/notification-digest-store.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotificationDigestWindowEntity } from './entities/notification-digest-window.entity';
+
+export interface DigestWindowRecord {
+  key: string;
+  notificationId: string;
+  eventTimes: string[];
+  /** Epoch ms after which this window is considered expired. */
+  windowExpiresAt: number;
+}
+
+/** Durable backing store for open digest windows. */
+@Injectable()
+export class NotificationDigestStoreService {
+  constructor(
+    @InjectRepository(NotificationDigestWindowEntity)
+    private readonly repo: Repository<NotificationDigestWindowEntity>,
+  ) {}
+
+  async get(key: string): Promise<DigestWindowRecord | null> {
+    const row = await this.repo.findOne({ where: { digest_key: key } });
+    return row ? this.toRecord(row) : null;
+  }
+
+  async set(record: DigestWindowRecord): Promise<void> {
+    const entity = this.repo.create({
+      digest_key: record.key,
+      notification_id: record.notificationId,
+      event_times: record.eventTimes,
+      window_expires_at: record.windowExpiresAt,
+    });
+    await this.repo.save(entity);
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.repo.delete({ digest_key: key });
+  }
+
+  async listAll(): Promise<DigestWindowRecord[]> {
+    const rows = await this.repo.find();
+    return rows.map((row) => this.toRecord(row));
+  }
+
+  private toRecord(row: NotificationDigestWindowEntity): DigestWindowRecord {
+    return {
+      key: row.digest_key,
+      notificationId: row.notification_id,
+      eventTimes: row.event_times,
+      windowExpiresAt: Number(row.window_expires_at),
+    };
+  }
+}

--- a/backend/src/notifications/notification-retry-store.service.spec.ts
+++ b/backend/src/notifications/notification-retry-store.service.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotificationRetryStoreService } from './notification-retry-store.service';
+import { NotificationRetryJobEntity } from './entities/notification-retry-job.entity';
+
+const mockRepo = () => ({
+  create: jest.fn((data: Partial<NotificationRetryJobEntity>) => data),
+  save: jest.fn(async (entity: unknown) => entity),
+  find: jest.fn(),
+});
+
+describe('NotificationRetryStoreService', () => {
+  let service: NotificationRetryStoreService;
+  let repo: ReturnType<typeof mockRepo>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationRetryStoreService,
+        { provide: getRepositoryToken(NotificationRetryJobEntity), useFactory: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get(NotificationRetryStoreService);
+    repo = module.get(getRepositoryToken(NotificationRetryJobEntity));
+  });
+
+  it('upserts a job record as an entity row', async () => {
+    await service.upsert({
+      dedupeKey: 'k1',
+      payload: {
+        dedupeKey: 'k1',
+        event: 'renewed',
+        recipientUserId: 'user-1',
+        creatorUserId: 'creator-1',
+        subscriptionId: 'sub-1',
+        planId: 1,
+      },
+      attempts: 1,
+      status: 'pending',
+    });
+
+    expect(repo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ dedupe_key: 'k1', attempts: 1, status: 'pending' }),
+    );
+  });
+
+  it('lists all jobs mapped back to the RetryJobRecord shape', async () => {
+    repo.find.mockResolvedValue([
+      {
+        dedupe_key: 'k1',
+        payload: { dedupeKey: 'k1' },
+        attempts: 2,
+        status: 'failed',
+        last_error: 'boom',
+      },
+    ]);
+
+    const result = await service.listAll();
+
+    expect(result).toEqual([
+      {
+        dedupeKey: 'k1',
+        payload: { dedupeKey: 'k1' },
+        attempts: 2,
+        status: 'failed',
+        lastError: 'boom',
+      },
+    ]);
+  });
+
+  it('lists only pending jobs', async () => {
+    repo.find.mockResolvedValue([]);
+    await service.listPending();
+    expect(repo.find).toHaveBeenCalledWith({ where: { status: 'pending' } });
+  });
+});

--- a/backend/src/notifications/notification-retry-store.service.ts
+++ b/backend/src/notifications/notification-retry-store.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  NotificationRetryJobEntity,
+  RetryJobStatus,
+} from './entities/notification-retry-job.entity';
+import type { SubscriptionLifecycleNotificationRequest } from './notifications.service';
+
+export interface RetryJobRecord {
+  dedupeKey: string;
+  payload: SubscriptionLifecycleNotificationRequest;
+  attempts: number;
+  status: RetryJobStatus;
+  lastError?: string;
+}
+
+/** Durable backing store for the subscription-lifecycle retry queue. */
+@Injectable()
+export class NotificationRetryStoreService {
+  constructor(
+    @InjectRepository(NotificationRetryJobEntity)
+    private readonly repo: Repository<NotificationRetryJobEntity>,
+  ) {}
+
+  async upsert(job: RetryJobRecord): Promise<void> {
+    const entity = this.repo.create({
+      dedupe_key: job.dedupeKey,
+      payload: job.payload,
+      attempts: job.attempts,
+      status: job.status,
+      last_error: job.lastError ?? null,
+    });
+    await this.repo.save(entity);
+  }
+
+  async listAll(): Promise<RetryJobRecord[]> {
+    const rows = await this.repo.find();
+    return rows.map((row) => this.toRecord(row));
+  }
+
+  async listPending(): Promise<RetryJobRecord[]> {
+    const rows = await this.repo.find({ where: { status: 'pending' } });
+    return rows.map((row) => this.toRecord(row));
+  }
+
+  private toRecord(row: NotificationRetryJobEntity): RetryJobRecord {
+    return {
+      dedupeKey: row.dedupe_key,
+      payload: row.payload,
+      attempts: row.attempts,
+      status: row.status,
+      lastError: row.last_error ?? undefined,
+    };
+  }
+}

--- a/backend/src/notifications/notification-retry-worker.service.spec.ts
+++ b/backend/src/notifications/notification-retry-worker.service.spec.ts
@@ -1,0 +1,52 @@
+import { NotificationRetryWorkerService } from './notification-retry-worker.service';
+
+describe('NotificationRetryWorkerService', () => {
+  let notificationsService: { processRetryQueue: jest.Mock };
+  let emailOutbox: { processPending: jest.Mock };
+  let worker: NotificationRetryWorkerService;
+
+  beforeEach(() => {
+    notificationsService = { processRetryQueue: jest.fn().mockResolvedValue(undefined) };
+    emailOutbox = { processPending: jest.fn().mockResolvedValue(undefined) };
+    worker = new NotificationRetryWorkerService(
+      notificationsService as any,
+      emailOutbox as any,
+    );
+  });
+
+  it('drains the retry queue and the email outbox on tick', async () => {
+    await worker.tick();
+
+    expect(notificationsService.processRetryQueue).toHaveBeenCalledTimes(1);
+    expect(emailOutbox.processPending).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run overlapping ticks concurrently', async () => {
+    let resolveFirst!: () => void;
+    notificationsService.processRetryQueue.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+
+    const firstTick = worker.tick();
+    const secondTick = worker.tick();
+
+    expect(notificationsService.processRetryQueue).toHaveBeenCalledTimes(1);
+
+    resolveFirst();
+    await Promise.all([firstTick, secondTick]);
+  });
+
+  it('swallows errors so a failed tick does not crash the scheduler', async () => {
+    notificationsService.processRetryQueue.mockRejectedValue(new Error('boom'));
+    await expect(worker.tick()).resolves.toBeUndefined();
+  });
+
+  it('allows the next tick to run after a failure', async () => {
+    notificationsService.processRetryQueue.mockRejectedValueOnce(new Error('boom'));
+    await worker.tick();
+    await worker.tick();
+    expect(notificationsService.processRetryQueue).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/notifications/notification-retry-worker.service.ts
+++ b/backend/src/notifications/notification-retry-worker.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
+import { NotificationsService } from './notifications.service';
+import { EmailOutboxService } from './email-outbox.service';
+
+/**
+ * Background worker stub: ticks on an interval to drain the pending
+ * subscription-lifecycle retry queue and re-attempt any pending outbox
+ * emails. Both underlying operations are already idempotent (dedupe-keyed
+ * retry jobs, dedupe-keyed outbox rows), so overlapping ticks are safe.
+ */
+@Injectable()
+export class NotificationRetryWorkerService {
+  private readonly logger = new Logger(NotificationRetryWorkerService.name);
+  private ticking = false;
+
+  constructor(
+    private readonly notificationsService: NotificationsService,
+    private readonly emailOutbox: EmailOutboxService,
+  ) {}
+
+  @Interval(60_000)
+  async tick(): Promise<void> {
+    if (this.ticking) return;
+    this.ticking = true;
+    try {
+      await this.notificationsService.processRetryQueue();
+      await this.emailOutbox.processPending();
+    } catch (error) {
+      this.logger.error(
+        `Retry worker tick failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    } finally {
+      this.ticking = false;
+    }
+  }
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,18 +1,37 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { EventsModule } from '../events/events.module';
+import { UsersModule } from '../users/users.module';
 import { Notification } from './entities/notification.entity';
+import { EmailOutboxEntry } from './entities/email-outbox-entry.entity';
+import { NotificationRetryJobEntity } from './entities/notification-retry-job.entity';
+import { NotificationDigestWindowEntity } from './entities/notification-digest-window.entity';
 import { NotificationsController } from './notifications.controller';
 import { SubscriptionLifecycleNotifierService } from './subscription-lifecycle-notifier.service';
 import { NotificationsService } from './notifications.service';
+import { NotificationRetryStoreService } from './notification-retry-store.service';
+import { NotificationDigestStoreService } from './notification-digest-store.service';
+import { EmailOutboxService } from './email-outbox.service';
+import { NotificationRetryWorkerService } from './notification-retry-worker.service';
+import { EMAIL_ADAPTER } from './adapters/email-adapter.interface';
+import { ConsoleEmailAdapter } from './adapters/console-email.adapter';
+import { SmtpEmailAdapter } from './adapters/smtp-email.adapter';
 
 @Module({
   imports: [
     EventsModule,
     ConfigModule,
-    TypeOrmModule.forFeature([Notification]),
+    UsersModule,
+    ScheduleModule,
+    TypeOrmModule.forFeature([
+      Notification,
+      EmailOutboxEntry,
+      NotificationRetryJobEntity,
+      NotificationDigestWindowEntity,
+    ]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({
@@ -23,7 +42,24 @@ import { NotificationsService } from './notifications.service';
     }),
   ],
   controllers: [NotificationsController],
-  providers: [NotificationsService, SubscriptionLifecycleNotifierService],
-  exports: [NotificationsService],
+  providers: [
+    NotificationsService,
+    SubscriptionLifecycleNotifierService,
+    NotificationRetryStoreService,
+    NotificationDigestStoreService,
+    EmailOutboxService,
+    NotificationRetryWorkerService,
+    ConsoleEmailAdapter,
+    SmtpEmailAdapter,
+    {
+      // Real mail delivery only when SMTP_HOST is explicitly configured;
+      // otherwise fall back to logging emails to the console (dev/test default).
+      provide: EMAIL_ADAPTER,
+      useFactory: (consoleAdapter: ConsoleEmailAdapter, smtpAdapter: SmtpEmailAdapter) =>
+        process.env.SMTP_HOST ? smtpAdapter : consoleAdapter,
+      inject: [ConsoleEmailAdapter, SmtpEmailAdapter],
+    },
+  ],
+  exports: [NotificationsService, EmailOutboxService],
 })
 export class NotificationsModule {}

--- a/backend/src/notifications/notifications.service.persistence.spec.ts
+++ b/backend/src/notifications/notifications.service.persistence.spec.ts
@@ -1,0 +1,258 @@
+import { NotificationsService } from './notifications.service';
+import { NotificationType } from './entities/notification.entity';
+
+const mockNotificationsRepo = () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn((dto: any) => dto),
+  save: jest.fn(async (n: any) => n),
+  update: jest.fn(),
+  remove: jest.fn(),
+  count: jest.fn(),
+});
+
+const mockRetryStore = () => ({
+  upsert: jest.fn().mockResolvedValue(undefined),
+  listAll: jest.fn().mockResolvedValue([]),
+  listPending: jest.fn().mockResolvedValue([]),
+});
+
+const mockDigestStore = () => ({
+  get: jest.fn(),
+  set: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  listAll: jest.fn().mockResolvedValue([]),
+});
+
+const mockEmailOutbox = () => ({
+  enqueue: jest.fn().mockResolvedValue(undefined),
+  processPending: jest.fn().mockResolvedValue(undefined),
+  listAll: jest.fn().mockResolvedValue([]),
+});
+
+const mockUsersService = () => ({
+  getNotificationPreferences: jest.fn(),
+});
+
+describe('NotificationsService — durable persistence', () => {
+  let repo: ReturnType<typeof mockNotificationsRepo>;
+  let retryStore: ReturnType<typeof mockRetryStore>;
+  let digestStore: ReturnType<typeof mockDigestStore>;
+  let emailOutbox: ReturnType<typeof mockEmailOutbox>;
+  let usersService: ReturnType<typeof mockUsersService>;
+  let service: NotificationsService;
+
+  beforeEach(() => {
+    repo = mockNotificationsRepo();
+    retryStore = mockRetryStore();
+    digestStore = mockDigestStore();
+    emailOutbox = mockEmailOutbox();
+    usersService = mockUsersService();
+
+    service = new NotificationsService(
+      repo as any,
+      5 * 60 * 1000,
+      retryStore as any,
+      digestStore as any,
+      emailOutbox as any,
+      usersService as any,
+    );
+  });
+
+  describe('hydrateFromStores / onModuleInit', () => {
+    it('reloads pending retry jobs and open digest windows from the durable stores', async () => {
+      retryStore.listAll.mockResolvedValue([
+        {
+          dedupeKey: 'k1',
+          payload: {
+            dedupeKey: 'k1',
+            event: 'renewed',
+            recipientUserId: 'user-1',
+            creatorUserId: 'creator-1',
+            subscriptionId: 'sub-1',
+            planId: 1,
+          },
+          attempts: 1,
+          status: 'pending',
+        },
+      ]);
+      digestStore.listAll.mockResolvedValue([
+        {
+          key: 'user-1:subscription_renewed:creator-1',
+          notificationId: 'notif-1',
+          eventTimes: ['2026-01-01T00:00:00.000Z'],
+          windowExpiresAt: Date.now() + 60_000,
+        },
+      ]);
+
+      await service.onModuleInit();
+
+      expect(service.getRetryQueueSnapshot()).toEqual([
+        expect.objectContaining({ dedupeKey: 'k1', status: 'pending' }),
+      ]);
+
+      // A subsequent fold should find the rehydrated window and update in-place.
+      repo.findOne.mockResolvedValue({
+        id: 'notif-1',
+        digest_count: 1,
+        digest_event_times: ['2026-01-01T00:00:00.000Z'],
+      });
+
+      const folded = await service.foldIntoDigest(
+        'user-1',
+        NotificationType.SUBSCRIPTION_RENEWED,
+        'creator-1',
+        '2026-01-02T00:00:00.000Z',
+      );
+
+      expect(folded).not.toBeNull();
+      expect(folded!.digest_count).toBe(2);
+    });
+  });
+
+  describe('retry queue persistence', () => {
+    it('mirrors the pending job to the retry store on enqueue', async () => {
+      repo.findOne.mockResolvedValue(null);
+      usersService.getNotificationPreferences.mockResolvedValue({
+        email_subscription_renewal: true,
+      });
+
+      await service.enqueueSubscriptionLifecycleNotification({
+        dedupeKey: 'k2',
+        event: 'renewed',
+        recipientUserId: 'user-1',
+        creatorUserId: 'creator-1',
+        subscriptionId: 'sub-1',
+        planId: 1,
+      });
+
+      expect(retryStore.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ dedupeKey: 'k2', status: 'pending' }),
+      );
+      expect(retryStore.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ dedupeKey: 'k2', status: 'completed' }),
+      );
+    });
+  });
+
+  describe('digest window persistence', () => {
+    it('persists a newly opened digest window', () => {
+      service.openDigestWindow(
+        'user-1',
+        NotificationType.SUBSCRIPTION_RENEWED,
+        'creator-1',
+        'notif-1',
+        '2026-01-01T00:00:00.000Z',
+      );
+
+      expect(digestStore.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'user-1:subscription_renewed:creator-1',
+          notificationId: 'notif-1',
+        }),
+      );
+    });
+
+    it('persists the updated window when a fold succeeds', async () => {
+      service.openDigestWindow(
+        'user-1',
+        NotificationType.SUBSCRIPTION_RENEWED,
+        'creator-1',
+        'notif-1',
+        '2026-01-01T00:00:00.000Z',
+      );
+      repo.findOne.mockResolvedValue({ id: 'notif-1', digest_count: 1, digest_event_times: [] });
+
+      await service.foldIntoDigest(
+        'user-1',
+        NotificationType.SUBSCRIPTION_RENEWED,
+        'creator-1',
+        '2026-01-02T00:00:00.000Z',
+      );
+
+      expect(digestStore.set).toHaveBeenCalledWith(
+        expect.objectContaining({ eventTimes: expect.arrayContaining(['2026-01-02T00:00:00.000Z']) }),
+      );
+    });
+
+    it('deletes the window when its notification has vanished', async () => {
+      service.openDigestWindow(
+        'user-1',
+        NotificationType.SUBSCRIPTION_RENEWED,
+        'creator-1',
+        'ghost',
+        '2026-01-01T00:00:00.000Z',
+      );
+      repo.findOne.mockResolvedValue(null);
+
+      await service.foldIntoDigest(
+        'user-1',
+        NotificationType.SUBSCRIPTION_RENEWED,
+        'creator-1',
+        '2026-01-02T00:00:00.000Z',
+      );
+
+      expect(digestStore.delete).toHaveBeenCalledWith('user-1:subscription_renewed:creator-1');
+    });
+  });
+
+  describe('durable email outbox', () => {
+    it('enqueues a durable outbox entry alongside the in-memory sentEmails log', async () => {
+      repo.findOne.mockResolvedValue(null);
+      usersService.getNotificationPreferences.mockResolvedValue({
+        email_subscription_renewal: true,
+      });
+
+      await service.enqueueSubscriptionLifecycleNotification({
+        dedupeKey: 'k3',
+        event: 'renewed',
+        recipientUserId: 'user-1',
+        creatorUserId: 'creator-1',
+        subscriptionId: 'sub-1',
+        planId: 1,
+      });
+
+      expect(emailOutbox.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ dedupeKey: 'k3', toUserId: 'user-1' }),
+      );
+      expect(service.getSentEmails()).toHaveLength(1);
+    });
+  });
+
+  describe('preferences', () => {
+    it('skips the email entirely when the recipient has disabled subscription-renewal emails', async () => {
+      repo.findOne.mockResolvedValue(null);
+      usersService.getNotificationPreferences.mockResolvedValue({
+        email_subscription_renewal: false,
+      });
+
+      await service.enqueueSubscriptionLifecycleNotification({
+        dedupeKey: 'k4',
+        event: 'renewed',
+        recipientUserId: 'user-1',
+        creatorUserId: 'creator-1',
+        subscriptionId: 'sub-1',
+        planId: 1,
+      });
+
+      expect(emailOutbox.enqueue).not.toHaveBeenCalled();
+      expect(service.getSentEmails()).toHaveLength(0);
+    });
+
+    it('fails open (still sends) if the preference lookup throws', async () => {
+      repo.findOne.mockResolvedValue(null);
+      usersService.getNotificationPreferences.mockRejectedValue(new Error('db down'));
+
+      await service.enqueueSubscriptionLifecycleNotification({
+        dedupeKey: 'k5',
+        event: 'renewed',
+        recipientUserId: 'user-1',
+        creatorUserId: 'creator-1',
+        subscriptionId: 'sub-1',
+        planId: 1,
+      });
+
+      expect(service.getSentEmails()).toHaveLength(1);
+    });
+  });
+});

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,9 +1,13 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, OnModuleInit, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Notification } from './entities/notification.entity';
 import { CreateNotificationDto, MarkReadDto } from './dto/notification.dto';
 import { NotificationType } from './entities/notification.entity';
+import { NotificationRetryStoreService } from './notification-retry-store.service';
+import { NotificationDigestStoreService } from './notification-digest-store.service';
+import { EmailOutboxService } from './email-outbox.service';
+import { UsersService } from '../users/users.service';
 
 export interface SubscriptionLifecycleNotificationRequest {
   dedupeKey: string;
@@ -46,7 +50,7 @@ interface DigestWindow {
 }
 
 @Injectable()
-export class NotificationsService {
+export class NotificationsService implements OnModuleInit {
   private readonly maxQueueAttempts = 3;
   private readonly retryQueue = new Map<string, NotificationQueueJob>();
   private readonly completedNotifications = new Map<string, Notification>();
@@ -67,8 +71,51 @@ export class NotificationsService {
     @InjectRepository(Notification)
     private readonly notificationsRepository: Repository<Notification>,
     digestWindowMs = 5 * 60 * 1000,
+    /**
+     * Durable backing stores for the retry queue / digest windows / email
+     * delivery. All optional so existing direct-construction call sites
+     * (and unit tests) keep working exactly as before, falling back to the
+     * in-memory-only behavior; the DI-wired production module always
+     * supplies them (see `NotificationsModule`), which is what gives this
+     * service its durability.
+     */
+    @Optional() private readonly retryStore?: NotificationRetryStoreService,
+    @Optional() private readonly digestStore?: NotificationDigestStoreService,
+    @Optional() private readonly emailOutbox?: EmailOutboxService,
+    @Optional() private readonly usersService?: UsersService,
   ) {
     this.digestWindowMs = digestWindowMs;
+  }
+
+  /** Reloads durable retry-queue/digest-window state into memory after a restart. */
+  async onModuleInit(): Promise<void> {
+    await this.hydrateFromStores();
+  }
+
+  async hydrateFromStores(): Promise<void> {
+    if (this.retryStore) {
+      const jobs = await this.retryStore.listAll();
+      for (const job of jobs) {
+        this.retryQueue.set(job.dedupeKey, {
+          dedupeKey: job.dedupeKey,
+          payload: job.payload,
+          attempts: job.attempts,
+          status: job.status,
+          lastError: job.lastError,
+        });
+      }
+    }
+
+    if (this.digestStore) {
+      const windows = await this.digestStore.listAll();
+      for (const record of windows) {
+        this.digestWindows.set(record.key, {
+          notificationId: record.notificationId,
+          eventTimes: record.eventTimes,
+          windowExpiresAt: record.windowExpiresAt,
+        });
+      }
+    }
   }
 
   async findAllForUser(
@@ -155,12 +202,14 @@ export class NotificationsService {
       return null;
     }
 
-    this.retryQueue.set(request.dedupeKey, {
+    const job: NotificationQueueJob = {
       dedupeKey: request.dedupeKey,
       payload: request,
       attempts: 0,
       status: 'pending',
-    });
+    };
+    this.retryQueue.set(request.dedupeKey, job);
+    await this.persistRetryJob(job);
 
     return this.processQueueJob(request.dedupeKey);
   }
@@ -241,6 +290,7 @@ export class NotificationsService {
     });
     if (!notification) {
       this.digestWindows.delete(key);
+      void this.digestStore?.delete(key).catch(() => undefined);
       return null;
     }
 
@@ -261,7 +311,16 @@ export class NotificationsService {
       notification.body = `You have ${countWord} new subscribers.`;
     }
 
-    return this.notificationsRepository.save(notification);
+    const saved = await this.notificationsRepository.save(notification);
+    void this.digestStore
+      ?.set({
+        key,
+        notificationId: window.notificationId,
+        eventTimes: window.eventTimes,
+        windowExpiresAt: window.windowExpiresAt,
+      })
+      .catch(() => undefined);
+    return saved;
   }
 
   /** Open a new digest window after creating the first notification. */
@@ -273,11 +332,48 @@ export class NotificationsService {
     firstEventTime: string,
   ): void {
     const key = this.digestKeyFor(userId, type, creatorUserId);
-    this.digestWindows.set(key, {
+    const window: DigestWindow = {
       notificationId,
       eventTimes: [firstEventTime],
       windowExpiresAt: Date.now() + this.digestWindowMs,
+    };
+    this.digestWindows.set(key, window);
+    void this.digestStore
+      ?.set({
+        key,
+        notificationId: window.notificationId,
+        eventTimes: window.eventTimes,
+        windowExpiresAt: window.windowExpiresAt,
+      })
+      .catch(() => undefined);
+  }
+
+  /** Persists the current in-memory state of a retry job to the durable store, if configured. */
+  private async persistRetryJob(job: NotificationQueueJob): Promise<void> {
+    if (!this.retryStore) return;
+    await this.retryStore.upsert({
+      dedupeKey: job.dedupeKey,
+      payload: job.payload,
+      attempts: job.attempts,
+      status: job.status,
+      lastError: job.lastError,
     });
+  }
+
+  /** Whether the recipient's notification preferences allow this email to be sent. Fails open. */
+  private async emailAllowedForRecipient(
+    payload: SubscriptionLifecycleNotificationRequest,
+  ): Promise<boolean> {
+    if (!this.usersService) return true;
+    try {
+      const preferences = await this.usersService.getNotificationPreferences(
+        payload.recipientUserId,
+      );
+      return preferences.email_subscription_renewal !== false;
+    } catch {
+      // Don't drop a lifecycle email over a preference-lookup failure.
+      return true;
+    }
   }
 
   // ── Private queue processing ────────────────────────────────────────────
@@ -302,6 +398,7 @@ export class NotificationsService {
 
     job.status = 'processing';
     job.attempts += 1;
+    await this.persistRetryJob(job);
 
     try {
       // Try to fold into an existing digest window first
@@ -345,21 +442,34 @@ export class NotificationsService {
 
       if (job.payload.emailEnabled !== false && !folded) {
         const template = this.buildSubscriptionLifecycleTemplate(job.payload, 1);
-        this.sentEmails.push({
-          dedupeKey,
-          toUserId: job.payload.recipientUserId,
-          subject: template.email.subject,
-          body: template.email.body,
-        });
+        const allowed = await this.emailAllowedForRecipient(job.payload);
+        if (allowed) {
+          this.sentEmails.push({
+            dedupeKey,
+            toUserId: job.payload.recipientUserId,
+            subject: template.email.subject,
+            body: template.email.body,
+          });
+          if (this.emailOutbox) {
+            await this.emailOutbox.enqueue({
+              dedupeKey,
+              toUserId: job.payload.recipientUserId,
+              subject: template.email.subject,
+              body: template.email.body,
+            });
+          }
+        }
       }
 
       job.status = 'completed';
       this.completedNotifications.set(dedupeKey, notification);
+      await this.persistRetryJob(job);
       return notification;
     } catch (error) {
       job.lastError = error instanceof Error ? error.message : String(error);
       job.status =
         job.attempts >= this.maxQueueAttempts ? 'failed' : 'pending';
+      await this.persistRetryJob(job);
       return null;
     }
   }


### PR DESCRIPTION


Summary
Implements four backend tickets:

closes #1439 — Durable notification email queue: emails are now persisted to a new email_outbox table before delivery, with pluggable ConsoleEmailAdapter (default) and SmtpEmailAdapter (raw net/tls, no new deps) implementations selected via SMTP_HOST. Failed sends stay pending and are retried by a scheduled worker; sentEmails/getSentEmails() behavior is preserved for backward compatibility.
closes #1440 — Persist notification retry/digest state: the subscription-lifecycle retry queue and digest windows (previously only in-memory Maps on NotificationsService) are now mirrored to notification_retry_jobs and notification_digest_windows tables and rehydrated on onModuleInit, so pending retries/digests survive a restart. A NotificationRetryWorkerService ticks every 60s to drain the retry queue and re-attempt pending outbox emails. Email sends now check the recipient's email_subscription_renewal preference (via UsersService), failing open on lookup errors.
closes #1442 — Gated-content checks on content reads: new ContentAccessService gates GET /v1/content/:id on subscription_tier — public content and content owners get the full payload, active subscribers (via SubscriptionsService#isSubscriber) get the full payload, everyone else gets a teaser with description/ipfs_cid/ipfs_url stripped. A new OptionalJwtAuthGuard lets the route resolve an optional requester identity without requiring auth.
closes #1441 — Expand games API: adds POST /v1/games/:id/start (host-only, PENDING→IN_PROGRESS, needs ≥2 players), POST /v1/games/:id/leave (removes the player, reassigns host to the next-lowest turn order, or clears it), and POST /v1/games/:id/score (updates a player's balance while IN_PROGRESS). A new host_user_id column on Game is set to the first player to join. Invalid state transitions return 400; non-host start returns 403.
All new persistence/DI is wired as optional dependencies on NotificationsService so every existing unit test keeps passing unchanged — production NotificationsModule always supplies the durable stores, which is what gives the service its durability.

Notes / follow-ups
ContentAccessService's subscriber check reuses SubscriptionsService#isSubscriber, which is keyed on Stellar addresses on-chain; until platform user IDs are bridged to wallet addresses (see the existing caveat on HybridFanAuthGuard), this treats requesterId/creator_id as opaque identity strings.
GamesModule/ContentModule are still not registered in AppModule — pre-existing, left as-is (out of scope for these tickets).
SmtpEmailAdapter is an intentionally basic stub (no STARTTLS upgrade, assumes single-chunk server replies) — swap for a hardened library-backed client before production mail volume.
Test plan
 npm test --prefix backend (new specs: games start/leave/score, ContentAccessService, OptionalJwtAuthGuard, email adapters, EmailOutboxService, retry/digest stores, retry worker, notifications persistence integration)
 Run the new migration (1750000000000-CreateNotificationDurableState) against a scratch DB
 Manually exercise GET /v1/content/:id as anonymous / non-subscriber / subscriber / owner
closes #