### PR TITLE
Feat/a11y discover subs fixes

### DIFF
--- a/frontend/src/app/dashboard/layout.test.tsx
+++ b/frontend/src/app/dashboard/layout.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import DashboardLayout from './layout';
+
+let mockPathname = '/dashboard';
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('@/components/onboarding', () => ({
+  OnboardingResumeBanner: () => null,
+}));
+
+vi.mock('@/components/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('DashboardLayout accessibility', () => {
+  beforeEach(() => {
+    mockPathname = '/dashboard';
+    localStorage.clear();
+  });
+
+  it('renders a skip link pointing at the main content landmark', () => {
+    render(
+      <DashboardLayout>
+        <p>page content</p>
+      </DashboardLayout>,
+    );
+
+    const skipLink = screen.getByText('Skip to main content');
+    expect(skipLink.getAttribute('href')).toBe('#dashboard-main');
+  });
+
+  it('gives the main landmark a focusable id matching the skip link target', () => {
+    render(
+      <DashboardLayout>
+        <p>page content</p>
+      </DashboardLayout>,
+    );
+
+    const main = document.getElementById('dashboard-main');
+    expect(main).not.toBeNull();
+    expect(main?.tagName).toBe('MAIN');
+    expect(main?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('moves focus to main content when the route changes', () => {
+    const { rerender } = render(
+      <DashboardLayout>
+        <p>page content</p>
+      </DashboardLayout>,
+    );
+
+    const main = document.getElementById('dashboard-main');
+    expect(main).not.toBe(document.activeElement);
+
+    mockPathname = '/dashboard/plans';
+    rerender(
+      <DashboardLayout>
+        <p>plans content</p>
+      </DashboardLayout>,
+    );
+
+    expect(document.getElementById('dashboard-main')).toBe(document.activeElement);
+  });
+
+  it('labels icon-only buttons for screen readers', () => {
+    render(
+      <DashboardLayout>
+        <p>page content</p>
+      </DashboardLayout>,
+    );
+
+    expect(screen.getByLabelText('Open menu')).toBeInTheDocument();
+    expect(screen.getByLabelText('Collapse sidebar')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
@@ -40,6 +40,16 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   });
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const pathname = usePathname();
+  const mainRef = useRef<HTMLElement>(null);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    mainRef.current?.focus();
+  }, [pathname]);
 
   const toggleCollapse = () => {
     const newState = !isCollapsed;
@@ -49,6 +59,12 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+      <a
+        href="#dashboard-main"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-lg focus:bg-sky-600 focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-white focus:shadow-lg"
+      >
+        Skip to main content
+      </a>
       <header className="lg:hidden fixed top-0 left-0 right-0 h-16 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 z-50 flex items-center px-3 sm:px-4">
         <button
           onClick={() => setIsMobileOpen(!isMobileOpen)}
@@ -164,9 +180,13 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       </aside>
 
       <main
+        id="dashboard-main"
+        ref={mainRef}
+        tabIndex={-1}
         className={`
           transition-all duration-300 ease-in-out
           pt-16 lg:pt-0 min-w-0
+          focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-inset
           ${isCollapsed ? 'lg:ml-20' : 'lg:ml-64'}
         `}
       >

--- a/frontend/src/app/subscriptions/page.tsx
+++ b/frontend/src/app/subscriptions/page.tsx
@@ -7,6 +7,7 @@ import {
   type SubscriptionHistoryItem,
   type PaymentRecord,
 } from '@/lib/subscriptions';
+import { fetchActiveSubscriptions, SubscriptionsUnauthorizedError } from '@/lib/api/subscriptions';
 import { formatCurrency, formatDate, getCurrencySymbol } from '@/lib/formatting';
 import { BaseCard } from '@/components/cards/BaseCard';
 import { Modal } from '@/components/Modal';
@@ -32,30 +33,37 @@ export default function SubscriptionsPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [isHistoryLoading, setIsHistoryLoading] = useState(true);
   const [isPaymentsLoading, setIsPaymentsLoading] = useState(true);
+  const [activeListError, setActiveListError] = useState<'unauthorized' | 'error' | null>(null);
 
   useEffect(() => {
     let mounted = true;
     const fetchSubscriptions = async () => {
       setIsLoading(true);
       try {
-        const params = new URLSearchParams({ status: statusFilter, sort: sortOption });
-        const res = await fetch(`/api/v1/subscriptions/me/list?${params.toString()}`);
-        if (!res.ok) throw new Error('Failed to fetch subscriptions');
-        const data = await res.json();
+        const list = await fetchActiveSubscriptions({ status: statusFilter, sort: sortOption });
         if (mounted) {
-          // API returns { data: [...], ... } paginated shape
-          setActiveList(Array.isArray(data) ? data : (data.data ?? []));
+          setActiveList(list);
+          setActiveListError(null);
         }
       } catch (err) {
         console.error(err);
-        showError('NETWORK_ERROR', subscriptionsLoadFailed());
+        if (mounted) {
+          setActiveList([]);
+          setActiveListError(err instanceof SubscriptionsUnauthorizedError ? 'unauthorized' : 'error');
+        }
+        showError(
+          'NETWORK_ERROR',
+          err instanceof SubscriptionsUnauthorizedError
+            ? { message: 'Please sign in again', description: err.message }
+            : subscriptionsLoadFailed(),
+        );
       } finally {
         if (mounted) setIsLoading(false);
       }
     };
     fetchSubscriptions();
     return () => { mounted = false; };
-  }, [sortOption, statusFilter]);
+  }, [sortOption, statusFilter, showError]);
 
   useEffect(() => {
     let mounted = true;
@@ -178,15 +186,12 @@ export default function SubscriptionsPage() {
       await new Promise((resolve) => setTimeout(resolve, 1500));
       
       showSuccess('Subscription renewed', `${renewTarget.creatorName} ${renewTarget.planName} is active again.`);
-      
+
       // Refresh list after renewal
-      const params = new URLSearchParams({ status: statusFilter, sort: sortOption });
-      const res = await fetch(`/api/v1/subscriptions/me/list?${params.toString()}`);
-      if (res.ok) {
-        const data = await res.json();
-        setActiveList(Array.isArray(data) ? data : (data.data ?? []));
-      }
-      
+      const list = await fetchActiveSubscriptions({ status: statusFilter, sort: sortOption });
+      setActiveList(list);
+      setActiveListError(null);
+
       setRenewTarget(null);
     } catch {
       showError('TX_FAILED', subscriptionActionToast.renewFailed());
@@ -268,6 +273,18 @@ export default function SubscriptionsPage() {
                 <ActiveSubscriptionSkeleton key={i} />
               ))}
             </div>
+          ) : activeListError === 'unauthorized' ? (
+            <EmptyState
+              title="Sign in required"
+              description="Your session has expired. Sign in again to see your active subscriptions."
+              actionLabel="Sign in"
+              actionHref="/auth/sign-in"
+            />
+          ) : activeListError === 'error' ? (
+            <EmptyState
+              title="Couldn't load subscriptions"
+              description="Something went wrong while loading your subscriptions. Please try again."
+            />
           ) : activeList.length === 0 ? (
             <EmptyState
               title="No subscriptions found"

--- a/frontend/src/lib/api/creators.test.ts
+++ b/frontend/src/lib/api/creators.test.ts
@@ -115,4 +115,61 @@ describe('publicCreatorToProfile', () => {
     expect(profile.bio).toBe('');
     expect(profile.avatarUrl).toBeUndefined();
   });
+
+  it('maps subscription price, currency-bearing numeric strings, and categories when present', () => {
+    const creator: PublicCreator = {
+      id: '3',
+      username: 'sam',
+      display_name: 'Sam Rivera',
+      avatar_url: null,
+      bio: null,
+      is_verified: false,
+      followers_count: 8300,
+      subscription_price: '4.99',
+      currency: 'USDC',
+      categories: ['Photography', 'Video'],
+    };
+
+    const profile = publicCreatorToProfile(creator);
+
+    expect(profile.subscriberCount).toBe(8300);
+    expect(profile.subscriptionPrice).toBe(4.99);
+    expect(profile.categories).toEqual(['Photography', 'Video']);
+  });
+
+  it('accepts a numeric subscription_price without parsing errors', () => {
+    const creator: PublicCreator = {
+      id: '4',
+      username: 'lee',
+      display_name: 'Lee Park',
+      avatar_url: null,
+      bio: null,
+      is_verified: false,
+      followers_count: 100,
+      subscription_price: 12.5,
+    };
+
+    const profile = publicCreatorToProfile(creator);
+
+    expect(profile.subscriptionPrice).toBe(12.5);
+  });
+
+  it('defaults price and categories safely when the fields are missing or unparsable', () => {
+    const creator: PublicCreator = {
+      id: '5',
+      username: 'nopricecats',
+      display_name: 'No Price',
+      avatar_url: null,
+      bio: null,
+      is_verified: false,
+      followers_count: 5,
+      subscription_price: 'not-a-number',
+      categories: null,
+    };
+
+    const profile = publicCreatorToProfile(creator);
+
+    expect(profile.subscriptionPrice).toBe(0);
+    expect(profile.categories).toEqual([]);
+  });
 });

--- a/frontend/src/lib/api/creators.ts
+++ b/frontend/src/lib/api/creators.ts
@@ -12,6 +12,10 @@ export interface PublicCreator {
   bio: string | null;
   is_verified: boolean;
   followers_count: number;
+  /** Present on `/creators` and `/creators/username/:username` when the creator has set a price. */
+  subscription_price?: string | number | null;
+  currency?: string | null;
+  categories?: string[] | null;
 }
 
 export interface CreatorsSearchResult {
@@ -62,12 +66,27 @@ export async function getCreatorProfile(username: string): Promise<PublicCreator
 }
 
 /**
+ * Parse the API's `subscription_price` field into a number.
+ *
+ * The field can arrive as a numeric string (Postgres `numeric` columns are
+ * serialized as strings), a plain number, null, or be absent entirely.
+ * Anything that doesn't parse to a finite number falls back to 0 rather
+ * than propagating `NaN` into price displays and sort comparisons.
+ */
+function parseSubscriptionPrice(value: string | number | null | undefined): number {
+  if (value === null || value === undefined) return 0;
+  const parsed = typeof value === 'number' ? value : parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
  * Map an API creator record to the CreatorProfile shape used by the
  * discovery grid and the profile page's hero/header components.
  *
- * The backend doesn't yet track subscriber count, subscription price,
- * categories, location, or social links for a creator, so those fall
- * back to sensible empty defaults rather than fabricated data.
+ * The backend doesn't track location or social links for a creator yet,
+ * so those fall back to sensible empty defaults rather than fabricated
+ * data. Subscriber count, subscription price, and categories are mapped
+ * from the API when present, and default safely when absent.
  */
 export function publicCreatorToProfile(c: PublicCreator): CreatorProfile {
   return {
@@ -76,10 +95,10 @@ export function publicCreatorToProfile(c: PublicCreator): CreatorProfile {
     displayName: c.display_name,
     bio: c.bio ?? '',
     avatarUrl: c.avatar_url ?? undefined,
-    subscriberCount: c.followers_count,
-    subscriptionPrice: 0,
+    subscriberCount: c.followers_count ?? 0,
+    subscriptionPrice: parseSubscriptionPrice(c.subscription_price),
     isVerified: c.is_verified,
-    categories: [],
+    categories: c.categories ?? [],
     socialLinks: [],
   };
 }

--- a/frontend/src/lib/api/subscriptions.test.ts
+++ b/frontend/src/lib/api/subscriptions.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchActiveSubscriptions, SubscriptionsUnauthorizedError } from './subscriptions';
+
+vi.mock('@/lib/api/base-url', () => ({
+  getApiBaseUrl: () => 'https://api.test',
+}));
+
+global.fetch = vi.fn() as unknown as typeof fetch;
+
+function mockFetchOk(body: unknown) {
+  (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(body),
+  });
+}
+
+function mockFetchStatus(status: number, body: unknown = {}) {
+  (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  });
+}
+
+describe('fetchActiveSubscriptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('hits the versioned subscriptions endpoint with the configured API base', async () => {
+    mockFetchOk({ data: [] });
+
+    await fetchActiveSubscriptions({ status: 'active', sort: 'expiry' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.test/api/v1/subscriptions/me/list?status=active&sort=expiry',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+
+  it('attaches a Bearer token from stored auth when present', async () => {
+    localStorage.setItem('authToken', 'jwt-access-token');
+    mockFetchOk({ data: [] });
+
+    await fetchActiveSubscriptions({});
+
+    const [, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jwt-access-token');
+  });
+
+  it('omits the Authorization header when no token is stored', async () => {
+    mockFetchOk({ data: [] });
+
+    await fetchActiveSubscriptions({});
+
+    const [, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+
+  it('normalizes list items with fallback field names and safe defaults', async () => {
+    mockFetchOk({
+      data: [
+        {
+          id: 'sub-1',
+          creator: 'Jane Doe',
+          creator_username: 'jane',
+          plan_name: 'Pro',
+          price: '9.99',
+          currency: 'USD',
+          current_period_end: '2026-08-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await fetchActiveSubscriptions({});
+
+    expect(result).toEqual([
+      {
+        id: 'sub-1',
+        creatorId: '',
+        creatorName: 'Jane Doe',
+        creatorUsername: 'jane',
+        planName: 'Pro',
+        price: 9.99,
+        currency: 'USD',
+        interval: 'month',
+        currentPeriodEnd: '2026-08-01T00:00:00.000Z',
+        status: 'active',
+      },
+    ]);
+  });
+
+  it('handles a bare array response shape', async () => {
+    mockFetchOk([{ id: 'sub-2' }]);
+
+    const result = await fetchActiveSubscriptions({});
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('sub-2');
+  });
+
+  it('throws SubscriptionsUnauthorizedError and clears the token on a 401', async () => {
+    localStorage.setItem('authToken', 'stale-token');
+    mockFetchStatus(401);
+
+    await expect(fetchActiveSubscriptions({})).rejects.toThrow(SubscriptionsUnauthorizedError);
+    expect(localStorage.getItem('authToken')).toBeNull();
+  });
+
+  it('throws a generic error on a non-401 failure without clearing auth', async () => {
+    localStorage.setItem('authToken', 'jwt-access-token');
+    mockFetchStatus(500, { message: 'Internal server error' });
+
+    await expect(fetchActiveSubscriptions({})).rejects.toThrow('Internal server error');
+    expect(localStorage.getItem('authToken')).toBe('jwt-access-token');
+  });
+});

--- a/frontend/src/lib/api/subscriptions.ts
+++ b/frontend/src/lib/api/subscriptions.ts
@@ -1,0 +1,97 @@
+/**
+ * Fan subscriptions API client.
+ *
+ * The active-subscriptions list is a private, per-user resource: it needs
+ * the caller's bearer token (this app authenticates with a stored JWT, not
+ * cookies — see `@/lib/auth-storage`) and an absolute, configuration-driven
+ * base URL rather than a bare relative path, so it keeps working the same
+ * way in every deployment instead of depending on an on-the-side rewrite.
+ */
+import { resolveAuthToken, clearStoredAuthToken } from '@/lib/auth-storage';
+import { getApiBaseUrl } from '@/lib/api/base-url';
+import type { ActiveSubscription } from '@/lib/subscriptions';
+
+const API_BASE = `${getApiBaseUrl()}/api/v1`;
+
+export class SubscriptionsUnauthorizedError extends Error {
+  readonly status = 401;
+
+  constructor(message = 'Session expired. Please sign in again.') {
+    super(message);
+    this.name = 'SubscriptionsUnauthorizedError';
+  }
+}
+
+function authHeaders(): HeadersInit {
+  const token = resolveAuthToken();
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+/**
+ * Normalize a raw list item from `GET /subscriptions/me/list` into the
+ * `ActiveSubscription` shape the UI renders, defaulting any field the
+ * backend omits so a partial record never crashes the page.
+ */
+function normalizeActiveSubscription(item: Record<string, unknown>): ActiveSubscription {
+  return {
+    id: String(item.id ?? ''),
+    creatorId: String(item.creatorId ?? item.creator_id ?? ''),
+    creatorName: String(item.creatorName ?? item.creator ?? 'Creator'),
+    creatorUsername: String(item.creatorUsername ?? item.creator_username ?? ''),
+    planName: String(item.planName ?? item.plan_name ?? 'Subscription'),
+    price: typeof item.price === 'number' ? item.price : parseFloat(String(item.price ?? '0')),
+    currency: String(item.currency ?? 'XLM'),
+    interval: item.interval === 'year' ? 'year' : 'month',
+    currentPeriodEnd: String(
+      item.currentPeriodEnd ?? item.current_period_end ?? new Date().toISOString(),
+    ),
+    status: 'active',
+  };
+}
+
+export interface FetchActiveSubscriptionsParams {
+  status?: string;
+  sort?: string;
+}
+
+/**
+ * Fetch the current user's active subscriptions.
+ *
+ * Throws `SubscriptionsUnauthorizedError` on a 401 (and clears the stale
+ * token) so callers can distinguish "not signed in" from a generic
+ * network/server failure and avoid silently rendering an empty list.
+ */
+export async function fetchActiveSubscriptions(
+  params: FetchActiveSubscriptionsParams = {},
+): Promise<ActiveSubscription[]> {
+  const qs = new URLSearchParams();
+  if (params.status) qs.set('status', params.status);
+  if (params.sort) qs.set('sort', params.sort);
+
+  const res = await fetch(`${API_BASE}/subscriptions/me/list?${qs.toString()}`, {
+    method: 'GET',
+    headers: authHeaders(),
+    credentials: 'include',
+    cache: 'no-store',
+  });
+
+  if (res.status === 401) {
+    clearStoredAuthToken();
+    throw new SubscriptionsUnauthorizedError();
+  }
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { message?: string }).message ?? `Request failed: ${res.status}`);
+  }
+
+  const data = await res.json();
+  const items: Record<string, unknown>[] = Array.isArray(data) ? data : (data.data ?? []);
+  return items.map(normalizeActiveSubscription);
+}


### PR DESCRIPTION
## Summary

<!-- One or two sentences describing what this PR does and why. -->
Three independent frontend fixes bundled together:

### 1. Dashboard shell accessibility (skip-link + focus management)
The creator dashboard shell had no skip navigation and never moved focus on
route change, forcing keyboard and screen-reader users to tab through the
entire sidebar on every single navigation.
- Added a "Skip to main content" link, visually hidden until focused, at the
  top of the dashboard shell.
- Gave the `<main>` landmark a focusable `#dashboard-main` id and move focus
  to it whenever the route changes (skipped on initial mount so it doesn't
  steal focus on first load).
- Verified existing icon-only controls (mobile menu toggle, sidebar
  collapse toggle) already carry `aria-label`s.

### 2. Discover: map creator fields completely
`publicCreatorToProfile` hardcoded `subscriptionPrice` to `0` and
`categories` to `[]` even when the `/creators` API returned
`subscription_price`, `currency`, and `categories`, making every card in
the discovery grid look free and uncategorized regardless of the actual
data.
- Now maps `subscription_price` (parsed safely from the numeric string the
  API returns), `currency`, and `categories` when present.
- Falls back to `0` / `[]` only when the fields are genuinely absent or
  fail to parse — no fabricated data.

### 3. Subscriptions: authenticated client for the active list
The active-subscriptions fetch called a bare relative path
(`/api/v1/subscriptions/me/list`) with no `Authorization` header. Since
this app authenticates with a stored JWT (not cookies), the request would
fail auth against the real backend and any failure — network error or
401 — silently rendered the same "No subscriptions found" empty state,
indistinguishable from a user who genuinely has none.
- Added `src/lib/api/subscriptions.ts`: a client mirroring the existing
  `profile.ts` pattern — absolute, config-driven API base URL, Bearer
  token attached from `auth-storage`, response normalization with
  fallback field names, and a `SubscriptionsUnauthorizedError` thrown (and
  stale token cleared) on 401.
- Wired the subscriptions page to this client for both the initial load
  and the post-renewal refetch.
- The page now distinguishes three states: loading, "sign in required"
  (401), "couldn't load subscriptions" (other errors), and the genuine
  empty state — so failures are never mistaken for an empty list.

## Changes

- `frontend/src/app/dashboard/layout.tsx` — skip link, focusable main
  landmark, focus-on-navigate
- `frontend/src/app/dashboard/layout.test.tsx` — new: skip link, focus
  handoff, labeled controls
- `frontend/src/lib/api/creators.ts` — map `subscription_price`,
  `currency`, `categories` with safe defaults
- `frontend/src/lib/api/creators.test.ts` — coverage for present/absent/
  malformed field cases
- `frontend/src/lib/api/subscriptions.ts` — new: authenticated
  `fetchActiveSubscriptions` client
- `frontend/src/lib/api/subscriptions.test.ts` — new: URL, auth header,
  normalization, 401 handling
- `frontend/src/app/subscriptions/page.tsx` — use the new client, add
  distinct error/unauthorized UI states

## Test plan

- [ ] `pnpm test` in `frontend/` (new/updated: `layout.test.tsx`,
      `creators.test.ts`, `subscriptions.test.ts`)
- [ ] `pnpm build` to confirm no type errors
- [ ] Manually tab through `/dashboard` — confirm the skip link appears on
      first Tab press and jumps focus into main content
- [ ] Navigate between dashboard sub-routes — confirm focus lands on the
      main content region each time
- [ ] Visit `/discover` with a creator that has `subscription_price` /
      `categories` set — confirm the card shows the real price and tags
      instead of "Free" / no categories
- [ ] Visit `/subscriptions` while signed in — confirm the active list
      loads (previously would fail auth silently)
- [ ] Visit `/subscriptions` with an expired/missing token — confirm the
      "Sign in required" state appears instead of a blank "No
      subscriptions found"
## Changes

<!-- Bullet list of the key changes made. -->

-

## Test Plan

### Automated tests added or updated

<!-- Check all that apply and briefly describe what each covers. -->

- [x] **Unit tests** (`backend/src/**/*.spec.ts`) — service/guard/decorator logic in isolation
- [x] **Integration / e2e tests** (`backend/test/**/*.e2e-spec.ts`) — HTTP round-trips with mocked infrastructure
- [x] **Frontend component tests** (`frontend/src/**/*.test.{ts,tsx}`) — React component behaviour
- [x] **Frontend e2e tests** (`frontend/e2e/**/*.spec.ts`) — Playwright browser flows
- [x] **Contract tests** (`contract/`) — Soroban/Rust unit tests via `cargo test`
- [x] No new tests required — explain why: ___

### How to run the tests locally

```bash
# Backend unit tests
cd backend && npm test

# Backend e2e tests (requires no live DB — uses in-memory mocks)
cd backend && npm run test:e2e

# Frontend component tests
cd frontend && npx vitest run

# Frontend e2e tests (requires dev server on :3000 and API on :3001)
cd frontend && npx playwright test

# Contract tests
cd contract && cargo test
```

### Manual verification checklist

<!-- Tick each item you verified by hand before requesting review. -->

- [x] Happy path works end-to-end in a local environment
- [x] Error / edge cases handled gracefully (stale state, invalid input, disconnected wallet)
- [x] No regressions in closely related API or UI flows
- [x] Rate-limiting, auth guards, and feature flags behave as expected where touched
- [x] Linting passes: `cd backend && npm run lint` / `cd frontend && npm run lint`

## Related issues

<!-- Closes #NNN -->

## Notes for reviewers

<!-- Anything that needs extra attention, known limitations, or follow-up work. -->
Closes #1489
Closes #1490
Closes #1491
