### PR TITLE
Frontend/four issues content csp docs

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,51 @@
+# Frontend local environment template.
+#
+# Copy to `.env.local` (gitignored) and adjust as needed:
+#   cp .env.example .env.local
+#
+# See docs/LOCAL_QUICKSTART.md for the full local + Freighter walkthrough.
+
+# --- API -------------------------------------------------------------------
+# Origin of the Nest backend. Next.js proxies same-origin `/api/v1/*`
+# requests to `${NEXT_PUBLIC_API_URL}/v1/*` (see next.config.ts rewrites),
+# so the browser never needs CORS for normal API calls made through
+# `/api/v1/...`. Only direct, non-proxied calls (e.g. Soroban RPC/Horizon
+# from the wallet flow) need to be allowed via CORS/CSP separately.
+NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# --- Stellar network ---------------------------------------------------------
+# One of: testnet | futurenet | mainnet. Determines the default Horizon /
+# Soroban RPC endpoints in src/lib/contract-config.ts when the URLs below
+# are left unset.
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
+# Override the network defaults if you're running against a local/private
+# Horizon or Soroban RPC instance. Leave unset to use the public testnet
+# endpoints. If you do set these, also see docs/CSP.md — the configured
+# host is added to the CSP connect-src allowlist automatically.
+# NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+# NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# --- Contract IDs ------------------------------------------------------------
+# Required for the app to consider its Soroban contract config valid
+# (see validateRuntimeContractConfig in src/lib/contract-config.ts).
+# Get these from your local contract deployment output (see contract/README).
+NEXT_PUBLIC_MYFANS_TOKEN_CONTRACT_ID=
+NEXT_PUBLIC_CREATOR_REGISTRY_CONTRACT_ID=
+NEXT_PUBLIC_SUBSCRIPTION_CONTRACT_ID=
+NEXT_PUBLIC_CONTENT_ACCESS_CONTRACT_ID=
+NEXT_PUBLIC_EARNINGS_CONTRACT_ID=
+
+# --- App environment ---------------------------------------------------------
+NEXT_PUBLIC_APP_ENV=development
+
+# --- Feature flags (optional, all default to off/false) ----------------------
+# NEXT_PUBLIC_FEATURE_WALLET_CONNECT=false
+# NEXT_PUBLIC_FEATURE_CRYPTO_PAYMENTS=false
+# NEXT_PUBLIC_FEATURE_NEW_SUBSCRIPTION_FLOW=false
+
+# --- Dev-only auth shortcut (optional) ----------------------------------------
+# Lets you bypass wallet sign-in during local development for flows that
+# just need an authenticated session. Leave unset outside local dev.
+# NEXT_PUBLIC_DEV_AUTH_TOKEN=
+# NEXT_PUBLIC_DEV_USER_ID=

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,55 @@
+# MyFans Frontend
+
+Next.js app for MyFans: creator/fan UI, Stellar wallet connection
+(Freighter and others), and subscription/content flows.
+
+## Quickstart
+
+New to the frontend, or need to connect Freighter against your local API?
+See **[docs/LOCAL_QUICKSTART.md](./docs/LOCAL_QUICKSTART.md)** — a
+step-by-step local setup + Freighter connection walkthrough (~15 minutes),
+including a troubleshooting section for common wallet/CORS/CSP issues.
+
+Short version:
+
+```bash
+cd frontend
+cp .env.example .env.local   # fill in contract IDs if you have a local deployment
+npm ci
+npm run dev
+```
+
+The app expects the backend on `http://localhost:3001` by default
+(`NEXT_PUBLIC_API_URL` in `.env.example`); Next.js proxies same-origin
+`/api/v1/*` calls to it (see `next.config.ts`).
+
+## Scripts
+
+- `npm run dev` — start the Next.js dev server on `:3000`.
+- `npm run build` / `npm run start` — production build/serve.
+- `npm test` — Vitest unit/integration tests.
+- `npm run test:e2e` — Playwright end-to-end tests.
+- `npm run lint` — ESLint.
+- `npm run storybook` — component storybook on `:6006`.
+
+## Documentation
+
+- [`docs/LOCAL_QUICKSTART.md`](./docs/LOCAL_QUICKSTART.md) — local env +
+  Freighter quickstart and troubleshooting.
+- [`docs/CSP.md`](./docs/CSP.md) — Content-Security-Policy `connect-src`
+  host allowlist (API origin + Stellar/Soroban RPC hosts) and how to
+  update it when RPC endpoints change.
+- [`docs/SECURITY_HEADERS.md`](./docs/SECURITY_HEADERS.md) — full security
+  header set.
+- [`docs/ANALYTICS.md`](./docs/ANALYTICS.md) — analytics provider config.
+- [`docs/PLAYWRIGHT_FLAKE_TRIAGE.md`](./docs/PLAYWRIGHT_FLAKE_TRIAGE.md) —
+  triaging flaky e2e tests.
+- [`src/components/wallet/README.md`](./src/components/wallet/README.md) —
+  wallet connection system (multi-wallet support, auto-reconnect, error
+  handling).
+- [`ACCESSIBILITY.md`](./ACCESSIBILITY.md) — accessibility conventions.
+- [`STAGING_PARITY_CHECKLIST.md`](./STAGING_PARITY_CHECKLIST.md) — staging
+  parity checklist.
+
+For the full-stack (contract + backend + frontend) setup, see the
+[root README](../README.md).

--- a/frontend/docs/CSP.md
+++ b/frontend/docs/CSP.md
@@ -1,0 +1,64 @@
+# Content-Security-Policy: connect-src hosts
+
+The `Content-Security-Policy` header is built in `next.config.ts` via
+`buildContentSecurityPolicy()` (`src/lib/csp.ts`). This document covers the
+`connect-src` directive specifically, since it's the one that controls which
+hosts the app (and connected wallets like Freighter) are allowed to talk to.
+
+## What's allowed
+
+`connect-src` is built from `buildConnectSrcHosts()` and always includes:
+
+1. **The app's own API origin** — the host portion of `getApiBaseUrl()`
+   (`NEXT_PUBLIC_API_URL`, defaulting to `http://localhost:3001`).
+2. **Default Stellar/Soroban hosts** (`DEFAULT_STELLAR_CONNECT_HOSTS` in
+   `src/lib/csp.ts`):
+   - `*.stellar.org`
+   - `mainnet.sorobanrpc.com`
+   - `rpc-futurenet.stellar.org`
+   - `soroban-testnet.stellar.org`
+   - `horizon-testnet.stellar.org`
+   - `horizon-futurenet.stellar.org`
+3. **Whatever RPC hosts are actually configured**, extracted from:
+   - `NEXT_PUBLIC_SOROBAN_RPC_URL`
+   - `NEXT_PUBLIC_HORIZON_URL`
+
+   This matters when the app is pointed at a non-default RPC — a private
+   Soroban RPC endpoint, a different testnet provider, a self-hosted Horizon
+   instance, etc. Without step 3, CSP would silently block those calls even
+   though `contract-config.ts` is configured to use them, and wallet
+   signing/submission would fail with an opaque CSP violation in the
+   console instead of a clear error.
+4. In non-production builds only: `localhost:*` and `127.0.0.1:*`, so local
+   backends and local RPC nodes work without any extra configuration.
+
+Everything else is blocked. A host that isn't the API origin, isn't in
+`DEFAULT_STELLAR_CONNECT_HOSTS`, and isn't reachable via
+`NEXT_PUBLIC_SOROBAN_RPC_URL` / `NEXT_PUBLIC_HORIZON_URL` will **not** be
+added automatically — this is intentional, so a compromised or unexpected
+host can't sneak into the policy.
+
+## Updating the host list
+
+- **Adding a new default Stellar/Soroban host** (e.g. Stellar ships a new
+  network or RPC provider): add it to `DEFAULT_STELLAR_CONNECT_HOSTS` in
+  `src/lib/csp.ts`.
+- **Using a custom/private RPC or Horizon endpoint**: set
+  `NEXT_PUBLIC_SOROBAN_RPC_URL` and/or `NEXT_PUBLIC_HORIZON_URL` in your env
+  (see `.env.example`) — no code change needed, the host is picked up
+  automatically.
+- **Verifying nothing regressed**: run the CSP regression test in
+  `src/lib/csp.test.ts` (`npm test -- csp`). It asserts the default Stellar
+  hosts are always present and that a configured RPC/Horizon host is added,
+  so an accidental deletion of a host from `DEFAULT_STELLAR_CONNECT_HOSTS`
+  or a change to `buildConnectSrcHosts()` that drops env-configured hosts
+  fails CI instead of shipping a broken wallet connection.
+
+## Related
+
+- `src/lib/csp.ts` — host + CSP string construction, unit-tested directly.
+- `src/lib/csp.test.ts` — regression test guarding wallet connect-src hosts.
+- `src/lib/contract-config.ts` — resolves `sorobanRpcUrl` / `horizonUrl` per
+  network; keep `NETWORK_DEFAULTS` there in sync with
+  `DEFAULT_STELLAR_CONNECT_HOSTS`.
+- `docs/SECURITY_HEADERS.md` — the rest of the security header set.

--- a/frontend/docs/CSP.md
+++ b/frontend/docs/CSP.md
@@ -54,6 +54,36 @@ host can't sneak into the policy.
   or a change to `buildConnectSrcHosts()` that drops env-configured hosts
   fails CI instead of shipping a broken wallet connection.
 
+## Regression test
+
+`src/lib/csp.test.ts` is a CI regression test for `connect-src`. It exists
+because CSP is easy to break silently — a refactor of `next.config.ts` or
+`src/lib/csp.ts` can drop a Stellar host and nothing fails locally; it only
+shows up later as a wallet extension throwing CSP violations in production.
+
+What it asserts:
+
+- Every host in `DEFAULT_STELLAR_CONNECT_HOSTS` (`*.stellar.org`,
+  `mainnet.sorobanrpc.com`, `rpc-futurenet.stellar.org`,
+  `soroban-testnet.stellar.org`, `horizon-testnet.stellar.org`,
+  `horizon-futurenet.stellar.org`) is present in `connect-src`.
+- The API origin host is present.
+- A host configured via `NEXT_PUBLIC_SOROBAN_RPC_URL` /
+  `NEXT_PUBLIC_HORIZON_URL` is added and deduped against the defaults.
+- Hosts that aren't the API origin, a default Stellar host, or an
+  env-configured RPC/Horizon host are **not** added.
+- `localhost:*` / `127.0.0.1:*` only appear outside production.
+
+Run it directly with `npm test -- csp` (or `npm test` for the full suite).
+
+**When you need to update the host list**, edit
+`DEFAULT_STELLAR_CONNECT_HOSTS` in `src/lib/csp.ts` and update the
+corresponding assertions/list in `src/lib/csp.test.ts` and the "What's
+allowed" section above in the same change — the test is intentionally
+written to fail if the two drift apart, so a host removal must be a
+deliberate, reviewed edit in both places, not an accidental side effect of
+an unrelated refactor.
+
 ## Related
 
 - `src/lib/csp.ts` — host + CSP string construction, unit-tested directly.

--- a/frontend/docs/LOCAL_QUICKSTART.md
+++ b/frontend/docs/LOCAL_QUICKSTART.md
@@ -1,0 +1,115 @@
+# Frontend local quickstart + Freighter setup
+
+Get the frontend running locally against the local API and connect
+Freighter to it. Written to be followed top-to-bottom in under 15 minutes.
+
+## 1. Prerequisites (2 min)
+
+- Node.js (see root `package.json`/`.nvmrc` if present) and `npm`.
+- The backend running locally on `:3001` — from repo root:
+  ```bash
+  cd backend && npm ci && npm run start:dev
+  # or from repo root: ./scripts/myfans dev:backend
+  ```
+- The [Freighter](https://freighter.app) browser extension installed, with
+  a wallet created/imported and unlocked.
+
+## 2. Configure the environment (2 min)
+
+```bash
+cd frontend
+cp .env.example .env.local
+```
+
+Defaults in `.env.example` point at a local backend (`http://localhost:3001`)
+and Stellar **testnet**, which is what Freighter should also be set to (see
+step 4). If you have Soroban contract IDs from a local deployment
+(`cd contract && ...`, see `contract/README.md`), fill in the
+`NEXT_PUBLIC_*_CONTRACT_ID` values in `.env.local` — the app will otherwise
+show contract-config validation warnings, but the UI still loads.
+
+## 3. Install and run (3 min)
+
+```bash
+npm ci
+npm run dev
+```
+
+Open `http://localhost:3000`. The app talks to the backend through Next's
+same-origin `/api/v1/*` proxy (configured in `next.config.ts`), so you
+should **not** need to touch CORS for normal API calls.
+
+## 4. Connect Freighter (5 min)
+
+1. Open the Freighter extension and switch its network to match
+   `NEXT_PUBLIC_STELLAR_NETWORK` in `.env.local` (default: **Test Net**).
+   Settings → Preferences → Network in the extension.
+2. In the app, open the wallet connect flow (e.g. `/wallet-demo`, or the
+   "Connect wallet" button in the nav) and choose **Freighter**.
+3. Approve the connection request in the Freighter popup.
+4. You should land back in the app with a connected address shown. If
+   nothing happens, see Troubleshooting below before retrying.
+
+## 5. Smoke test (3 min)
+
+- [ ] `npm run dev` starts without errors and `/` loads.
+- [ ] A page that hits the API (e.g. `/discover` or `/feed`) renders data
+      instead of an error state — confirms the API proxy/backend is reachable.
+- [ ] Freighter connects and shows an address (step 4).
+- [ ] No `Content-Security-Policy` violations appear in the browser
+      console when connecting the wallet (see `docs/CSP.md` if you do).
+
+If all four pass, your local setup is good to go.
+
+## Troubleshooting
+
+### Freighter isn't detected / "install wallet" prompt shown
+
+- Make sure the extension is enabled for the current browser profile and
+  the tab was loaded (or reloaded) **after** installing it.
+- Freighter injects its API into `window` on page load — a hot-reloaded
+  page sometimes misses it; do a hard refresh.
+
+### Freighter connects but transactions fail with a network mismatch
+
+- The wallet's selected network (Test Net / Public Net / Futurenet) must
+  match `NEXT_PUBLIC_STELLAR_NETWORK`. Mismatches typically show up as a
+  signing error or an invalid-transaction response from Horizon/Soroban
+  RPC rather than an obvious "wrong network" message.
+
+### Wallet calls fail with a CSP / "Refused to connect" console error
+
+- This means the RPC/Horizon host Freighter (or the app) is calling isn't
+  in the CSP `connect-src` allowlist. If you've set a custom
+  `NEXT_PUBLIC_SOROBAN_RPC_URL` or `NEXT_PUBLIC_HORIZON_URL`, restart
+  `npm run dev` after editing `.env.local` — Next only reads env at server
+  start. See `docs/CSP.md` for exactly which hosts are allowed and how to
+  add one.
+
+### API calls fail with a CORS error in the console
+
+- Requests made through the app's own fetch calls should go through
+  `/api/v1/*`, which Next rewrites server-side (no CORS involved). A CORS
+  error usually means either:
+  - The backend isn't running / isn't on the port `NEXT_PUBLIC_API_URL`
+    points at (default `http://localhost:3001`) — check the backend
+    terminal for startup errors.
+  - Some code is calling the backend origin directly (bypassing the
+    `/api/v1` proxy) — check the backend's CORS allowlist
+    (`backend/src/common/services/cors.service.ts`) includes
+    `http://localhost:3000`.
+
+### `.env.local` changes don't seem to take effect
+
+- Restart `npm run dev`. Next.js only reads `NEXT_PUBLIC_*` env vars at
+  build/server start, not on hot reload.
+
+## Related docs
+
+- [`docs/CSP.md`](./CSP.md) — CSP `connect-src` host allowlist and how
+  wallet/RPC hosts get added to it.
+- [`src/components/wallet/README.md`](../src/components/wallet/README.md) —
+  wallet connection system internals (multi-wallet support, reconnection,
+  error handling).
+- Root [`README.md`](../../README.md) — full-stack setup (contract +
+  backend + frontend together).

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,52 +2,16 @@ import type { NextConfig } from "next";
 import withBundleAnalyzer from "@next/bundle-analyzer";
 import { getRemoteImagePatterns } from "./src/lib/image-remote-patterns";
 import { getApiBaseUrl } from "./src/lib/api/base-url";
+import { buildContentSecurityPolicy } from "./src/lib/csp";
 
 const isProd = process.env.NODE_ENV === 'production';
 
-// Helper to generate CSP
+// Builds the CSP header value, including connect-src hosts derived from
+// NEXT_PUBLIC_SOROBAN_RPC_URL / NEXT_PUBLIC_HORIZON_URL. See src/lib/csp.ts
+// and docs/CSP.md for the full host list and how to update it.
 function getCSP() {
   const apiHost = new URL(getApiBaseUrl()).host;
-
-  const stellarHosts = [
-    '*.stellar.org',
-    'mainnet.sorobanrpc.com',
-    'rpc-futurenet.stellar.org'
-  ];
-
-  const connectSrc = [
-    "'self'",
-    apiHost,
-    ...stellarHosts,
-    // Add localhost for dev
-    !isProd && 'localhost:*',
-    !isProd && '127.0.0.1:*',
-  ].filter(Boolean).join(' ');
-
-  const scriptSrc = isProd 
-    ? "'self'" 
-    : "'self' 'unsafe-inline' 'unsafe-eval'";
-
-  const directives = {
-    'default-src': ["'self'"],
-    'script-src': [scriptSrc],
-    'style-src': ["'self'", "'unsafe-inline'"],
-    'img-src': ["'self'", "data:", "https:"],
-    'font-src': ["'self'", "data:"],
-    'connect-src': [connectSrc],
-    'frame-ancestors': ["'none'"],
-    'base-uri': ["'self'"],
-    'form-action': ["'self'"],
-    'upgrade-insecure-requests': isProd ? [] : null,
-  };
-
-  return Object.entries(directives)
-    .filter(([_, value]) => value !== null)
-    .map(([key, value]) => {
-      if (Array.isArray(value) && value.length === 0) return key;
-      return `${key} ${Array.isArray(value) ? value.join(' ') : value}`;
-    })
-    .join('; ');
+  return buildContentSecurityPolicy({ apiHost, isProd });
 }
 
 const nextConfig: NextConfig = {

--- a/frontend/src/app/content/[id]/unlock-flow.test.tsx
+++ b/frontend/src/app/content/[id]/unlock-flow.test.tsx
@@ -1,0 +1,143 @@
+/* eslint-disable @next/next/no-img-element */
+import type { ComponentProps, ReactNode } from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ContentPage from '@/app/content/[id]/page';
+import { ToastProvider } from '@/contexts/ToastContext';
+import type { ContentMetadata } from '@/lib/api/content';
+
+/**
+ * Integration tests for the content/[id] unlock flow.
+ *
+ * Unlike page.test.tsx (which exercises the subscription badge alone),
+ * these tests mock the content API layer directly so we can assert on
+ * the actual gated (locked overlay) vs unlocked (player) rendering that
+ * GatedContentViewer produces once access has been checked.
+ */
+
+vi.mock('next/image', () => ({
+  default: (props: ComponentProps<'img'> & { fill?: boolean; priority?: boolean }) => {
+    const sanitizedProps = { ...props };
+    delete sanitizedProps.fill;
+    delete sanitizedProps.priority;
+
+    return <img {...sanitizedProps} alt={props.alt ?? ''} />;
+  },
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/lib/api/content', () => ({
+  getContentById: vi.fn(),
+}));
+
+import { getContentById } from '@/lib/api/content';
+
+const baseContent: ContentMetadata = {
+  id: '1',
+  title: 'Behind the scenes',
+  description: 'Exclusive footage from the last shoot.',
+  contentUrl: 'https://cdn.example.com/videos/1.mp4',
+  thumbnailUrl: 'https://cdn.example.com/thumbs/1.jpg',
+  type: 'video',
+  isGated: true,
+  creator: {
+    id: 'creator-1',
+    name: 'Jamie Rivera',
+    username: 'jamierivera',
+    isVerified: true,
+  },
+  metadata: {
+    publishedAt: '2026-01-01T00:00:00.000Z',
+    viewCount: 1000,
+    likeCount: 50,
+    commentCount: 5,
+    tags: ['exclusive'],
+  },
+};
+
+function renderContentPage() {
+  return render(
+    <ToastProvider>
+      <ContentPage params={Promise.resolve({ id: '1' })} />
+    </ToastProvider>,
+  );
+}
+
+describe('content/[id] unlock flow', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.mocked(getContentById).mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the locked overlay for gated content without an active subscription', async () => {
+    vi.mocked(getContentById).mockResolvedValue({ ...baseContent, isGated: true });
+
+    vi.useFakeTimers();
+    await act(async () => {
+      renderContentPage();
+    });
+
+    // ClientContent's onCheckAccess resolves after a simulated 1.5s network round trip.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(screen.getByText('Exclusive Content')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: `Subscribe to ${baseContent.creator.name}` }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+  });
+
+  it('renders the full player for unlocked (un-gated) content', async () => {
+    vi.mocked(getContentById).mockResolvedValue({ ...baseContent, isGated: false });
+
+    renderContentPage();
+
+    await waitFor(() => {
+      expect(screen.queryByText('Exclusive Content')).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Verifying access...')).not.toBeInTheDocument();
+  });
+
+  it('renders the full player once a gated content check resolves to an active subscription', async () => {
+    window.localStorage.setItem(
+      'myfans.viewer.subscriptions.v1',
+      JSON.stringify({ [baseContent.creator.id]: 'active' }),
+    );
+    vi.mocked(getContentById).mockResolvedValue({ ...baseContent, isGated: true });
+
+    vi.useFakeTimers();
+    await act(async () => {
+      renderContentPage();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(screen.queryByText('Exclusive Content')).not.toBeInTheDocument();
+    expect(
+      screen.getAllByRole('status', { name: 'Subscription status: active' }).length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/lib/csp.test.ts
+++ b/frontend/src/lib/csp.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildConnectSrcHosts,
+  buildContentSecurityPolicy,
+  DEFAULT_STELLAR_CONNECT_HOSTS,
+  extractHost,
+} from '@/lib/csp';
+
+/**
+ * Regression tests for the CSP `connect-src` allowlist.
+ *
+ * CSP changes are easy to get wrong silently: a well-meaning refactor of
+ * next.config.ts (or of src/lib/csp.ts) can drop a Stellar host from the
+ * policy and nothing will fail until a wallet extension starts throwing
+ * CSP violations in production. These tests pin the critical hosts down
+ * so that regression shows up as a failing test instead.
+ *
+ * See docs/CSP.md for the update process this suite is meant to protect.
+ */
+
+const API_HOST = 'localhost:3001';
+
+describe('extractHost', () => {
+  it('extracts host:port from a URL with a non-default port', () => {
+    expect(extractHost('https://custom-rpc.example.com:8443/soroban')).toBe(
+      'custom-rpc.example.com:8443',
+    );
+  });
+
+  it('extracts a bare host when no port is present', () => {
+    expect(extractHost('https://soroban-testnet.stellar.org')).toBe(
+      'soroban-testnet.stellar.org',
+    );
+  });
+
+  it('returns null for missing or invalid values', () => {
+    expect(extractHost(undefined)).toBeNull();
+    expect(extractHost('')).toBeNull();
+    expect(extractHost('not a url')).toBeNull();
+  });
+});
+
+describe('buildConnectSrcHosts', () => {
+  it('always includes every default Stellar/Soroban host', () => {
+    const hosts = buildConnectSrcHosts(API_HOST, {});
+
+    for (const stellarHost of DEFAULT_STELLAR_CONNECT_HOSTS) {
+      expect(hosts).toContain(stellarHost);
+    }
+  });
+
+  it('includes the API origin host', () => {
+    const hosts = buildConnectSrcHosts(API_HOST, {});
+    expect(hosts).toContain(API_HOST);
+  });
+
+  it('adds the configured NEXT_PUBLIC_SOROBAN_RPC_URL host', () => {
+    const hosts = buildConnectSrcHosts(API_HOST, {
+      NEXT_PUBLIC_SOROBAN_RPC_URL: 'https://my-private-soroban-rpc.example.com',
+    });
+
+    expect(hosts).toContain('my-private-soroban-rpc.example.com');
+  });
+
+  it('adds the configured NEXT_PUBLIC_HORIZON_URL host', () => {
+    const hosts = buildConnectSrcHosts(API_HOST, {
+      NEXT_PUBLIC_HORIZON_URL: 'https://my-horizon.example.com:4433',
+    });
+
+    expect(hosts).toContain('my-horizon.example.com:4433');
+  });
+
+  it('dedupes when a configured host matches a default host', () => {
+    const hosts = buildConnectSrcHosts(API_HOST, {
+      NEXT_PUBLIC_SOROBAN_RPC_URL: 'https://mainnet.sorobanrpc.com',
+    });
+
+    expect(hosts.filter((host) => host === 'mainnet.sorobanrpc.com')).toHaveLength(1);
+  });
+
+  it('does not allow arbitrary unconfigured hosts', () => {
+    const hosts = buildConnectSrcHosts(API_HOST, {});
+    expect(hosts).not.toContain('evil.example.com');
+  });
+});
+
+describe('buildContentSecurityPolicy', () => {
+  it('produces a connect-src directive containing the critical wallet hosts', () => {
+    const csp = buildContentSecurityPolicy({
+      apiHost: API_HOST,
+      isProd: true,
+      env: {
+        NEXT_PUBLIC_SOROBAN_RPC_URL: 'https://my-private-soroban-rpc.example.com',
+      },
+    });
+
+    const connectSrcLine = csp
+      .split(';')
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith('connect-src'));
+
+    expect(connectSrcLine).toBeDefined();
+    expect(connectSrcLine).toContain("'self'");
+    expect(connectSrcLine).toContain(API_HOST);
+    expect(connectSrcLine).toContain('my-private-soroban-rpc.example.com');
+
+    for (const stellarHost of DEFAULT_STELLAR_CONNECT_HOSTS) {
+      expect(connectSrcLine).toContain(stellarHost);
+    }
+  });
+
+  it('fails fast if a required Stellar host is dropped from the default list', () => {
+    // Guards against someone editing DEFAULT_STELLAR_CONNECT_HOSTS and
+    // removing a host that wallets depend on (e.g. mainnet Soroban RPC).
+    expect(DEFAULT_STELLAR_CONNECT_HOSTS).toEqual(
+      expect.arrayContaining([
+        '*.stellar.org',
+        'mainnet.sorobanrpc.com',
+        'rpc-futurenet.stellar.org',
+      ]),
+    );
+  });
+
+  it('includes localhost sources only outside production', () => {
+    const devCsp = buildContentSecurityPolicy({ apiHost: API_HOST, isProd: false, env: {} });
+    const prodCsp = buildContentSecurityPolicy({ apiHost: API_HOST, isProd: true, env: {} });
+
+    expect(devCsp).toContain('localhost:*');
+    expect(prodCsp).not.toContain('localhost:*');
+  });
+});

--- a/frontend/src/lib/csp.ts
+++ b/frontend/src/lib/csp.ts
@@ -1,0 +1,115 @@
+/**
+ * Content-Security-Policy `connect-src` host resolution.
+ *
+ * Wallet extensions (Freighter et al.) and in-app Soroban/Horizon calls need
+ * `connect-src` to allow the API origin plus every Stellar RPC host actually
+ * in use. Previously the Soroban RPC / Horizon host list in `next.config.ts`
+ * was a hardcoded set of well-known hosts and did not take
+ * `NEXT_PUBLIC_SOROBAN_RPC_URL` / `NEXT_PUBLIC_HORIZON_URL` into account, so
+ * pointing the app at a non-default RPC (a private endpoint, a different
+ * testnet provider, etc.) silently broke wallet calls once CSP started
+ * blocking the un-listed host.
+ *
+ * See `docs/CSP.md` for the list of hosts this allows and how to update it
+ * safely when Stellar/Soroban infrastructure changes.
+ */
+
+export type EnvSource = Record<string, string | undefined>;
+
+/**
+ * Well-known Stellar/Soroban hosts that must always be reachable regardless
+ * of which network the app is configured for. Keep this in sync with
+ * `NETWORK_DEFAULTS` in `contract-config.ts`.
+ */
+export const DEFAULT_STELLAR_CONNECT_HOSTS = [
+  '*.stellar.org',
+  'mainnet.sorobanrpc.com',
+  'rpc-futurenet.stellar.org',
+  'soroban-testnet.stellar.org',
+  'horizon-testnet.stellar.org',
+  'horizon-futurenet.stellar.org',
+];
+
+/** Extract a `host` or `host:port` suitable for a CSP source list from a URL string. */
+export function extractHost(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.port ? `${url.hostname}:${url.port}` : url.hostname;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the deduped list of hosts that belong in `connect-src`: the API
+ * origin, the default Stellar hosts, and whatever hosts are actually
+ * configured via `NEXT_PUBLIC_SOROBAN_RPC_URL` / `NEXT_PUBLIC_HORIZON_URL`.
+ */
+export function buildConnectSrcHosts(
+  apiHost: string,
+  env: EnvSource = process.env,
+): string[] {
+  const configuredHosts = [
+    extractHost(env.NEXT_PUBLIC_SOROBAN_RPC_URL),
+    extractHost(env.NEXT_PUBLIC_HORIZON_URL),
+  ].filter((host): host is string => !!host);
+
+  return Array.from(
+    new Set([apiHost, ...DEFAULT_STELLAR_CONNECT_HOSTS, ...configuredHosts]),
+  );
+}
+
+export interface BuildCspOptions {
+  /** Host (and optional port) of the app's own API origin. */
+  apiHost: string;
+  /** Whether to build the stricter production policy. */
+  isProd: boolean;
+  env?: EnvSource;
+}
+
+/**
+ * Build the full `Content-Security-Policy` header value used by
+ * `next.config.ts`. Kept separate from `next.config.ts` so it can be
+ * unit-tested directly without booting Next.js.
+ */
+export function buildContentSecurityPolicy({
+  apiHost,
+  isProd,
+  env = process.env,
+}: BuildCspOptions): string {
+  const connectHosts = buildConnectSrcHosts(apiHost, env);
+
+  const connectSrc = [
+    "'self'",
+    ...connectHosts,
+    // Add localhost for dev
+    !isProd && 'localhost:*',
+    !isProd && '127.0.0.1:*',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const scriptSrc = isProd ? "'self'" : "'self' 'unsafe-inline' 'unsafe-eval'";
+
+  const directives: Record<string, string[] | null> = {
+    'default-src': ["'self'"],
+    'script-src': [scriptSrc],
+    'style-src': ["'self'", "'unsafe-inline'"],
+    'img-src': ["'self'", 'data:', 'https:'],
+    'font-src': ["'self'", 'data:'],
+    'connect-src': [connectSrc],
+    'frame-ancestors': ["'none'"],
+    'base-uri': ["'self'"],
+    'form-action': ["'self'"],
+    'upgrade-insecure-requests': isProd ? [] : null,
+  };
+
+  return Object.entries(directives)
+    .filter(([, value]) => value !== null)
+    .map(([key, value]) => {
+      if (Array.isArray(value) && value.length === 0) return key;
+      return `${key} ${Array.isArray(value) ? value.join(' ') : value}`;
+    })
+    .join('; ');
+}


### PR DESCRIPTION
## Summary

<!-- One or two sentences describing what this PR does and why. -->

### 1. Content page integration tests for unlock flow
`content/[id]` previously only had a test for the page shell (subscription badge), not the actual unlock flow. Added `frontend/src/app/content/[id]/unlock-flow.test.tsx`, which mocks the content API layer (`getContentById`) directly and asserts:
- Gated content without an active subscription renders the locked overlay ("Exclusive Content" + Subscribe CTA)
- Un-gated content renders the full player immediately
- Gated content resolves to the full player once the access check reflects an active subscription

Uses fake timers to deterministically advance past the simulated access-check delay, keeping the suite stable in CI.

### 2. Local env + Freighter quickstart for the frontend package
Contributors had no documented path to set up the frontend locally or connect Freighter to the local API.
- Added `frontend/.env.example` (API base URL, Stellar network, Horizon/Soroban RPC overrides, contract IDs, feature flags, dev-auth shortcut) and un-ignored it in `frontend/.gitignore` (which blanket-ignores `.env*`).
- Added `frontend/docs/LOCAL_QUICKSTART.md`: a ~15-minute walkthrough (prerequisites → env setup → install/run → connect Freighter → smoke-test checklist) plus troubleshooting for common wallet/CORS/CSP failures.
- Added `frontend/README.md` linking the quickstart and other existing docs (CSP, security headers, wallet system, accessibility) — no frontend README existed before.

### 3. Enforce CSP connect-src for configured Soroban RPC
`next.config.ts`'s CSP builder hardcoded a fixed Stellar host list and never read `NEXT_PUBLIC_SOROBAN_RPC_URL` / `NEXT_PUBLIC_HORIZON_URL`. Pointing the app at a non-default RPC silently broke wallet calls once CSP blocked the un-listed host.
- Extracted CSP construction into `frontend/src/lib/csp.ts` (`buildConnectSrcHosts`, `buildContentSecurityPolicy`), independently testable from `next.config.ts`.
- `connect-src` now always includes the API origin + default Stellar hosts, plus whatever host is configured via `NEXT_PUBLIC_SOROBAN_RPC_URL` / `NEXT_PUBLIC_HORIZON_URL`, deduped.
- `next.config.ts` now delegates to the shared helper; existing default-host behavior is unchanged.
- Documented the full allowed host list and rationale in `frontend/docs/CSP.md`

### 4. CSP regression test for wallet connect-src hosts
CSP changes can silently break wallets — a refactor can drop a Stellar host and nothing fails until a wallet throws a CSP violation in production.
- Added `frontend/src/lib/csp.test.ts` asserting: every default Stellar host isresent, env-configured RPC/Horizon hosts are added and deduped, arbitraryunconfigured hosts are rejected, and `localhost:*`/`127.0.0.1:*` only appear outside production.
- Documented the regression test and the update process (edit `DEFAULT_STELLAR_he docs together) in `frontend/docs/CSP.md`.

## Changes

<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [x] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [x] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [x] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [x] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [x] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [x] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [ ] Happy path works end-to-end in a local environment
- [ ] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [ ] No regressions in closely related API or UI flows
- [ ] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [ ] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues

<!-- Closes #NNN -->

## Notes for reviewers

<!-- Anything that needs extra attention, known limitations, or follow-up work. -->
Closes #1492
Closes #1493
Closes #1488
Closes #1494